### PR TITLE
feat(KCW-64): Basic Lending/Borrowing UI

### DIFF
--- a/src/app/services/etherium-services/smart-contracts/abis/aave-data-provider.json
+++ b/src/app/services/etherium-services/smart-contracts/abis/aave-data-provider.json
@@ -1,0 +1,572 @@
+[
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "addressesProvider",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "ADDRESSES_PROVIDER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getATokenTotalSupply",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAllATokens",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct IPoolDataProvider.TokenData[]",
+          "components": [
+            {
+              "name": "symbol",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "tokenAddress",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAllReservesTokens",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct IPoolDataProvider.TokenData[]",
+          "components": [
+            {
+              "name": "symbol",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "tokenAddress",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDebtCeiling",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDebtCeilingDecimals",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getFlashLoanEnabled",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getInterestRateStrategyAddress",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "irStrategyAddress",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getIsVirtualAccActive",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLiquidationProtocolFee",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPaused",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "isPaused",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReserveCaps",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "borrowCap",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "supplyCap",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReserveConfigurationData",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "decimals",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "ltv",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "liquidationThreshold",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "liquidationBonus",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "reserveFactor",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "usageAsCollateralEnabled",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "borrowingEnabled",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "stableBorrowRateEnabled",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "isActive",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "isFrozen",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReserveData",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "unbacked",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "accruedToTreasuryScaled",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "totalAToken",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "totalVariableDebt",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "liquidityRate",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "variableBorrowRate",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "liquidityIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "variableBorrowIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "lastUpdateTimestamp",
+          "type": "uint40",
+          "internalType": "uint40"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReserveDeficit",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReserveTokensAddresses",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "aTokenAddress",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "stableDebtTokenAddress",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "variableDebtTokenAddress",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getSiloedBorrowing",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTotalDebt",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUnbackedMintCap",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserReserveData",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "currentATokenBalance",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "currentStableDebt",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "currentVariableDebt",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "principalStableDebt",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "scaledVariableDebt",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "stableBorrowRate",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "liquidityRate",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "stableRateLastUpdated",
+          "type": "uint40",
+          "internalType": "uint40"
+        },
+        {
+          "name": "usageAsCollateralEnabled",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getVirtualUnderlyingBalance",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    }
+  ]

--- a/src/app/services/etherium-services/smart-contracts/abis/aave-oracle-abi.json
+++ b/src/app/services/etherium-services/smart-contracts/abis/aave-oracle-abi.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "function",
+    "name": "getAssetPrice",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setAssetPrice",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "price",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_CURRENCY_UNIT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/app/services/etherium-services/smart-contracts/abis/aave-pool-abi.json
+++ b/src/app/services/etherium-services/smart-contracts/abis/aave-pool-abi.json
@@ -1,0 +1,2021 @@
+[
+  {
+    "type": "function",
+    "name": "ADDRESSES_PROVIDER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPoolAddressesProvider"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BRIDGE_PROTOCOL_FEE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "FLASHLOAN_PREMIUM_TOTAL",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "FLASHLOAN_PREMIUM_TO_PROTOCOL",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_NUMBER_RESERVES",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "backUnbacked",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "borrow",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "configureEModeCategory",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "config",
+        "type": "tuple",
+        "internalType": "struct DataTypes.EModeCategoryBaseConfiguration",
+        "components": [
+          {
+            "name": "ltv",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationThreshold",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationBonus",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "configureEModeCategoryBorrowableBitmap",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "borrowableBitmap",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "configureEModeCategoryCollateralBitmap",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "collateralBitmap",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "dropReserve",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "eliminateReserveDeficit",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finalizeTransfer",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "balanceFromBefore",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "balanceToBefore",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "flashLoan",
+    "inputs": [
+      {
+        "name": "receiverAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "amounts",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "interestRateModes",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "params",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "flashLoanSimple",
+    "inputs": [
+      {
+        "name": "receiverAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "params",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getBorrowLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBridgeLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getConfiguration",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.ReserveConfigurationMap",
+        "components": [
+          {
+            "name": "data",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeCategoryBorrowableBitmap",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeCategoryCollateralBitmap",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeCategoryCollateralConfig",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.CollateralConfig",
+        "components": [
+          {
+            "name": "ltv",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationThreshold",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationBonus",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeCategoryData",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.EModeCategoryLegacy",
+        "components": [
+          {
+            "name": "ltv",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationThreshold",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "liquidationBonus",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "priceSource",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeCategoryLabel",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEModeLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getFlashLoanLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLiquidationGracePeriod",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint40",
+        "internalType": "uint40"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLiquidationLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPoolLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveAToken",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveAddressById",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveData",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.ReserveDataLegacy",
+        "components": [
+          {
+            "name": "configuration",
+            "type": "tuple",
+            "internalType": "struct DataTypes.ReserveConfigurationMap",
+            "components": [
+              {
+                "name": "data",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "liquidityIndex",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "currentLiquidityRate",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "variableBorrowIndex",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "currentVariableBorrowRate",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "currentStableBorrowRate",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "lastUpdateTimestamp",
+            "type": "uint40",
+            "internalType": "uint40"
+          },
+          {
+            "name": "id",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "aTokenAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "stableDebtTokenAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "variableDebtTokenAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "interestRateStrategyAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "accruedToTreasury",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "unbacked",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "isolationModeTotalDebt",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveDeficit",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveNormalizedIncome",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveNormalizedVariableDebt",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserveVariableDebtToken",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReservesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReservesList",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSupplyLogic",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserAccountData",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalCollateralBase",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalDebtBase",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "availableBorrowsBase",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "currentLiquidationThreshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ltv",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "healthFactor",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserConfiguration",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.UserConfigurationMap",
+        "components": [
+          {
+            "name": "data",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserEMode",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVirtualUnderlyingBalance",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initReserve",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "aTokenAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "variableDebtAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "interestRateStrategyAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "liquidationCall",
+    "inputs": [
+      {
+        "name": "collateralAsset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "debtAsset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "debtToCover",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiveAToken",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "mintToTreasury",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "mintUnbacked",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "repay",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "repayWithATokens",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "repayWithPermit",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permitV",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "permitR",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "permitS",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rescueTokens",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resetIsolationModeTotalDebt",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setConfiguration",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "configuration",
+        "type": "tuple",
+        "internalType": "struct DataTypes.ReserveConfigurationMap",
+        "components": [
+          {
+            "name": "data",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setLiquidationGracePeriod",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "until",
+        "type": "uint40",
+        "internalType": "uint40"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setReserveInterestRateStrategyAddress",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rateStrategyAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setUserEMode",
+    "inputs": [
+      {
+        "name": "categoryId",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setUserUseReserveAsCollateral",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "useAsCollateral",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supply",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supplyWithPermit",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permitV",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "permitR",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "permitS",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "syncIndexesState",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "syncRatesState",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateBridgeProtocolFee",
+    "inputs": [
+      {
+        "name": "bridgeProtocolFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateFlashloanPremiums",
+    "inputs": [
+      {
+        "name": "flashLoanPremiumTotal",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "flashLoanPremiumToProtocol",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "BackUnbacked",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "backer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Borrow",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum DataTypes.InterestRateMode"
+      },
+      {
+        "name": "borrowRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "indexed": true,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DeficitCovered",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "amountCovered",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DeficitCreated",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "debtAsset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amountCreated",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FlashLoan",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "initiator",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "asset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "interestRateMode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum DataTypes.InterestRateMode"
+      },
+      {
+        "name": "premium",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "indexed": true,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IsolationModeTotalDebtUpdated",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "totalDebt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "LiquidationCall",
+    "inputs": [
+      {
+        "name": "collateralAsset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "debtAsset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "debtToCover",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "liquidatedCollateralAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "liquidator",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "receiveAToken",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MintUnbacked",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "indexed": true,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MintedToTreasury",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amountMinted",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Repay",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "repayer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "useATokens",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReserveDataUpdated",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "liquidityRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stableBorrowRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "variableBorrowRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "liquidityIndex",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "variableBorrowIndex",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReserveUsedAsCollateralDisabled",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ReserveUsedAsCollateralEnabled",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Supply",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "onBehalfOf",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "referralCode",
+        "type": "uint16",
+        "indexed": true,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UserEModeSet",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "categoryId",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdraw",
+    "inputs": [
+      {
+        "name": "reserve",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/src/app/services/etherium-services/smart-contracts/abis/aave-pool-addresses-abi.json
+++ b/src/app/services/etherium-services/smart-contracts/abis/aave-pool-addresses-abi.json
@@ -1,0 +1,498 @@
+[
+    {
+      "type": "function",
+      "name": "getACLAdmin",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getACLManager",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAddress",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketId",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPool",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPoolConfigurator",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPoolDataProvider",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPriceOracle",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPriceOracleSentinel",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setACLAdmin",
+      "inputs": [
+        {
+          "name": "newAclAdmin",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setACLManager",
+      "inputs": [
+        {
+          "name": "newAclManager",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAddress",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAddressAsProxy",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newImplementationAddress",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setMarketId",
+      "inputs": [
+        {
+          "name": "newMarketId",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setPoolConfiguratorImpl",
+      "inputs": [
+        {
+          "name": "newPoolConfiguratorImpl",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setPoolDataProvider",
+      "inputs": [
+        {
+          "name": "newDataProvider",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setPoolImpl",
+      "inputs": [
+        {
+          "name": "newPoolImpl",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setPriceOracle",
+      "inputs": [
+        {
+          "name": "newPriceOracle",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setPriceOracleSentinel",
+      "inputs": [
+        {
+          "name": "newPriceOracleSentinel",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "ACLAdminUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ACLManagerUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AddressSet",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AddressSetAsProxy",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "proxyAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "oldImplementationAddress",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "newImplementationAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MarketIdSet",
+      "inputs": [
+        {
+          "name": "oldMarketId",
+          "type": "string",
+          "indexed": true,
+          "internalType": "string"
+        },
+        {
+          "name": "newMarketId",
+          "type": "string",
+          "indexed": true,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolConfiguratorUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolDataProviderUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PriceOracleSentinelUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PriceOracleUpdated",
+      "inputs": [
+        {
+          "name": "oldAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ProxyCreated",
+      "inputs": [
+        {
+          "name": "id",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "proxyAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "implementationAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    }
+  ]

--- a/src/app/services/etherium-services/smart-contracts/abis/aave-ui-data-provider.json
+++ b/src/app/services/etherium-services/smart-contracts/abis/aave-ui-data-provider.json
@@ -1,0 +1,480 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_networkBaseTokenPriceInUsdProxyAggregator",
+        "type": "address",
+        "internalType": "contract AggregatorInterface"
+      },
+      {
+        "name": "_marketReferenceCurrencyPriceInUsdProxyAggregator",
+        "type": "address",
+        "internalType": "contract AggregatorInterface"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "ETH_CURRENCY_UNIT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MKR_ADDRESS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "bytes32ToString",
+    "inputs": [
+      {
+        "name": "_bytes32",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getEModes",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "contract IPoolAddressesProvider"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IUiPoolDataProviderV3.Emode[]",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "eMode",
+            "type": "tuple",
+            "internalType": "struct DataTypes.EModeCategory",
+            "components": [
+              {
+                "name": "ltv",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "liquidationThreshold",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "liquidationBonus",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "collateralBitmap",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "label",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "borrowableBitmap",
+                "type": "uint128",
+                "internalType": "uint128"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReservesData",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "contract IPoolAddressesProvider"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IUiPoolDataProviderV3.AggregatedReserveData[]",
+        "components": [
+          {
+            "name": "underlyingAsset",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "decimals",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "baseLTVasCollateral",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "reserveLiquidationThreshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "reserveLiquidationBonus",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "reserveFactor",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "usageAsCollateralEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "borrowingEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isFrozen",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "liquidityIndex",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "variableBorrowIndex",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "liquidityRate",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "variableBorrowRate",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "lastUpdateTimestamp",
+            "type": "uint40",
+            "internalType": "uint40"
+          },
+          {
+            "name": "aTokenAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "variableDebtTokenAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "interestRateStrategyAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "availableLiquidity",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "totalScaledVariableDebt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "priceInMarketReferenceCurrency",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "priceOracle",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "variableRateSlope1",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "variableRateSlope2",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "baseVariableBorrowRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "optimalUsageRatio",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "isPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isSiloedBorrowing",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "accruedToTreasury",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "unbacked",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "isolationModeTotalDebt",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "flashLoanEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "debtCeiling",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "borrowCap",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "supplyCap",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "debtCeilingDecimals",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "borrowableInIsolation",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "virtualAccActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "virtualUnderlyingBalance",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "deficit",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      },
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IUiPoolDataProviderV3.BaseCurrencyInfo",
+        "components": [
+          {
+            "name": "marketReferenceCurrencyUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "marketReferenceCurrencyPriceInUsd",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "networkBaseTokenPriceInUsd",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "networkBaseTokenPriceDecimals",
+            "type": "uint8",
+            "internalType": "uint8"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReservesList",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "contract IPoolAddressesProvider"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserReservesData",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "contract IPoolAddressesProvider"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IUiPoolDataProviderV3.UserReserveData[]",
+        "components": [
+          {
+            "name": "underlyingAsset",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "scaledATokenBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "usageAsCollateralEnabledOnUser",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "scaledVariableDebt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "marketReferenceCurrencyPriceInUsdProxyAggregator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AggregatorInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "networkBaseTokenPriceInUsdProxyAggregator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AggregatorInterface"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-data-provider.contract.ts
+++ b/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-data-provider.contract.ts
@@ -1,0 +1,34 @@
+import { ethers } from 'ethers';
+import { BaseContract } from '../base-contract';
+import { WalletService } from '../../../../wallet.service';
+import AaveDataProviderABI from '../../abis/aave-data-provider.json';
+
+export interface UserReserveData {
+  currentATokenBalance: bigint;
+  currentStableDebt: bigint;
+  currentVariableDebt: bigint;
+  principalStableDebt: bigint;
+  scaledVariableDebt: bigint;
+  stableBorrowRate: bigint;
+  liquidityRate: bigint;
+  stableRateLastUpdated: number;
+  usageAsCollateralEnabled: boolean;
+}
+
+export class AaveDataProviderContract extends BaseContract {
+  static getContract(address: string, walletService: WalletService): AaveDataProviderContract {
+    return new AaveDataProviderContract(address, walletService);
+  }
+
+  constructor(address: string, walletService: WalletService) {
+    super(address, AaveDataProviderABI, walletService);
+  }
+
+  async getUserReserveData(asset: string, user: string): Promise<UserReserveData> {
+    return await this.callViewMethod<UserReserveData>('getUserReserveData', asset, user);
+  }
+
+  async getReservesList(): Promise<string[]> {
+    return await this.callViewMethod<string[]>('getAllReservesTokens');
+  }
+}

--- a/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-pool.contract.ts
+++ b/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-pool.contract.ts
@@ -1,0 +1,72 @@
+import { ethers } from 'ethers';
+import { BaseContract } from '../base-contract';
+import { WalletService } from '../../../../wallet.service';
+import { WalletActionService } from '../../../../wallet-action.service';
+import AavePoolABI from '../../abis/aave-pool-abi.json';
+
+export interface UserAccountData {
+  totalCollateralBase: bigint;
+  totalDebtBase: bigint;
+  availableBorrowsBase: bigint;
+  currentLiquidationThreshold: bigint;
+  ltv: bigint;
+  healthFactor: bigint;
+}
+
+export class AavePoolContract extends BaseContract {
+  static getContract(
+    address: string,
+    walletService: WalletService,
+    walletActionService?: WalletActionService,
+  ): AavePoolContract {
+    return new AavePoolContract(address, walletService, walletActionService);
+  }
+
+  constructor(
+    address: string,
+    walletService: WalletService,
+    walletActionService?: WalletActionService,
+  ) {
+    super(address, AavePoolABI, walletService, walletActionService);
+  }
+
+  async supply(
+    asset: string,
+    amount: ethers.BigNumberish,
+    onBehalfOf: string,
+    referralCode = 0,
+  ) {
+    return await this.doContractAction('supply', asset, amount, onBehalfOf, referralCode);
+  }
+
+  async withdraw(asset: string, amount: ethers.BigNumberish, to: string) {
+    return await this.doContractAction('withdraw', asset, amount, to);
+  }
+
+  async borrow(
+    asset: string,
+    amount: ethers.BigNumberish,
+    interestRateMode: number,
+    referralCode = 0,
+    onBehalfOf: string,
+  ) {
+    return await this.doContractAction('borrow', asset, amount, interestRateMode, referralCode, onBehalfOf);
+  }
+
+  async repay(
+    asset: string,
+    amount: ethers.BigNumberish,
+    interestRateMode: number,
+    onBehalfOf: string,
+  ) {
+    return await this.doContractAction('repay', asset, amount, interestRateMode, onBehalfOf);
+  }
+
+  async getUserAccountData(user: string): Promise<UserAccountData> {
+    return await this.callViewMethod<UserAccountData>('getUserAccountData', user);
+  }
+
+  async getReservesList(): Promise<string[]> {
+    return await this.callViewMethod<string[]>('getReservesList');
+  }
+}

--- a/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-ui-data-provider.contract.ts
+++ b/src/app/services/etherium-services/smart-contracts/contracts/aave/aave-ui-data-provider.contract.ts
@@ -1,0 +1,78 @@
+import { ethers } from 'ethers';
+import { BaseContract } from '../base-contract';
+import { WalletService } from '../../../../wallet.service';
+import AaveUiDataProviderABI from '../../abis/aave-ui-data-provider.json';
+
+export interface AggregatedReserveData {
+  underlyingAsset: string;
+  name: string;
+  symbol: string;
+  decimals: bigint;
+  baseLTVasCollateral: bigint;
+  reserveLiquidationThreshold: bigint;
+  reserveLiquidationBonus: bigint;
+  reserveFactor: bigint;
+  usageAsCollateralEnabled: boolean;
+  borrowingEnabled: boolean;
+  isActive: boolean;
+  isFrozen: boolean;
+  liquidityRate: bigint;
+  variableBorrowRate: bigint;
+  aTokenAddress: string;
+  variableDebtTokenAddress: string;
+  availableLiquidity: bigint;
+  totalScaledVariableDebt: bigint;
+  priceInMarketReferenceCurrency: bigint;
+  supplyCap: bigint;
+  borrowCap: bigint;
+  isPaused: boolean;
+}
+
+export interface UserReserveData {
+  underlyingAsset: string;
+  scaledATokenBalance: bigint;
+  usageAsCollateralEnabled: boolean;
+  scaledVariableDebt: bigint;
+  currentATokenBalance?: bigint;
+  currentVariableDebt?: bigint;
+}
+
+export interface BaseCurrencyInfo {
+  marketReferenceCurrencyUnit: bigint;
+  marketReferenceCurrencyPriceInUsd: bigint;
+  networkBaseTokenPriceInUsd: bigint;
+  networkBaseTokenPriceDecimals: number;
+}
+
+export class AaveUiDataProviderContract extends BaseContract {
+  static getContract(address: string, walletService: WalletService): AaveUiDataProviderContract {
+    return new AaveUiDataProviderContract(address, walletService);
+  }
+
+  constructor(address: string, walletService: WalletService) {
+    super(address, AaveUiDataProviderABI, walletService);
+  }
+
+  async getReservesData(providerAddress: string): Promise<{
+    reservesData: AggregatedReserveData[];
+    baseCurrencyInfo: BaseCurrencyInfo;
+  }> {
+    const result = await this.callViewMethod<[AggregatedReserveData[], BaseCurrencyInfo]>(
+      'getReservesData',
+      providerAddress,
+    );
+    return { reservesData: result[0], baseCurrencyInfo: result[1] };
+  }
+
+  async getUserReservesData(
+    providerAddress: string,
+    user: string,
+  ): Promise<{ userReservesData: UserReserveData[]; userEmodeCategoryId: number }> {
+    const result = await this.callViewMethod<[UserReserveData[], number]>(
+      'getUserReservesData',
+      providerAddress,
+      user,
+    );
+    return { userReservesData: result[0], userEmodeCategoryId: result[1] };
+  }
+}

--- a/src/app/v2/pages/app/common/wrapper-nav/icons/nav-icons.ts
+++ b/src/app/v2/pages/app/common/wrapper-nav/icons/nav-icons.ts
@@ -58,6 +58,14 @@ export class NavIcons {
 </svg>
   `;
 
+  static readonly lending = `
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 26V22M16 26V18M20 26V20M24 26V16M28 26V14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="20" cy="14" r="4" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M18 14h4M20 12v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>
+  `;
+
   static readonly chevronUp = `
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M18 15L12 9L6 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/app/v2/pages/app/common/wrapper-nav/wrapper-nav.component.ts
+++ b/src/app/v2/pages/app/common/wrapper-nav/wrapper-nav.component.ts
@@ -41,6 +41,11 @@ export class WrapperNavComponent implements AfterViewInit, OnDestroy {
       link: '/app/home',
     },
     {
+      svgContent: this.domSanitizer.bypassSecurityTrustHtml(NavIcons.lending),
+      alt: 'Lending',
+      link: '/app/lending',
+    },
+    {
       svgContent: this.domSanitizer.bypassSecurityTrustHtml(NavIcons.activity),
       alt: 'History',
       link: '/app/activity',

--- a/src/app/v2/pages/app/lending/lending-action.shared.scss
+++ b/src/app/v2/pages/app/lending/lending-action.shared.scss
@@ -1,0 +1,197 @@
+.lending-action {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #fff;
+    margin: 0;
+  }
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: color 0.15s;
+
+  &:hover { color: #fff; }
+}
+
+.token-info-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.token-info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+
+  &__label { color: #888; }
+  &__value { color: #ddd; font-weight: 500; }
+  &__value--green { color: #46be8c; }
+  &__value--orange { color: #ff9800; }
+  &__value--red { color: #f44336; }
+}
+
+.amount-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.amount-input-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: #888;
+}
+
+.max-btn {
+  background: rgba(70, 190, 140, 0.15);
+  border: none;
+  color: #46be8c;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+
+  &:hover { opacity: 0.8; }
+}
+
+.amount-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.amount-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  color: #fff;
+  font-size: 20px;
+  font-weight: 500;
+  padding: 14px 60px 14px 16px;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus { border-color: rgba(70, 190, 140, 0.5); }
+
+  &::placeholder { color: rgba(255, 255, 255, 0.2); }
+
+  /* Remove number arrows */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button { -webkit-appearance: none; }
+  -moz-appearance: textfield;
+}
+
+.amount-input__symbol {
+  position: absolute;
+  right: 14px;
+  font-size: 13px;
+  color: #888;
+  pointer-events: none;
+}
+
+.amount-usd {
+  font-size: 12px;
+  color: #666;
+  padding-left: 4px;
+}
+
+.status-msg {
+  padding: 12px 14px;
+  border-radius: 10px;
+  font-size: 13px;
+
+  &--success {
+    background: rgba(76, 175, 80, 0.1);
+    border: 1px solid rgba(76, 175, 80, 0.25);
+    color: #4caf50;
+  }
+
+  &--error {
+    background: rgba(244, 67, 54, 0.1);
+    border: 1px solid rgba(244, 67, 54, 0.25);
+    color: #f44336;
+  }
+}
+
+.submit-btn {
+  background: #46be8c;
+  color: #000;
+  border: none;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 14px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  &:hover:not(:disabled) { opacity: 0.85; }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.hint {
+  font-size: 11px;
+  color: #555;
+  text-align: center;
+  margin: 0;
+}
+
+.loading-state {
+  color: #888;
+  font-size: 14px;
+  text-align: center;
+  padding: 32px;
+}
+
+.spinner-sm {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/app/v2/pages/app/lending/lending.routes.ts
+++ b/src/app/v2/pages/app/lending/lending.routes.ts
@@ -1,0 +1,35 @@
+import { Routes } from '@angular/router';
+import { LendingDashboardComponent } from './pages/dashboard/lending-dashboard.component';
+import { LendingSupplyComponent } from './pages/supply/lending-supply.component';
+import { LendingWithdrawComponent } from './pages/withdraw/lending-withdraw.component';
+import { LendingBorrowComponent } from './pages/borrow/lending-borrow.component';
+import { LendingRepayComponent } from './pages/repay/lending-repay.component';
+import { LendingDataService } from './services/lending-data.service';
+
+export const LendingRoutes: Routes = [
+  {
+    path: '',
+    component: LendingDashboardComponent,
+    providers: [LendingDataService],
+  },
+  {
+    path: 'supply/:address',
+    component: LendingSupplyComponent,
+    providers: [LendingDataService],
+  },
+  {
+    path: 'withdraw/:address',
+    component: LendingWithdrawComponent,
+    providers: [LendingDataService],
+  },
+  {
+    path: 'borrow/:address',
+    component: LendingBorrowComponent,
+    providers: [LendingDataService],
+  },
+  {
+    path: 'repay/:address',
+    component: LendingRepayComponent,
+    providers: [LendingDataService],
+  },
+];

--- a/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.html
+++ b/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.html
@@ -1,0 +1,68 @@
+<div class="lending-action">
+  <div class="lending-action__header">
+    <button class="back-btn" (click)="goBack()">← Back</button>
+    <h2 class="lending-action__title">Borrow {{ token()?.symbol }}</h2>
+  </div>
+
+  @if (!token()) {
+    <div class="loading-state">Loading…</div>
+  } @else {
+    <div class="token-info-card">
+      <div class="token-info-row">
+        <span class="token-info-row__label">Borrow APY (Variable)</span>
+        <span class="token-info-row__value token-info-row__value--orange">{{ token()!.borrowApy.toFixed(2) }}%</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Available to Borrow</span>
+        <span class="token-info-row__value">{{ maxBorrowInToken() }} {{ token()!.symbol }}</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Max (USD)</span>
+        <span class="token-info-row__value">{{ dataService.formatUsd(maxBorrowUsd()) }}</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Health Factor</span>
+        <span class="token-info-row__value">{{ dataService.formatHealthFactor(dataService.userMetrics().healthFactor) }}</span>
+      </div>
+    </div>
+
+    <div class="amount-input-group">
+      <div class="amount-input-label">
+        <span>Amount to borrow</span>
+        <button class="max-btn" (click)="setMax()">MAX</button>
+      </div>
+      <div class="amount-input-wrapper">
+        <input
+          class="amount-input"
+          type="number"
+          placeholder="0.00"
+          [value]="amount()"
+          (input)="onAmountChange($any($event.target).value)"
+          min="0" step="any"
+        />
+        <span class="amount-input__symbol">{{ token()!.symbol }}</span>
+      </div>
+      @if (amount()) {
+        <div class="amount-usd">≈ {{ usdValue() }}</div>
+      }
+    </div>
+
+    @if (txStatus() === 'success') {
+      <div class="status-msg status-msg--success">✅ Borrow successful!</div>
+    }
+    @if (txStatus() === 'error') {
+      <div class="status-msg status-msg--error">❌ {{ txError() }}</div>
+    }
+
+    <button class="submit-btn" [disabled]="!isValid() || isProcessing()" (click)="onSubmit()"
+      style="background: #ff9800;">
+      @if (isProcessing()) {
+        <span class="spinner-sm"></span> Processing…
+      } @else {
+        Borrow {{ amount() ? amount() : '' }} {{ token()!.symbol }}
+      }
+    </button>
+
+    <p class="hint">Borrowing uses variable interest rate mode.</p>
+  }
+</div>

--- a/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.scss
+++ b/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.scss
@@ -1,0 +1,1 @@
+@import '../../lending-action.shared';

--- a/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.ts
+++ b/src/app/v2/pages/app/lending/pages/borrow/lending-borrow.component.ts
@@ -1,0 +1,74 @@
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LendingDataService, LendingToken } from '../../services/lending-data.service';
+
+@Component({
+  selector: 'app-lending-borrow',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './lending-borrow.component.html',
+  styleUrl: './lending-borrow.component.scss',
+})
+export class LendingBorrowComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  protected dataService = inject(LendingDataService);
+
+  readonly token = signal<LendingToken | null>(null);
+  readonly amount = signal('');
+  readonly isProcessing = signal(false);
+  readonly txStatus = signal<'idle' | 'success' | 'error'>('idle');
+  readonly txError = signal('');
+
+  readonly maxBorrowUsd = computed(() => this.dataService.userMetrics().availableBorrowsUsd);
+  readonly maxBorrowInToken = computed(() => {
+    const price = this.token()?.usdPrice ?? 0;
+    if (price === 0) return '0';
+    return (this.maxBorrowUsd() / price).toFixed(6);
+  });
+
+  readonly parsedAmount = computed(() => parseFloat(this.amount()) || 0);
+  readonly isValid = computed(
+    () => this.parsedAmount() > 0 && this.parsedAmount() <= parseFloat(this.maxBorrowInToken()),
+  );
+  readonly usdValue = computed(() =>
+    this.dataService.formatUsd(this.parsedAmount() * (this.token()?.usdPrice ?? 0)),
+  );
+
+  ngOnInit() {
+    const address = this.route.snapshot.paramMap.get('address');
+    const load = () => {
+      const token = this.dataService.tokens().find(
+        (t) => t.address.toLowerCase() === (address ?? '').toLowerCase(),
+      );
+      this.token.set(token ?? null);
+    };
+    if (address && this.dataService.tokens().length) {
+      load();
+    } else if (address) {
+      this.dataService.loadData().then(load);
+    }
+  }
+
+  setMax() { this.amount.set(this.maxBorrowInToken()); }
+  onAmountChange(value: string) { this.amount.set(value); }
+
+  async onSubmit() {
+    const token = this.token();
+    if (!token || !this.isValid()) return;
+    this.isProcessing.set(true);
+    this.txStatus.set('idle');
+    const success = await this.dataService.borrow(token, this.amount());
+    if (success) {
+      this.txStatus.set('success');
+      await this.dataService.loadData();
+    } else {
+      this.txStatus.set('error');
+      this.txError.set('Transaction failed or was rejected.');
+    }
+    this.isProcessing.set(false);
+  }
+
+  goBack() { this.router.navigate(['/app/lending']); }
+}

--- a/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.html
+++ b/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.html
@@ -1,0 +1,215 @@
+<div class="lending-dashboard">
+  <!-- Loading state -->
+  @if (isLoading()) {
+    <div class="lending-dashboard__loading">
+      <div class="spinner"></div>
+      <p>Loading lending data…</p>
+    </div>
+  }
+
+  <!-- Error state -->
+  @if (error()) {
+    <div class="lending-dashboard__error">
+      <span>⚠️ {{ error() }}</span>
+      <button class="btn btn--sm btn--outline" (click)="refresh()">Retry</button>
+    </div>
+  }
+
+  @if (!isLoading() && !error()) {
+    <!-- Health Factor + Metrics -->
+    <div class="lending-dashboard__metrics">
+      <div class="metric-card">
+        <div class="metric-card__label">Net Worth</div>
+        <div class="metric-card__value">
+          {{ formatUsd(userMetrics().totalCollateralUsd - userMetrics().totalDebtUsd) }}
+        </div>
+      </div>
+
+      <div class="metric-card">
+        <div class="metric-card__label">Total Supplied</div>
+        <div class="metric-card__value">{{ formatUsd(userMetrics().totalCollateralUsd) }}</div>
+      </div>
+
+      <div class="metric-card">
+        <div class="metric-card__label">Total Borrowed</div>
+        <div class="metric-card__value">{{ formatUsd(userMetrics().totalDebtUsd) }}</div>
+      </div>
+
+      <div class="metric-card metric-card--hf" [class]="'metric-card--hf metric-card--' + healthFactorClass()">
+        <div class="metric-card__label">Health Factor</div>
+        <div class="metric-card__value metric-card__value--hf">{{ formatHf() }}</div>
+        <div class="metric-card__hf-bar">
+          <div
+            class="metric-card__hf-fill"
+            [class]="'metric-card__hf-fill--' + healthFactorClass()"
+            [style.width.%]="userMetrics().ltv"
+          ></div>
+        </div>
+        <div class="metric-card__hf-hint">
+          LTV: {{ userMetrics().ltv.toFixed(1) }}%
+        </div>
+      </div>
+    </div>
+
+    <!-- Section tabs -->
+    <div class="lending-dashboard__tabs">
+      <button
+        class="tab-btn"
+        [class.tab-btn--active]="activeSection() === 'supply'"
+        (click)="setSection('supply')"
+      >Supply</button>
+      <button
+        class="tab-btn"
+        [class.tab-btn--active]="activeSection() === 'borrow'"
+        (click)="setSection('borrow')"
+      >Borrow</button>
+    </div>
+
+    @if (activeSection() === 'supply') {
+      <!-- Your Supplies -->
+      @if (suppliedTokens().length > 0) {
+        <div class="lending-dashboard__section">
+          <h3 class="section-title">Your Supplies</h3>
+          <div class="asset-table">
+            <div class="asset-table__header">
+              <span>Asset</span>
+              <span>Supplied</span>
+              <span>APY</span>
+              <span>Actions</span>
+            </div>
+            @for (token of suppliedTokens(); track token.address) {
+              <div class="asset-table__row">
+                <div class="asset-info">
+                  <div class="asset-info__symbol">{{ token.symbol }}</div>
+                  @if (token.isCollateral) {
+                    <div class="badge badge--collateral">Collateral</div>
+                  }
+                </div>
+                <div class="asset-amount">
+                  <div>{{ formatBalance(token.suppliedBalance) }}</div>
+                  <div class="asset-amount__usd">
+                    {{ formatUsd(parseFloat(token.suppliedBalance) * token.usdPrice) }}
+                  </div>
+                </div>
+                <div class="apy apy--supply">{{ formatApy(token.supplyApy) }}</div>
+                <div class="asset-actions">
+                  <button class="btn btn--sm btn--primary" (click)="onSupplyClick(token)">Supply</button>
+                  <button class="btn btn--sm btn--outline" (click)="onWithdrawClick(token)">Withdraw</button>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Assets to Supply -->
+      <div class="lending-dashboard__section">
+        <h3 class="section-title">Assets to Supply</h3>
+        @if (availableToSupply().length === 0) {
+          <p class="empty-state">No assets available to supply in your wallet.</p>
+        } @else {
+          <div class="asset-table">
+            <div class="asset-table__header">
+              <span>Asset</span>
+              <span>Wallet Balance</span>
+              <span>APY</span>
+              <span>Action</span>
+            </div>
+            @for (token of availableToSupply(); track token.address) {
+              <div class="asset-table__row">
+                <div class="asset-info">
+                  <div class="asset-info__symbol">{{ token.symbol }}</div>
+                </div>
+                <div class="asset-amount">
+                  <div>{{ formatBalance(token.walletBalance) }}</div>
+                  <div class="asset-amount__usd">
+                    {{ formatUsd(parseFloat(token.walletBalance) * token.usdPrice) }}
+                  </div>
+                </div>
+                <div class="apy apy--supply">{{ formatApy(token.supplyApy) }}</div>
+                <div class="asset-actions">
+                  <button class="btn btn--sm btn--primary" (click)="onSupplyClick(token)">Supply</button>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+
+    @if (activeSection() === 'borrow') {
+      <!-- Your Borrows -->
+      @if (borrowedTokens().length > 0) {
+        <div class="lending-dashboard__section">
+          <h3 class="section-title">Your Borrows</h3>
+          <div class="asset-table">
+            <div class="asset-table__header">
+              <span>Asset</span>
+              <span>Debt</span>
+              <span>APY</span>
+              <span>Actions</span>
+            </div>
+            @for (token of borrowedTokens(); track token.address) {
+              <div class="asset-table__row">
+                <div class="asset-info">
+                  <div class="asset-info__symbol">{{ token.symbol }}</div>
+                </div>
+                <div class="asset-amount">
+                  <div>{{ formatBalance(token.borrowedBalance) }}</div>
+                  <div class="asset-amount__usd">
+                    {{ formatUsd(parseFloat(token.borrowedBalance) * token.usdPrice) }}
+                  </div>
+                </div>
+                <div class="apy apy--borrow">{{ formatApy(token.borrowApy) }}</div>
+                <div class="asset-actions">
+                  <button class="btn btn--sm btn--danger" (click)="onRepayClick(token)">Repay</button>
+                  <button class="btn btn--sm btn--outline" (click)="onBorrowClick(token)">Borrow More</button>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Assets to Borrow -->
+      <div class="lending-dashboard__section">
+        <h3 class="section-title">Assets to Borrow</h3>
+        @if (userMetrics().availableBorrowsUsd === 0) {
+          <p class="empty-state">Supply collateral first to enable borrowing.</p>
+        } @else if (availableToBorrow().length === 0) {
+          <p class="empty-state">No assets available to borrow.</p>
+        } @else {
+          <div class="asset-table">
+            <div class="asset-table__header">
+              <span>Asset</span>
+              <span>Available</span>
+              <span>APY</span>
+              <span>Action</span>
+            </div>
+            @for (token of availableToBorrow(); track token.address) {
+              <div class="asset-table__row">
+                <div class="asset-info">
+                  <div class="asset-info__symbol">{{ token.symbol }}</div>
+                </div>
+                <div class="asset-amount">
+                  <div class="asset-amount__usd">
+                    {{ formatUsd(userMetrics().availableBorrowsUsd) }} max
+                  </div>
+                </div>
+                <div class="apy apy--borrow">{{ formatApy(token.borrowApy) }}</div>
+                <div class="asset-actions">
+                  <button class="btn btn--sm btn--secondary" (click)="onBorrowClick(token)">Borrow</button>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Refresh button -->
+    <div class="lending-dashboard__footer">
+      <button class="btn btn--outline btn--sm" (click)="refresh()">↺ Refresh</button>
+    </div>
+  }
+</div>

--- a/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.scss
+++ b/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.scss
@@ -1,0 +1,255 @@
+.lending-dashboard {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+  margin: 0 auto;
+  width: 100%;
+
+  &__loading,
+  &__error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 32px;
+    color: #aaa;
+    font-size: 14px;
+  }
+
+  &__error {
+    color: #e57373;
+    background: rgba(229, 115, 115, 0.08);
+    border-radius: 12px;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 12px 16px;
+  }
+
+  &__metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  &__tabs {
+    display: flex;
+    gap: 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+    padding-bottom: 8px;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: center;
+    padding: 8px 0;
+  }
+}
+
+.metric-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+
+  &__label {
+    font-size: 11px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+  }
+
+  &__value {
+    font-size: 18px;
+    font-weight: 600;
+    color: #fff;
+  }
+
+  &__value--hf {
+    font-size: 22px;
+  }
+
+  &__hf-bar {
+    height: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 2px;
+    margin: 8px 0 4px;
+    overflow: hidden;
+  }
+
+  &__hf-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.4s ease;
+
+    &--safe { background: #4caf50; }
+    &--warning { background: #ff9800; }
+    &--danger { background: #f44336; }
+  }
+
+  &__hf-hint {
+    font-size: 11px;
+    color: #888;
+  }
+
+  &--safe .metric-card__value--hf { color: #4caf50; }
+  &--warning .metric-card__value--hf { color: #ff9800; }
+  &--danger .metric-card__value--hf { color: #f44336; }
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &--active {
+    background: rgba(70, 190, 140, 0.15);
+    color: #46be8c;
+  }
+
+  &:hover:not(.tab-btn--active) {
+    color: #ccc;
+  }
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.asset-table {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  overflow: hidden;
+
+  &__header {
+    display: grid;
+    grid-template-columns: 2fr 2fr 1.2fr 2fr;
+    padding: 10px 14px;
+    font-size: 11px;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: 2fr 2fr 1.2fr 2fr;
+    padding: 12px 14px;
+    align-items: center;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    transition: background 0.15s;
+
+    &:last-child { border-bottom: none; }
+    &:hover { background: rgba(255, 255, 255, 0.03); }
+  }
+}
+
+.asset-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  &__symbol {
+    font-size: 14px;
+    font-weight: 600;
+    color: #fff;
+  }
+}
+
+.asset-amount {
+  font-size: 13px;
+  color: #ddd;
+
+  &__usd {
+    font-size: 11px;
+    color: #666;
+    margin-top: 2px;
+  }
+}
+
+.apy {
+  font-size: 13px;
+  font-weight: 600;
+
+  &--supply { color: #46be8c; }
+  &--borrow { color: #ff9800; }
+}
+
+.asset-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+
+  &--collateral {
+    background: rgba(70, 190, 140, 0.15);
+    color: #46be8c;
+    border: 1px solid rgba(70, 190, 140, 0.3);
+  }
+}
+
+.empty-state {
+  font-size: 13px;
+  color: #666;
+  padding: 16px;
+  text-align: center;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(255,255,255,0.1);
+  border-top-color: #46be8c;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+// Buttons
+.btn {
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+
+  &:hover { opacity: 0.85; }
+
+  &--sm { font-size: 12px; padding: 5px 10px; }
+  &--md { font-size: 14px; padding: 8px 16px; }
+
+  &--primary { background: #46be8c; color: #000; }
+  &--secondary { background: rgba(70,190,140,0.2); color: #46be8c; border: 1px solid rgba(70,190,140,0.3); }
+  &--outline { background: transparent; color: #aaa; border: 1px solid rgba(255,255,255,0.15); }
+  &--danger { background: rgba(244,67,54,0.15); color: #f44336; border: 1px solid rgba(244,67,54,0.3); }
+}

--- a/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.ts
+++ b/src/app/v2/pages/app/lending/pages/dashboard/lending-dashboard.component.ts
@@ -1,0 +1,89 @@
+import {
+  Component,
+  inject,
+  OnInit,
+  signal,
+  computed,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { LendingDataService, LendingToken } from '../../services/lending-data.service';
+
+@Component({
+  selector: 'app-lending-dashboard',
+  imports: [CommonModule],
+  templateUrl: './lending-dashboard.component.html',
+  styleUrl: './lending-dashboard.component.scss',
+})
+export class LendingDashboardComponent implements OnInit {
+  protected dataService = inject(LendingDataService);
+  private router = inject(Router);
+
+  readonly isLoading = this.dataService.isLoading;
+  readonly error = this.dataService.error;
+  readonly userMetrics = this.dataService.userMetrics;
+  readonly suppliedTokens = this.dataService.suppliedTokens;
+  readonly borrowedTokens = this.dataService.borrowedTokens;
+  readonly availableToSupply = this.dataService.availableToSupply;
+  readonly availableToBorrow = this.dataService.availableToBorrow;
+
+  // Active section: 'supply' | 'borrow'
+  readonly activeSection = signal<'supply' | 'borrow'>('supply');
+
+  readonly healthFactorClass = computed(() => {
+    const hf = this.userMetrics().healthFactor;
+    if (!isFinite(hf) || hf > 2) return 'safe';
+    if (hf > 1.2) return 'warning';
+    return 'danger';
+  });
+
+  ngOnInit() {
+    this.dataService.loadData();
+  }
+
+  onSupplyClick(token: LendingToken) {
+    this.router.navigate(['/app/lending/supply', token.address]);
+  }
+
+  onWithdrawClick(token: LendingToken) {
+    this.router.navigate(['/app/lending/withdraw', token.address]);
+  }
+
+  onBorrowClick(token: LendingToken) {
+    this.router.navigate(['/app/lending/borrow', token.address]);
+  }
+
+  onRepayClick(token: LendingToken) {
+    this.router.navigate(['/app/lending/repay', token.address]);
+  }
+
+  refresh() {
+    this.dataService.loadData();
+  }
+
+  formatApy(apy: number): string {
+    return apy.toFixed(2) + '%';
+  }
+
+  formatBalance(balance: string, decimals = 4): string {
+    const val = parseFloat(balance);
+    if (val === 0) return '0';
+    return val.toFixed(decimals);
+  }
+
+  formatUsd(amount: number): string {
+    return this.dataService.formatUsd(amount);
+  }
+
+  formatHf(): string {
+    return this.dataService.formatHealthFactor(this.userMetrics().healthFactor);
+  }
+
+  setSection(s: 'supply' | 'borrow') {
+    this.activeSection.set(s);
+  }
+
+  parseFloat(v: string): number {
+    return parseFloat(v) || 0;
+  }
+}

--- a/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.html
+++ b/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.html
@@ -1,0 +1,66 @@
+<div class="lending-action">
+  <div class="lending-action__header">
+    <button class="back-btn" (click)="goBack()">← Back</button>
+    <h2 class="lending-action__title">Repay {{ token()?.symbol }}</h2>
+  </div>
+
+  @if (!token()) {
+    <div class="loading-state">Loading…</div>
+  } @else {
+    <div class="token-info-card">
+      <div class="token-info-row">
+        <span class="token-info-row__label">Borrow APY</span>
+        <span class="token-info-row__value token-info-row__value--orange">{{ token()!.borrowApy.toFixed(2) }}%</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Outstanding Debt</span>
+        <span class="token-info-row__value token-info-row__value--red">
+          {{ token()!.borrowedBalance | number: '1.0-6' }} {{ token()!.symbol }}
+        </span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Wallet Balance</span>
+        <span class="token-info-row__value">{{ token()!.walletBalance | number: '1.0-6' }} {{ token()!.symbol }}</span>
+      </div>
+    </div>
+
+    <div class="amount-input-group">
+      <div class="amount-input-label">
+        <span>Amount to repay</span>
+        <button class="max-btn" (click)="setMax()">MAX</button>
+      </div>
+      <div class="amount-input-wrapper">
+        <input
+          class="amount-input"
+          type="number"
+          placeholder="0.00"
+          [value]="amount()"
+          (input)="onAmountChange($any($event.target).value)"
+          min="0" step="any"
+        />
+        <span class="amount-input__symbol">{{ token()!.symbol }}</span>
+      </div>
+      @if (amount()) {
+        <div class="amount-usd">≈ {{ usdValue() }}</div>
+      }
+    </div>
+
+    @if (txStatus() === 'success') {
+      <div class="status-msg status-msg--success">✅ Repayment successful!</div>
+    }
+    @if (txStatus() === 'error') {
+      <div class="status-msg status-msg--error">❌ {{ txError() }}</div>
+    }
+
+    <button class="submit-btn" [disabled]="!isValid() || isProcessing()" (click)="onSubmit()"
+      style="background: #f44336; color: #fff;">
+      @if (isProcessing()) {
+        <span class="spinner-sm"></span> Processing…
+      } @else {
+        Repay {{ amount() ? amount() : '' }} {{ token()!.symbol }}
+      }
+    </button>
+
+    <p class="hint">Repayment will approve spending if allowance is insufficient.</p>
+  }
+</div>

--- a/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.scss
+++ b/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.scss
@@ -1,0 +1,1 @@
+@import '../../lending-action.shared';

--- a/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.ts
+++ b/src/app/v2/pages/app/lending/pages/repay/lending-repay.component.ts
@@ -1,0 +1,68 @@
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LendingDataService, LendingToken } from '../../services/lending-data.service';
+
+@Component({
+  selector: 'app-lending-repay',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './lending-repay.component.html',
+  styleUrl: './lending-repay.component.scss',
+})
+export class LendingRepayComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  protected dataService = inject(LendingDataService);
+
+  readonly token = signal<LendingToken | null>(null);
+  readonly amount = signal('');
+  readonly isProcessing = signal(false);
+  readonly txStatus = signal<'idle' | 'success' | 'error'>('idle');
+  readonly txError = signal('');
+
+  readonly maxAmount = computed(() => this.token()?.borrowedBalance ?? '0');
+  readonly parsedAmount = computed(() => parseFloat(this.amount()) || 0);
+  readonly isValid = computed(
+    () => this.parsedAmount() > 0 && this.parsedAmount() <= parseFloat(this.maxAmount()),
+  );
+  readonly usdValue = computed(() =>
+    this.dataService.formatUsd(this.parsedAmount() * (this.token()?.usdPrice ?? 0)),
+  );
+
+  ngOnInit() {
+    const address = this.route.snapshot.paramMap.get('address');
+    const load = () => {
+      const token = this.dataService.tokens().find(
+        (t) => t.address.toLowerCase() === (address ?? '').toLowerCase(),
+      );
+      this.token.set(token ?? null);
+    };
+    if (address && this.dataService.tokens().length) {
+      load();
+    } else if (address) {
+      this.dataService.loadData().then(load);
+    }
+  }
+
+  setMax() { this.amount.set(this.maxAmount()); }
+  onAmountChange(value: string) { this.amount.set(value); }
+
+  async onSubmit() {
+    const token = this.token();
+    if (!token || !this.isValid()) return;
+    this.isProcessing.set(true);
+    this.txStatus.set('idle');
+    const success = await this.dataService.approveAndRepay(token, this.amount());
+    if (success) {
+      this.txStatus.set('success');
+      await this.dataService.loadData();
+    } else {
+      this.txStatus.set('error');
+      this.txError.set('Transaction failed or was rejected.');
+    }
+    this.isProcessing.set(false);
+  }
+
+  goBack() { this.router.navigate(['/app/lending']); }
+}

--- a/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.html
+++ b/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.html
@@ -1,0 +1,78 @@
+<div class="lending-action">
+  <div class="lending-action__header">
+    <button class="back-btn" (click)="goBack()">← Back</button>
+    <h2 class="lending-action__title">Supply {{ token()?.symbol }}</h2>
+  </div>
+
+  @if (!token()) {
+    <div class="loading-state">Loading…</div>
+  } @else {
+    <!-- Token info -->
+    <div class="token-info-card">
+      <div class="token-info-row">
+        <span class="token-info-row__label">Supply APY</span>
+        <span class="token-info-row__value token-info-row__value--green">{{ token()!.supplyApy.toFixed(2) }}%</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Wallet Balance</span>
+        <span class="token-info-row__value">{{ token()!.walletBalance | number: '1.0-6' }} {{ token()!.symbol }}</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Currently Supplied</span>
+        <span class="token-info-row__value">{{ token()!.suppliedBalance | number: '1.0-6' }} {{ token()!.symbol }}</span>
+      </div>
+    </div>
+
+    <!-- Amount input -->
+    <div class="amount-input-group">
+      <div class="amount-input-label">
+        <span>Amount to supply</span>
+        <button class="max-btn" (click)="setMax()">MAX</button>
+      </div>
+      <div class="amount-input-wrapper">
+        <input
+          class="amount-input"
+          type="number"
+          placeholder="0.00"
+          [value]="amount()"
+          (input)="onAmountChange($any($event.target).value)"
+          min="0"
+          step="any"
+        />
+        <span class="amount-input__symbol">{{ token()!.symbol }}</span>
+      </div>
+      @if (amount()) {
+        <div class="amount-usd">≈ {{ usdValue() }}</div>
+      }
+    </div>
+
+    <!-- Status messages -->
+    @if (txStatus() === 'success') {
+      <div class="status-msg status-msg--success">
+        ✅ Supply successful! Your position has been updated.
+      </div>
+    }
+    @if (txStatus() === 'error') {
+      <div class="status-msg status-msg--error">
+        ❌ {{ txError() }}
+      </div>
+    }
+
+    <!-- Submit -->
+    <button
+      class="submit-btn"
+      [disabled]="!isValid() || isProcessing()"
+      (click)="onSubmit()"
+    >
+      @if (isProcessing()) {
+        <span class="spinner-sm"></span> Processing…
+      } @else {
+        Supply {{ amount() ? amount() : '' }} {{ token()!.symbol }}
+      }
+    </button>
+
+    <p class="hint">
+      Supplying will first require an ERC-20 approval if your allowance is insufficient.
+    </p>
+  }
+</div>

--- a/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.scss
+++ b/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.scss
@@ -1,0 +1,1 @@
+@import '../../lending-action.shared';

--- a/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.ts
+++ b/src/app/v2/pages/app/lending/pages/supply/lending-supply.component.ts
@@ -1,0 +1,81 @@
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LendingDataService, LendingToken } from '../../services/lending-data.service';
+
+@Component({
+  selector: 'app-lending-supply',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './lending-supply.component.html',
+  styleUrl: './lending-supply.component.scss',
+})
+export class LendingSupplyComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  protected dataService = inject(LendingDataService);
+
+  readonly token = signal<LendingToken | null>(null);
+  readonly amount = signal('');
+  readonly isProcessing = signal(false);
+  readonly txStatus = signal<'idle' | 'success' | 'error'>('idle');
+  readonly txError = signal('');
+
+  readonly maxAmount = computed(() => this.token()?.walletBalance ?? '0');
+  readonly parsedAmount = computed(() => parseFloat(this.amount()) || 0);
+  readonly isValid = computed(
+    () => this.parsedAmount() > 0 && this.parsedAmount() <= parseFloat(this.maxAmount()),
+  );
+  readonly usdValue = computed(() =>
+    this.dataService.formatUsd(this.parsedAmount() * (this.token()?.usdPrice ?? 0)),
+  );
+
+  ngOnInit() {
+    const address = this.route.snapshot.paramMap.get('address');
+    if (address && this.dataService.tokens().length) {
+      const token = this.dataService.tokens().find(
+        (t) => t.address.toLowerCase() === address.toLowerCase(),
+      );
+      this.token.set(token ?? null);
+    } else if (address) {
+      // Load data if not yet loaded
+      this.dataService.loadData().then(() => {
+        const token = this.dataService.tokens().find(
+          (t) => t.address.toLowerCase() === address.toLowerCase(),
+        );
+        this.token.set(token ?? null);
+      });
+    }
+  }
+
+  setMax() {
+    this.amount.set(this.maxAmount());
+  }
+
+  onAmountChange(value: string) {
+    this.amount.set(value);
+  }
+
+  async onSubmit() {
+    const token = this.token();
+    if (!token || !this.isValid()) return;
+
+    this.isProcessing.set(true);
+    this.txStatus.set('idle');
+
+    const success = await this.dataService.approveAndSupply(token, this.amount());
+
+    if (success) {
+      this.txStatus.set('success');
+      await this.dataService.loadData();
+    } else {
+      this.txStatus.set('error');
+      this.txError.set('Transaction failed or was rejected.');
+    }
+    this.isProcessing.set(false);
+  }
+
+  goBack() {
+    this.router.navigate(['/app/lending']);
+  }
+}

--- a/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.html
+++ b/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.html
@@ -1,0 +1,57 @@
+<div class="lending-action">
+  <div class="lending-action__header">
+    <button class="back-btn" (click)="goBack()">← Back</button>
+    <h2 class="lending-action__title">Withdraw {{ token()?.symbol }}</h2>
+  </div>
+
+  @if (!token()) {
+    <div class="loading-state">Loading…</div>
+  } @else {
+    <div class="token-info-card">
+      <div class="token-info-row">
+        <span class="token-info-row__label">Supply APY</span>
+        <span class="token-info-row__value token-info-row__value--green">{{ token()!.supplyApy.toFixed(2) }}%</span>
+      </div>
+      <div class="token-info-row">
+        <span class="token-info-row__label">Supplied Balance</span>
+        <span class="token-info-row__value">{{ token()!.suppliedBalance | number: '1.0-6' }} {{ token()!.symbol }}</span>
+      </div>
+    </div>
+
+    <div class="amount-input-group">
+      <div class="amount-input-label">
+        <span>Amount to withdraw</span>
+        <button class="max-btn" (click)="setMax()">MAX</button>
+      </div>
+      <div class="amount-input-wrapper">
+        <input
+          class="amount-input"
+          type="number"
+          placeholder="0.00"
+          [value]="amount()"
+          (input)="onAmountChange($any($event.target).value)"
+          min="0" step="any"
+        />
+        <span class="amount-input__symbol">{{ token()!.symbol }}</span>
+      </div>
+      @if (amount()) {
+        <div class="amount-usd">≈ {{ usdValue() }}</div>
+      }
+    </div>
+
+    @if (txStatus() === 'success') {
+      <div class="status-msg status-msg--success">✅ Withdraw successful!</div>
+    }
+    @if (txStatus() === 'error') {
+      <div class="status-msg status-msg--error">❌ {{ txError() }}</div>
+    }
+
+    <button class="submit-btn" [disabled]="!isValid() || isProcessing()" (click)="onSubmit()">
+      @if (isProcessing()) {
+        <span class="spinner-sm"></span> Processing…
+      } @else {
+        Withdraw {{ amount() ? amount() : '' }} {{ token()!.symbol }}
+      }
+    </button>
+  }
+</div>

--- a/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.scss
+++ b/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.scss
@@ -1,0 +1,1 @@
+@import '../../lending-action.shared';

--- a/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.ts
+++ b/src/app/v2/pages/app/lending/pages/withdraw/lending-withdraw.component.ts
@@ -1,0 +1,68 @@
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LendingDataService, LendingToken } from '../../services/lending-data.service';
+
+@Component({
+  selector: 'app-lending-withdraw',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './lending-withdraw.component.html',
+  styleUrl: './lending-withdraw.component.scss',
+})
+export class LendingWithdrawComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  protected dataService = inject(LendingDataService);
+
+  readonly token = signal<LendingToken | null>(null);
+  readonly amount = signal('');
+  readonly isProcessing = signal(false);
+  readonly txStatus = signal<'idle' | 'success' | 'error'>('idle');
+  readonly txError = signal('');
+
+  readonly maxAmount = computed(() => this.token()?.suppliedBalance ?? '0');
+  readonly parsedAmount = computed(() => parseFloat(this.amount()) || 0);
+  readonly isValid = computed(
+    () => this.parsedAmount() > 0 && this.parsedAmount() <= parseFloat(this.maxAmount()),
+  );
+  readonly usdValue = computed(() =>
+    this.dataService.formatUsd(this.parsedAmount() * (this.token()?.usdPrice ?? 0)),
+  );
+
+  ngOnInit() {
+    const address = this.route.snapshot.paramMap.get('address');
+    const load = () => {
+      const token = this.dataService.tokens().find(
+        (t) => t.address.toLowerCase() === (address ?? '').toLowerCase(),
+      );
+      this.token.set(token ?? null);
+    };
+    if (address && this.dataService.tokens().length) {
+      load();
+    } else if (address) {
+      this.dataService.loadData().then(load);
+    }
+  }
+
+  setMax() { this.amount.set(this.maxAmount()); }
+  onAmountChange(value: string) { this.amount.set(value); }
+
+  async onSubmit() {
+    const token = this.token();
+    if (!token || !this.isValid()) return;
+    this.isProcessing.set(true);
+    this.txStatus.set('idle');
+    const success = await this.dataService.withdraw(token, this.amount());
+    if (success) {
+      this.txStatus.set('success');
+      await this.dataService.loadData();
+    } else {
+      this.txStatus.set('error');
+      this.txError.set('Transaction failed or was rejected.');
+    }
+    this.isProcessing.set(false);
+  }
+
+  goBack() { this.router.navigate(['/app/lending']); }
+}

--- a/src/app/v2/pages/app/lending/services/lending-data.service.ts
+++ b/src/app/v2/pages/app/lending/services/lending-data.service.ts
@@ -1,0 +1,352 @@
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { ethers, formatUnits } from 'ethers';
+import { WalletService } from '../../../../../services/wallet.service';
+import { WalletActionService } from '../../../../../services/wallet-action.service';
+import { AavePoolContract, UserAccountData } from '../../../../../services/etherium-services/smart-contracts/contracts/aave/aave-pool.contract';
+import {
+  AaveUiDataProviderContract,
+  AggregatedReserveData,
+} from '../../../../../services/etherium-services/smart-contracts/contracts/aave/aave-ui-data-provider.contract';
+import { AaveDataProviderContract, UserReserveData } from '../../../../../services/etherium-services/smart-contracts/contracts/aave/aave-data-provider.contract';
+import { ERC20Contract } from '../../../../../services/etherium-services/smart-contracts/contracts/erc20-contract';
+
+export interface LendingToken {
+  symbol: string;
+  address: string;
+  decimals: number;
+  supplyApy: number;
+  borrowApy: number;
+  usdPrice: number;
+  // User data
+  walletBalance: string;
+  suppliedBalance: string;   // aToken balance
+  borrowedBalance: string;   // variable debt balance
+  isCollateral: boolean;
+  canSupply: boolean;
+  canWithdraw: boolean;
+  canBorrow: boolean;
+  canRepay: boolean;
+  // Market
+  isActive: boolean;
+  isFrozen: boolean;
+  borrowingEnabled: boolean;
+  ltv: string;
+  liquidationThreshold: string;
+  aTokenAddress: string;
+  variableDebtTokenAddress: string;
+}
+
+export interface UserMetrics {
+  totalCollateralUsd: number;
+  totalDebtUsd: number;
+  availableBorrowsUsd: number;
+  healthFactor: number;
+  ltv: number;
+  loading: boolean;
+}
+
+export const VARIABLE_RATE_MODE = 2;
+
+// Contract addresses on IGRA testnet — update to mainnet when ready
+// TODO: Replace placeholder addresses with actual IGRA Aave V3 deployments
+export const IGRA_LENDING_CONTRACTS = {
+  POOL_ADDRESSES_PROVIDER: '0xeE03b5c85d38d3F39A62ceEBe4D0A1B3D25e7E7',
+  POOL: '0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2',
+  UI_DATA_PROVIDER: '0x42A7B860C15B52F1b91fA16C3bd7FC7360B6cD4c',
+  DATA_PROVIDER: '0x3e9708d80f7B3e43118013075F7e95CE3AB31F31',
+};
+
+const RAY = 10n ** 27n;
+const SECONDS_PER_YEAR = 31536000n;
+
+function rayToApy(ray: bigint): number {
+  if (!ray || ray === 0n) return 0;
+  const depositApy = ((1 + Number(ray) / Number(RAY) / Number(SECONDS_PER_YEAR)) ** Number(SECONDS_PER_YEAR) - 1) * 100;
+  return Math.round(depositApy * 100) / 100;
+}
+
+@Injectable()
+export class LendingDataService {
+  private walletService = inject(WalletService);
+  private walletActionService = inject(WalletActionService);
+
+  private _tokens = signal<LendingToken[]>([]);
+  private _userMetrics = signal<UserMetrics>({
+    totalCollateralUsd: 0,
+    totalDebtUsd: 0,
+    availableBorrowsUsd: 0,
+    healthFactor: 0,
+    ltv: 0,
+    loading: false,
+  });
+  private _isLoading = signal(false);
+  private _error = signal<string | null>(null);
+
+  readonly tokens = this._tokens.asReadonly();
+  readonly userMetrics = this._userMetrics.asReadonly();
+  readonly isLoading = this._isLoading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  readonly suppliedTokens = computed(() =>
+    this._tokens().filter((t) => parseFloat(t.suppliedBalance) > 0),
+  );
+
+  readonly borrowedTokens = computed(() =>
+    this._tokens().filter((t) => parseFloat(t.borrowedBalance) > 0),
+  );
+
+  readonly availableToSupply = computed(() =>
+    this._tokens().filter((t) => t.canSupply && parseFloat(t.walletBalance) > 0),
+  );
+
+  readonly availableToBorrow = computed(() =>
+    this._tokens().filter((t) => t.canBorrow && t.borrowingEnabled && t.isActive && !t.isFrozen),
+  );
+
+  private getPool(): AavePoolContract {
+    return AavePoolContract.getContract(
+      IGRA_LENDING_CONTRACTS.POOL,
+      this.walletService,
+      this.walletActionService,
+    );
+  }
+
+  private getUiDataProvider(): AaveUiDataProviderContract {
+    return AaveUiDataProviderContract.getContract(
+      IGRA_LENDING_CONTRACTS.UI_DATA_PROVIDER,
+      this.walletService,
+    );
+  }
+
+  private getDataProvider(): AaveDataProviderContract {
+    return AaveDataProviderContract.getContract(
+      IGRA_LENDING_CONTRACTS.DATA_PROVIDER,
+      this.walletService,
+    );
+  }
+
+  private getErc20(address: string): ERC20Contract {
+    return ERC20Contract.getContract(address, this.walletService, this.walletActionService);
+  }
+
+  async loadData(): Promise<void> {
+    this._isLoading.set(true);
+    this._error.set(null);
+
+    try {
+      const userAddress = this.walletService.getCurrentWallet()?.getL2WalletAddress();
+      if (!userAddress) {
+        this._error.set('No L2 wallet connected');
+        return;
+      }
+
+      const uiProvider = this.getUiDataProvider();
+      const dataProvider = this.getDataProvider();
+
+      // Load reserves data
+      const reservesResult = await uiProvider.getReservesData(IGRA_LENDING_CONTRACTS.POOL_ADDRESSES_PROVIDER);
+      const { reservesData, baseCurrencyInfo } = reservesResult;
+
+      // Build a map of user reserve data fetched per-asset from the DataProvider
+      const userReservesMap = new Map<string, UserReserveData>();
+      await Promise.all(
+        reservesData.map(async (reserve) => {
+          try {
+            const ur = await dataProvider.getUserReserveData(reserve.underlyingAsset, userAddress);
+            userReservesMap.set(reserve.underlyingAsset.toLowerCase(), ur);
+          } catch {
+            // ignore per-asset errors
+          }
+        }),
+      );
+
+      // Process tokens
+      const tokens: LendingToken[] = [];
+      for (const reserve of reservesData) {
+        if (!reserve.isActive) continue;
+
+        const userReserve = userReservesMap.get(reserve.underlyingAsset.toLowerCase());
+
+        // Get wallet balance
+        let walletBalance = '0';
+        try {
+          const erc20 = ERC20Contract.getContract(reserve.underlyingAsset, this.walletService);
+          const rawBalance = await erc20.balanceOf(userAddress) as bigint;
+          walletBalance = formatUnits(rawBalance, Number(reserve.decimals));
+        } catch {
+          // ignore balance read errors
+        }
+
+        const supplyApy = rayToApy(reserve.liquidityRate);
+        const borrowApy = rayToApy(reserve.variableBorrowRate);
+
+        // USD price from baseCurrency ref
+        const priceInRef = Number(reserve.priceInMarketReferenceCurrency);
+        const refUnit = Number(baseCurrencyInfo.marketReferenceCurrencyUnit);
+        const refPriceUsd = Number(baseCurrencyInfo.networkBaseTokenPriceInUsd) /
+          (10 ** baseCurrencyInfo.networkBaseTokenPriceDecimals);
+        const usdPrice = refUnit > 0 ? (priceInRef / refUnit) * refPriceUsd : 0;
+
+        const suppliedBalance = userReserve?.currentATokenBalance != null && userReserve.currentATokenBalance > 0n
+          ? formatUnits(userReserve.currentATokenBalance, Number(reserve.decimals))
+          : '0';
+
+        const borrowedBalance = userReserve?.currentVariableDebt != null && userReserve.currentVariableDebt > 0n
+          ? formatUnits(userReserve.currentVariableDebt, Number(reserve.decimals))
+          : '0';
+
+        tokens.push({
+          symbol: reserve.symbol,
+          address: reserve.underlyingAsset,
+          decimals: Number(reserve.decimals),
+          supplyApy,
+          borrowApy,
+          usdPrice,
+          walletBalance,
+          suppliedBalance,
+          borrowedBalance,
+          isCollateral: userReserve?.usageAsCollateralEnabled ?? reserve.usageAsCollateralEnabled ?? false,
+          canSupply: parseFloat(walletBalance) > 0 && reserve.isActive && !reserve.isFrozen,
+          canWithdraw: parseFloat(suppliedBalance) > 0,
+          canBorrow: reserve.borrowingEnabled && reserve.isActive && !reserve.isFrozen,
+          canRepay: parseFloat(borrowedBalance) > 0,
+          isActive: reserve.isActive,
+          isFrozen: reserve.isFrozen,
+          borrowingEnabled: reserve.borrowingEnabled,
+          ltv: formatUnits(reserve.baseLTVasCollateral, 2),
+          liquidationThreshold: formatUnits(reserve.reserveLiquidationThreshold, 2),
+          aTokenAddress: reserve.aTokenAddress,
+          variableDebtTokenAddress: reserve.variableDebtTokenAddress,
+        });
+      }
+
+      this._tokens.set(tokens);
+
+      // Load user account data (health factor etc.)
+      await this.loadUserMetrics(userAddress);
+    } catch (e) {
+      this._error.set((e as Error).message ?? 'Failed to load lending data');
+      console.error('LendingDataService.loadData error:', e);
+    } finally {
+      this._isLoading.set(false);
+    }
+  }
+
+  async loadUserMetrics(userAddress: string): Promise<void> {
+    this._userMetrics.update((m) => ({ ...m, loading: true }));
+    try {
+      const pool = this.getPool();
+      const data: UserAccountData = await pool.getUserAccountData(userAddress);
+
+      const BASE_UNIT = 100000000n; // 1e8
+      const totalCollateralUsd = Number(data.totalCollateralBase) / Number(BASE_UNIT);
+      const totalDebtUsd = Number(data.totalDebtBase) / Number(BASE_UNIT);
+      const availableBorrowsUsd = Number(data.availableBorrowsBase) / Number(BASE_UNIT);
+      const healthFactor = data.healthFactor === ethers.MaxUint256
+        ? Infinity
+        : Number(data.healthFactor) / 1e18;
+      const ltv = totalCollateralUsd > 0 ? (totalDebtUsd / totalCollateralUsd) * 100 : 0;
+
+      this._userMetrics.set({
+        totalCollateralUsd,
+        totalDebtUsd,
+        availableBorrowsUsd,
+        healthFactor,
+        ltv,
+        loading: false,
+      });
+    } catch (e) {
+      console.error('loadUserMetrics error:', e);
+      this._userMetrics.update((m) => ({ ...m, loading: false }));
+    }
+  }
+
+  // --- Actions ---
+
+  async approveAndSupply(token: LendingToken, amount: string): Promise<boolean> {
+    const userAddress = this.walletService.getCurrentWallet()?.getL2WalletAddress();
+    if (!userAddress) return false;
+
+    try {
+      const parsedAmount = ethers.parseUnits(amount, token.decimals);
+      const erc20 = this.getErc20(token.address);
+
+      // Check allowance
+      const allowance = await erc20.allowance(userAddress, IGRA_LENDING_CONTRACTS.POOL) as bigint;
+      if (allowance < parsedAmount) {
+        const approveResult = await erc20.approve(IGRA_LENDING_CONTRACTS.POOL, parsedAmount.toString());
+        if (!approveResult?.result) return false;
+      }
+
+      const pool = this.getPool();
+      const result = await pool.supply(token.address, parsedAmount, userAddress);
+      return !!result?.result;
+    } catch (e) {
+      console.error('supply error:', e);
+      return false;
+    }
+  }
+
+  async withdraw(token: LendingToken, amount: string): Promise<boolean> {
+    const userAddress = this.walletService.getCurrentWallet()?.getL2WalletAddress();
+    if (!userAddress) return false;
+
+    try {
+      const parsedAmount = ethers.parseUnits(amount, token.decimals);
+      const pool = this.getPool();
+      const result = await pool.withdraw(token.address, parsedAmount, userAddress);
+      return !!result?.result;
+    } catch (e) {
+      console.error('withdraw error:', e);
+      return false;
+    }
+  }
+
+  async borrow(token: LendingToken, amount: string): Promise<boolean> {
+    const userAddress = this.walletService.getCurrentWallet()?.getL2WalletAddress();
+    if (!userAddress) return false;
+
+    try {
+      const parsedAmount = ethers.parseUnits(amount, token.decimals);
+      const pool = this.getPool();
+      const result = await pool.borrow(token.address, parsedAmount, VARIABLE_RATE_MODE, 0, userAddress);
+      return !!result?.result;
+    } catch (e) {
+      console.error('borrow error:', e);
+      return false;
+    }
+  }
+
+  async approveAndRepay(token: LendingToken, amount: string): Promise<boolean> {
+    const userAddress = this.walletService.getCurrentWallet()?.getL2WalletAddress();
+    if (!userAddress) return false;
+
+    try {
+      const parsedAmount = ethers.parseUnits(amount, token.decimals);
+      const erc20 = this.getErc20(token.address);
+
+      const allowance = await erc20.allowance(userAddress, IGRA_LENDING_CONTRACTS.POOL) as bigint;
+      if (allowance < parsedAmount) {
+        const approveResult = await erc20.approve(IGRA_LENDING_CONTRACTS.POOL, parsedAmount.toString());
+        if (!approveResult?.result) return false;
+      }
+
+      const pool = this.getPool();
+      const result = await pool.repay(token.address, parsedAmount, VARIABLE_RATE_MODE, userAddress);
+      return !!result?.result;
+    } catch (e) {
+      console.error('repay error:', e);
+      return false;
+    }
+  }
+
+  formatUsd(amount: number): string {
+    if (amount === 0) return '$0.00';
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+  }
+
+  formatHealthFactor(hf: number): string {
+    if (!isFinite(hf)) return '∞';
+    return hf.toFixed(2);
+  }
+}

--- a/src/app/v2/pages/app/lending/services/lending-data.service.ts
+++ b/src/app/v2/pages/app/lending/services/lending-data.service.ts
@@ -206,10 +206,10 @@ export class LendingDataService {
           suppliedBalance,
           borrowedBalance,
           isCollateral: userReserve?.usageAsCollateralEnabled ?? reserve.usageAsCollateralEnabled ?? false,
-          canSupply: parseFloat(walletBalance) > 0 && reserve.isActive && !reserve.isFrozen,
-          canWithdraw: parseFloat(suppliedBalance) > 0,
-          canBorrow: reserve.borrowingEnabled && reserve.isActive && !reserve.isFrozen,
-          canRepay: parseFloat(borrowedBalance) > 0,
+          canSupply: parseFloat(walletBalance) > 0 && reserve.isActive && !reserve.isFrozen && !reserve.isPaused,
+          canWithdraw: parseFloat(suppliedBalance) > 0 && !reserve.isPaused,
+          canBorrow: reserve.borrowingEnabled && reserve.isActive && !reserve.isFrozen && !reserve.isPaused,
+          canRepay: parseFloat(borrowedBalance) > 0 && !reserve.isPaused,
           isActive: reserve.isActive,
           isFrozen: reserve.isFrozen,
           borrowingEnabled: reserve.borrowingEnabled,
@@ -323,16 +323,18 @@ export class LendingDataService {
 
     try {
       const parsedAmount = ethers.parseUnits(amount, token.decimals);
+      const isFullRepay = amount === token.borrowedBalance;
+      const repayAmount = isFullRepay ? ethers.MaxUint256 : parsedAmount;
       const erc20 = this.getErc20(token.address);
 
       const allowance = await erc20.allowance(userAddress, IGRA_LENDING_CONTRACTS.POOL) as bigint;
-      if (allowance < parsedAmount) {
-        const approveResult = await erc20.approve(IGRA_LENDING_CONTRACTS.POOL, parsedAmount.toString());
+      if (allowance < repayAmount) {
+        const approveResult = await erc20.approve(IGRA_LENDING_CONTRACTS.POOL, repayAmount.toString());
         if (!approveResult?.result) return false;
       }
 
       const pool = this.getPool();
-      const result = await pool.repay(token.address, parsedAmount, VARIABLE_RATE_MODE, userAddress);
+      const result = await pool.repay(token.address, repayAmount, VARIABLE_RATE_MODE, userAddress);
       return !!result?.result;
     } catch (e) {
       console.error('repay error:', e);

--- a/src/app/v2/pages/app/logged.routes.ts
+++ b/src/app/v2/pages/app/logged.routes.ts
@@ -6,6 +6,7 @@ import { TransactionsComponent } from './transactions/transactions.component';
 import { SettingsComponent } from './settings/settings.component';
 import { ActivityComponent } from './activity/activity.component';
 import { HomeRoutes } from './home/routes/home.routes';
+import { LendingRoutes } from './lending/lending.routes';
 
 export const loggedRoutes: Routes = [
   {
@@ -37,6 +38,11 @@ export const loggedRoutes: Routes = [
         path: 'activity',
         component: ActivityComponent,
         data: { animation: 'Activity' },
+      },
+      {
+        path: 'lending',
+        children: LendingRoutes,
+        data: { animation: 'Lending' },
       },
     ],
   },


### PR DESCRIPTION
## KCW-64 — Basic Lending/Borrowing UI

### What's built
A complete lending/borrowing interface in the web wallet backed by Aave V3 contracts on IGRA.

### Features
- **Lending Dashboard** (`/app/lending`) — health factor display, supplied assets, borrowed assets, available markets, Supply/Borrow section tabs
- **Supply flow** — enter amount → ERC-20 approve if needed → Pool.supply()
- **Withdraw flow** — enter amount → Pool.withdraw()
- **Borrow flow** — enter amount → Pool.borrow() (variable rate)
- **Repay flow** — enter amount → ERC-20 approve if needed → Pool.repay()
- **Health factor indicator** — color-coded (green/orange/red), LTV bar
- **Lending nav item** added to bottom navigation

### Architecture
- `LendingDataService` — route-scoped provider, loads reserves via UiDataProvider + user positions via DataProvider, handles supply/withdraw/borrow/repay actions
- 3 new Aave contract wrappers: `AavePoolContract`, `AaveUiDataProviderContract`, `AaveDataProviderContract`
- ABIs copied from defi-frontend: pool, ui-data-provider, data-provider, oracle, pool-addresses

### ⚠️ Needs follow-up
- **Contract addresses** in `IGRA_LENDING_CONTRACTS` are **placeholder** — real IGRA Aave V3 deployment addresses must be filled in
- No wallet-connect guard yet (shows error if L2 not connected)
- No L2 chain guard (should only be visible when L2 display mode is active)
- Token icons not shown (no logo URL in scope)

### Build
✅ `ng build --configuration development` passes with no errors