### PR TITLE
Extract blake2b hashing helpers and apply to Kaspa address handling

### DIFF
--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -925,9 +925,7 @@ export class ContractsPageComponent implements OnInit {
     if (normalized.startsWith('kaspa') || normalized.startsWith('kaspatest')) {
       try {
         const pubkeyBytes = this.templatePatcher.kaspaAddressToPubkeyBytes(value.trim());
-        const pubkeyUint8 = Uint8Array.from(pubkeyBytes);
-        const hash = blake2b(pubkeyUint8, { dkLen: 32 });
-        const hashHex = Array.from(hash).map(b => b.toString(16).padStart(2, '0')).join('');
+        const hashHex = this.computeBlake2bHex(pubkeyBytes);
         this.templateFormValues[paramName] = hashHex;
         this.templateFormValues[paramName + '_isAutoHashed'] = 'true';
       } catch {
@@ -937,19 +935,32 @@ export class ContractsPageComponent implements OnInit {
   }
 
   /**
+   * Convert a 64-char hex string into a 32-byte Uint8Array.
+   */
+  private hex32ToBytes(value: string): Uint8Array {
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 64; i += 2) {
+      bytes[i / 2] = Number.parseInt(value.slice(i, i + 2), 16);
+    }
+    return bytes;
+  }
+
+  /**
+   * Compute a blake2b-256 hash and return lowercase hex.
+   */
+  private computeBlake2bHex(input: ArrayLike<number>): string {
+    const hash = blake2b(Uint8Array.from(input), { dkLen: 32 });
+    return Array.from(hash).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  /**
    * Compute blake2b-256 hash of a hex value and update the field
    */
   computeBlake2bHash(paramName: string) {
     const value = (this.templateFormValues[paramName] || '').trim().replace(/^0x/i, '');
     if (!/^[0-9a-fA-F]{64}$/.test(value)) return;
 
-    const bytes = new Uint8Array(32);
-    for (let i = 0; i < 64; i += 2) {
-      bytes[i / 2] = Number.parseInt(value.slice(i, i + 2), 16);
-    }
-    const hash = blake2b(bytes, { dkLen: 32 });
-    const hashHex = Array.from(hash).map(b => b.toString(16).padStart(2, '0')).join('');
-    this.templateFormValues[paramName] = hashHex;
+    this.templateFormValues[paramName] = this.computeBlake2bHex(this.hex32ToBytes(value));
     this.templateFormValues[paramName + '_isAutoHashed'] = 'true';
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure Kaspa addresses pasted into hash fields are converted from address->pubkey->blake2b-256 hash and mark the field as auto-hashed. 
- Reduce duplicated hex-to-bytes and hashing logic by centralizing functionality into helper methods. 
- Preserve the existing behavior of not auto-replacing arbitrary 64-char hex inputs so users can choose whether to compute a hash.

### Description

- Added a helper `hex32ToBytes` to convert a 64-char hex string into a 32-byte `Uint8Array`.
- Added a helper `computeBlake2bHex` that computes a blake2b-256 hash and returns a lowercase hex string. 
- Updated `onHash32Input` to use `computeBlake2bHex` when extracting pubkey bytes from a Kaspa address and to set the `_isAutoHashed` flag. 
- Replaced inline byte-conversion and hashing in `computeBlake2bHash` with a call to the new helpers to eliminate duplicated code.

### Testing

- Ran `ng build` and the application compiled successfully. 
- Ran unit tests with `ng test` and all tests passed. 
- Ran linter with `npm run lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed8c3e870832e9b7116cfc701623a)