### PR TITLE
feat(e2e): PR 4a — settings suite (menu + export + delete)

### DIFF
--- a/e2e/helpers/settings.ts
+++ b/e2e/helpers/settings.ts
@@ -1,0 +1,26 @@
+import { Page, expect } from '@playwright/test';
+import { waitForWalletHome } from './wait';
+
+/**
+ * Open the settings menu overlay from the wallet home screen.
+ * Assumes the caller has already landed on /app/home.
+ */
+export async function openSettings(page: Page): Promise<void> {
+  await waitForWalletHome(page);
+  const settingsIcon = page.locator('kc-icon[iconClass="icon-settings"]').first();
+  await expect(settingsIcon).toBeVisible({ timeout: 10_000 });
+  await settingsIcon.click();
+  // Settings menu is an overlay — wait for its container to attach.
+  await expect(page.locator('.settings-menu-container').first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+export async function closeSettings(page: Page): Promise<void> {
+  const container = page.locator('.settings-menu-container').first();
+  if (await container.isVisible().catch(() => false)) {
+    // Click outside or press Escape to close.
+    await page.keyboard.press('Escape');
+    await container.waitFor({ state: 'detached', timeout: 5_000 }).catch(() => {});
+  }
+}

--- a/e2e/helpers/settings.ts
+++ b/e2e/helpers/settings.ts
@@ -7,10 +7,12 @@ import { waitForWalletHome } from './wait';
  */
 export async function openSettings(page: Page): Promise<void> {
   await waitForWalletHome(page);
-  const settingsIcon = page.locator('kc-icon[iconClass="icon-settings"]').first();
+  // wrapper-header binds `[iconClass]="'icon-settings'"` as an Angular input,
+  // which is NOT reflected to a DOM attribute. Use the stable CSS class on
+  // the host (`.settings-icon`) plus the (click) handler on kc-icon itself.
+  const settingsIcon = page.locator('kc-icon.settings-icon').first();
   await expect(settingsIcon).toBeVisible({ timeout: 10_000 });
   await settingsIcon.click();
-  // Settings menu is an overlay — wait for its container to attach.
   await expect(page.locator('.settings-menu-container').first()).toBeVisible({
     timeout: 10_000,
   });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { TEST_PASSWORD } from './fixtures/wallet';
+import { clearWalletState } from './helpers/storage';
+import { createNewWallet, gotoLanding } from './helpers/onboarding';
+import { openSettings } from './helpers/settings';
+import { clickKcButton } from './helpers/wait';
+
+test.describe('Settings', () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(180_000);
+    await clearWalletState(page);
+    await gotoLanding(page);
+    await createNewWallet(page, TEST_PASSWORD, 12);
+  });
+
+  test('@smoke opens settings menu with core items', async ({ page }) => {
+    await openSettings(page);
+
+    await expect(
+      page.locator('.menu-item', { hasText: 'Export KaspaCom wallet' }),
+    ).toBeVisible();
+    await expect(
+      page.locator('.menu-item.delete-wallet-item'),
+    ).toBeVisible();
+    await expect(page.locator('kc-button', { hasText: 'Log out' })).toBeVisible();
+  });
+
+  test('export wallet is password-gated and reveals backup data on verify', async ({
+    page,
+  }) => {
+    await openSettings(page);
+
+    await page
+      .locator('.menu-item', { hasText: 'Export KaspaCom wallet' })
+      .click();
+
+    // Initial step: "Export wallet" kicks off the password step.
+    await clickKcButton(page, 'Export wallet');
+
+    const passwordInput = page.locator('#password-input').first();
+    await expect(passwordInput).toBeVisible({ timeout: 10_000 });
+
+    // Wrong password should surface the error and stay on the password step.
+    await passwordInput.fill('definitely-the-wrong-password');
+    await clickKcButton(page, 'Verify Password');
+    await expect(page.locator('.error-message').first()).toBeVisible({
+      timeout: 5_000,
+    });
+    // The download button must NOT be visible while password is invalid.
+    await expect(
+      page.locator('kc-button', { hasText: 'Download Key File' }),
+    ).not.toBeVisible();
+
+    // Correct password → export step with download button.
+    await passwordInput.fill('');
+    await passwordInput.fill(TEST_PASSWORD);
+    await clickKcButton(page, 'Verify Password');
+
+    await expect(
+      page.locator('kc-button', { hasText: 'Download Key File' }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('delete wallet requires "DELETE MY DATA" phrase before the button enables', async ({
+    page,
+  }) => {
+    await openSettings(page);
+
+    await page.locator('.menu-item.delete-wallet-item').click();
+
+    // Warning + confirmation input render on the same dialog.
+    await expect(
+      page.getByText(/Are you sure you want to delete/i),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const phraseInput = page.locator('kc-input input').last();
+    const deleteBtn = page
+      .locator('kc-button', { hasText: 'Delete Wallet' })
+      .locator('button')
+      .first();
+    await expect(deleteBtn).toBeDisabled();
+
+    // Wrong phrase → still disabled.
+    await phraseInput.fill('delete it now please');
+    await expect(deleteBtn).toBeDisabled();
+
+    // Correct phrase (case-insensitive per the component) → enabled.
+    await phraseInput.fill('');
+    await phraseInput.fill('DELETE MY DATA');
+    await expect(deleteBtn).toBeEnabled();
+
+    // We do NOT click through to the actual delete in this test — deletion
+    // calls window.location.reload() which can destabilize the harness.
+    // Behavior after click is covered separately.
+  });
+});

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -25,7 +25,7 @@ test.describe('Settings', () => {
     await expect(page.locator('kc-button', { hasText: 'Log out' })).toBeVisible();
   });
 
-  test('export wallet is password-gated and reveals backup data on verify', async ({
+  test('@smoke export wallet is password-gated and reveals backup data on verify', async ({
     page,
   }) => {
     await openSettings(page);
@@ -61,7 +61,7 @@ test.describe('Settings', () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test('delete wallet requires "DELETE MY DATA" phrase before the button enables', async ({
+  test('@smoke delete wallet requires "DELETE MY DATA" phrase before the button enables', async ({
     page,
   }) => {
     await openSettings(page);

--- a/openspec/changes/wallet-e2e-tests/tasks.md
+++ b/openspec/changes/wallet-e2e-tests/tasks.md
@@ -67,8 +67,16 @@ Split into 2a–2e so each PR is independently ship-able.
 
 ## PR 4 — Settings + Token Import + Address Book + Misc
 
-- [ ] `e2e/settings.spec.ts` — export seed behind password, export private key behind password, network switch (TN10/Kasplex/IGRA), wallet deletion confirmation flow
-- [x] `e2e/token-import.spec.ts` (PR 4b) — opens import flow on L2, Look Up disabled on empty input, invalid-hex error (covers #182 entry-point regression). Full import + remove flow deferred until L2 RPC connection behavior is confirmed.
+### PR 4a — Settings (this PR)
+
+- [x] `e2e/settings.spec.ts` — settings menu opens, export wallet password gate, delete wallet phrase validation
+- [x] `helpers/settings.ts` — `openSettings()` / `closeSettings()`
+- [ ] Export private key flow (separate entry point — defer to PR 4a.1 once we find the account-settings overlay entry)
+- [ ] Network switch (dev-mode only, not on prod — lower priority)
+
+### PR 4b — Token import (merged in #199)
+
+- [x] `e2e/token-import.spec.ts` — opens import flow on L2, Look Up disabled on empty input, invalid-hex error (covers #182 entry-point regression). Full import + remove flow deferred until L2 RPC connection behavior is confirmed.
 - [x] `helpers/network.ts` — `switchToL2()` (dev-mode network selector)
 - [ ] `e2e/address-book.spec.ts` — add / edit / delete contacts, use contact in send flow
 - [ ] `e2e/pending-tx.spec.ts` — pending-transactions banner appears during broadcast and clears on confirmation


### PR DESCRIPTION
## Summary

Fifth PR in the wallet E2E rollout. Adds three tests for the settings overlay — all UI-only, no funded-wallet dependency (unblocked regardless of the WebSocket balance issue tracked in [`reference_wallet_balance_signals`](./openspec/changes/wallet-e2e-tests/design.md)).

## Tests added

| Test | What it asserts |
|------|-----------------|
| `@smoke opens settings menu with core items` | Settings icon opens the overlay; Export / Delete / Log out items all render |
| `export wallet is password-gated and reveals backup data on verify` | Wrong password → `.error-message` + no Download button. Correct password → Download Key File button appears |
| `delete wallet requires "DELETE MY DATA" phrase before the button enables` | Delete button disabled until exact phrase typed. Does NOT click through — deletion triggers `window.location.reload()` which destabilizes the harness (test scope ends at button-enabled assertion) |

## Helpers

- **`e2e/helpers/settings.ts`**
  - `openSettings(page)` — clicks the gear icon in wrapper-header, waits for `.settings-menu-container`
  - `closeSettings(page)` — dismisses via Escape

## Deferred to follow-up PRs

- **Export private key flow** — separate `export-account` flow, accessed via the account-settings overlay (not the settings menu). Need to map the overlay entry point before writing tests.
- **Network switch** — dev-mode-only UI (conditional on `isDevelopmentMode()`). Lower priority since it won't surface real-user regressions.

## Test plan

- [x] `npx playwright test --list` → 56 tests (was 44; +3 settings × 4 projects)
- [x] `npx tsc --noEmit --project e2e/tsconfig.json` clean
- [ ] CI green on `chromium` / `webkit` / `firefox` for e2e-smoke matrix
- [ ] mobile-safari can fail (non-blocking per PR #197)

## Notes

- Tests run after `createNewWallet(page, TEST_PASSWORD, 12)` in `beforeEach` — no funded wallet needed. Each test adds ~20s for the wallet creation flow; total ~90s per project.
- Settings is an overlay via `FlowPagesService`, not a routed page. Selector strategy matches the existing onboarding helpers: `formControlName` / `kc-button[text]` / stable class names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)