### PR TITLE
fix(e2e): valid BIP39 fixture seeds + wire KASPA_E2E_SEED

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -115,6 +115,10 @@ jobs:
         run: npm run e2e:smoke
         env:
           CI: 'true'
+          # Pre-funded TN10 seed for send/swap tests. Set as a KASPACOM
+          # organization secret. Unset/empty on forks; funded-wallet tests
+          # self-skip via getFundedSeed() when missing.
+          KASPA_E2E_SEED: ${{ secrets.KASPA_E2E_SEED }}
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/e2e/fixtures/wallet.ts
+++ b/e2e/fixtures/wallet.ts
@@ -1,25 +1,40 @@
 /**
- * Fixture wallets used for onboarding E2E tests.
+ * Fixture wallets used for onboarding / import E2E tests.
  *
- * These are publicly known BIP39 test vectors with zero balance on any network.
- * Do NOT use a production seed here. Pre-funded testnet wallets for send/swap
- * tests are injected at runtime via the KASPA_E2E_SEED env var.
+ * These are freshly-generated, valid BIP39 mnemonics with no funds on any
+ * network. They are committed on purpose: tests that drive the import UI
+ * need a seed the wallet SDK will accept, and an unfunded seed has no
+ * security value to protect.
+ *
+ * Pre-funded testnet wallets for send / swap tests are injected at runtime
+ * via the `KASPA_E2E_SEED` env var (GitHub Actions org secret), never from
+ * this file. Never put a funded seed here.
  */
 
 export const TEST_PASSWORD = 'WalletE2E!Password1';
 
-// BIP39 test vector — entropy 0x00000000000000000000000000000000
+// Fresh 12-word BIP39 mnemonic, generated 2026-04-20. Unfunded.
 export const BIP39_TEST_SEED_12 =
-  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  'client later lock verify knife lift obtain grant divorce siege rural time';
 
-// BIP39 test vector — entropy 0x0000…0000 (256-bit)
+// Fresh 24-word BIP39 mnemonic, generated 2026-04-20. Unfunded.
 export const BIP39_TEST_SEED_24 =
-  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+  'inch shift seed outside offer chimney puzzle chat talent issue love trash tiny assault wrestle skirt begin north announce clean peanut safe benefit essence';
 
 // secp256k1 private key (hex). Well-known test key, no funds anywhere.
 export const TEST_PRIVATE_KEY_HEX =
   '0000000000000000000000000000000000000000000000000000000000000001';
 
-// Clearly-invalid seed used to test error paths.
+// Clearly-invalid seed used to test the error path.
 export const INVALID_SEED_12 =
   'notaword notaword notaword notaword notaword notaword notaword notaword notaword notaword notaword notaword';
+
+/**
+ * Read the pre-funded TN10 seed from the environment. Returns undefined if
+ * unset, so tests can skip (rather than fail loudly) when running against
+ * a local env without the secret configured.
+ */
+export function getFundedSeed(): string | undefined {
+  const seed = process.env.KASPA_E2E_SEED?.trim();
+  return seed && seed.split(/\s+/).length >= 12 ? seed : undefined;
+}

--- a/e2e/helpers/onboarding.ts
+++ b/e2e/helpers/onboarding.ts
@@ -134,6 +134,12 @@ export async function importBySeedPhrase(
   await waitForHeading(page, /^Create Password$/i);
   await fillPasswordInputs(page, password, 'Next');
 
+  // Step 5: Success — "Wallet Loading" screen with a "Finish" button that
+  // calls walletService.forceReloadWallets() then router.navigate(/app/home).
+  // Unlike the new-wallet ADDRESS step, this one does not auto-navigate.
+  await waitForHeading(page, /Wallet Loading/i);
+  await clickKcButton(page, 'Finish');
+
   await waitForWalletHome(page);
 }
 
@@ -156,6 +162,9 @@ export async function importByPrivateKey(
 
   await waitForHeading(page, /^Create Password$/i);
   await fillPasswordInputs(page, password, 'Next');
+
+  await waitForHeading(page, /Wallet Loading/i);
+  await clickKcButton(page, 'Finish');
 
   await waitForWalletHome(page);
 }

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -79,11 +79,7 @@ test.describe('Onboarding', () => {
     await expect(continueBtn).toBeEnabled();
   });
 
-  // Not @smoke until PR 2 introduces KASPA_E2E_SEED — the BIP39 all-abandon
-  // test vector is rejected by @kaspacom/wallet-messages (likely a well-known-
-  // seed guard). The test still runs in the full suite via `npm run e2e`;
-  // re-tag as @smoke once a verified TN10 seed is wired in.
-  test('import via 12-word seed phrase lands on home', async ({ page }) => {
+  test('@smoke import via 12-word seed phrase lands on home', async ({ page }) => {
     await gotoLanding(page);
     await importBySeedPhrase(page, BIP39_TEST_SEED_12, TEST_PASSWORD);
     expect(await hasStoredWallet(page)).toBe(true);

--- a/openspec/changes/wallet-e2e-tests/tasks.md
+++ b/openspec/changes/wallet-e2e-tests/tasks.md
@@ -9,7 +9,7 @@
 - [x] Helpers: wait for hydration, clear/seed localStorage, drive onboarding flow
 - [x] `e2e/onboarding.spec.ts` — 10 tests: create (12/24), import seed (12/24), invalid seed, private key, login right/wrong password, checkbox gating
   - [x] 3 tests tagged `@smoke` in CI gate: landing, create, login-wrong-password
-  - [ ] Re-tag `@smoke` on import-seed tests once PR 2 wires `KASPA_E2E_SEED` (BIP39 all-abandon test vector is rejected by the wallet SDK — needs a real TN10 seed)
+  - [x] PR 1.1: replace rejected BIP39 all-abandon test vector with freshly-generated valid mnemonics; re-tag `import via 12-word seed` as `@smoke`; wire `KASPA_E2E_SEED` org secret into CI env
 - [x] Update `.github/workflows/pr-check.yml` — new `e2e-smoke` job (Chromium)
 - [x] `e2e/README.md` — how to run locally, env vars, CI behavior
 - [x] Fix dev-server host binding for CI (override `local.kaspa.com` → `127.0.0.1 --disable-host-check`)


### PR DESCRIPTION
## Summary

Small follow-up to #193 to close two loose ends from PR 1:

1. **Replace rejected test seed.** The BIP39 all-abandon test vector (`abandon × 11 about`) is rejected by `@kaspacom/wallet-messages` — almost certainly a well-known-seed blocklist. Swapped in fresh, valid 12-word and 24-word mnemonics. Unfunded = safe to commit.
2. **Wire the `KASPA_E2E_SEED` org secret** into the `e2e-smoke` job env. PR 2 (send/swap/approval) reads from it via a new `getFundedSeed()` helper that returns `undefined` on forks / local runs so funded tests self-skip instead of failing.

Re-tags `import via 12-word seed phrase` as `@smoke` — the CI gate now runs 4 tests (landing, create, import-seed, wrong-password).

## Test plan
- [x] `npx playwright test --list --grep @smoke` → 4 tests
- [x] `npx tsc --noEmit --project e2e/tsconfig.json` clean
- [ ] CI e2e-smoke green (will observe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)