### PR TITLE
feat(e2e): PR 4b — token import entry + validation suite

### DIFF
--- a/e2e/helpers/network.ts
+++ b/e2e/helpers/network.ts
@@ -1,0 +1,34 @@
+import { Page, expect } from '@playwright/test';
+import { waitForWalletHome } from './wait';
+
+/**
+ * Switch the wallet display to an L2 network (Kasplex testnet by default).
+ * Opens the network-selection overlay from the wrapper header and clicks
+ * the matching item. Only available in development builds — the selector
+ * is gated by `isDevelopmentMode()` in wrapper-header.component.ts.
+ */
+export async function switchToL2(
+  page: Page,
+  networkName: RegExp | string = /Kasplex/i,
+): Promise<void> {
+  await waitForWalletHome(page);
+  const networkInfo = page.locator('.network-info').first();
+  await expect(networkInfo).toBeVisible({ timeout: 10_000 });
+  await networkInfo.click();
+
+  await expect(page.locator('.network-selection-modal').first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const target = page
+    .locator('.network-item', { hasText: networkName })
+    .first();
+  await expect(target).toBeVisible({ timeout: 5_000 });
+  await target.click();
+
+  // After selection the component navigates back to /app/home.
+  await page
+    .locator('.network-selection-modal')
+    .waitFor({ state: 'detached', timeout: 5_000 })
+    .catch(() => {});
+}

--- a/e2e/token-import.spec.ts
+++ b/e2e/token-import.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { TEST_PASSWORD } from './fixtures/wallet';
+import { clearWalletState } from './helpers/storage';
+import { createNewWallet, gotoLanding } from './helpers/onboarding';
+import { switchToL2 } from './helpers/network';
+import { clickKcButton } from './helpers/wait';
+
+test.describe('Token import (ERC20)', () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(240_000);
+    await clearWalletState(page);
+    await gotoLanding(page);
+    await createNewWallet(page, TEST_PASSWORD, 12);
+    // ERC20 import only shows on L2. Skip the rest of the test if we
+    // can't reach the L2 network-selector (e.g. prod build hides it).
+    const networkInfo = page.locator('.network-info').first();
+    const hasDevNetworkSelector = await networkInfo
+      .isVisible()
+      .catch(() => false);
+    test.skip(
+      !hasDevNetworkSelector,
+      'Network selector (dev-mode only) not visible — token import is L2-gated.',
+    );
+    await switchToL2(page);
+  });
+
+  test('opens import token flow from L2 ERC20 assets', async ({ page }) => {
+    // On a fresh L2 wallet the ERC20 tab is the default empty view.
+    const importBtn = page
+      .locator('kc-button', { hasText: /^\+?\s*Import Token$/ })
+      .first();
+    await expect(importBtn).toBeVisible({ timeout: 15_000 });
+    await importBtn.locator('button').first().click();
+
+    // Import flow rendered — contract address input is the anchor.
+    await expect(
+      page.locator('kc-input[label="Contract Address"]').first(),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator('kc-button', { hasText: 'Look Up Token' }).first(),
+    ).toBeVisible();
+  });
+
+  test('Look Up button stays disabled while address input is empty', async ({
+    page,
+  }) => {
+    const importBtn = page
+      .locator('kc-button', { hasText: /^\+?\s*Import Token$/ })
+      .first();
+    await expect(importBtn).toBeVisible({ timeout: 15_000 });
+    await importBtn.locator('button').first().click();
+
+    const lookUpBtn = page
+      .locator('kc-button', { hasText: 'Look Up Token' })
+      .first()
+      .locator('button')
+      .first();
+    await expect(lookUpBtn).toBeVisible();
+    await expect(lookUpBtn).toBeDisabled();
+  });
+
+  test('invalid hex address surfaces an error on look-up', async ({ page }) => {
+    const importBtn = page
+      .locator('kc-button', { hasText: /^\+?\s*Import Token$/ })
+      .first();
+    await expect(importBtn).toBeVisible({ timeout: 15_000 });
+    await importBtn.locator('button').first().click();
+
+    const addrInput = page
+      .locator('kc-input[label="Contract Address"] input')
+      .first();
+    await expect(addrInput).toBeVisible({ timeout: 10_000 });
+    await addrInput.fill('this-is-not-a-valid-hex-address');
+
+    await clickKcButton(page, 'Look Up Token');
+
+    // Component sets state='error' which renders invalidReason inside the
+    // input. Assert any error-style message shows up near the input.
+    const errorText = page
+      .locator('kc-input[label="Contract Address"]')
+      .locator('text=/invalid|not valid|enter a valid/i')
+      .first();
+    await expect(errorText).toBeVisible({ timeout: 10_000 });
+
+    // Token card must NOT have rendered.
+    await expect(page.locator('.token-card').first()).not.toBeVisible();
+  });
+});

--- a/e2e/token-import.spec.ts
+++ b/e2e/token-import.spec.ts
@@ -24,7 +24,7 @@ test.describe('Token import (ERC20)', () => {
     await switchToL2(page);
   });
 
-  test('opens import token flow from L2 ERC20 assets', async ({ page }) => {
+  test('@smoke opens import token flow from L2 ERC20 assets', async ({ page }) => {
     // On a fresh L2 wallet the ERC20 tab is the default empty view.
     const importBtn = page
       .locator('kc-button', { hasText: /^\+?\s*Import Token$/ })
@@ -41,7 +41,7 @@ test.describe('Token import (ERC20)', () => {
     ).toBeVisible();
   });
 
-  test('Look Up button stays disabled while address input is empty', async ({
+  test('@smoke Look Up button stays disabled while address input is empty', async ({
     page,
   }) => {
     const importBtn = page
@@ -59,7 +59,7 @@ test.describe('Token import (ERC20)', () => {
     await expect(lookUpBtn).toBeDisabled();
   });
 
-  test('invalid hex address surfaces an error on look-up', async ({ page }) => {
+  test('@smoke invalid hex address surfaces an error on look-up', async ({ page }) => {
     const importBtn = page
       .locator('kc-button', { hasText: /^\+?\s*Import Token$/ })
       .first();

--- a/e2e/token-import.spec.ts
+++ b/e2e/token-import.spec.ts
@@ -34,7 +34,7 @@ test.describe('Token import (ERC20)', () => {
 
     // Import flow rendered — contract address input is the anchor.
     await expect(
-      page.locator('kc-input[label="Contract Address"]').first(),
+      page.locator('.import-token-container').first(),
     ).toBeVisible({ timeout: 10_000 });
     await expect(
       page.locator('kc-button', { hasText: 'Look Up Token' }).first(),
@@ -67,7 +67,7 @@ test.describe('Token import (ERC20)', () => {
     await importBtn.locator('button').first().click();
 
     const addrInput = page
-      .locator('kc-input[label="Contract Address"] input')
+      .locator('.import-token-container .address-input-row kc-input input')
       .first();
     await expect(addrInput).toBeVisible({ timeout: 10_000 });
     await addrInput.fill('this-is-not-a-valid-hex-address');
@@ -77,7 +77,7 @@ test.describe('Token import (ERC20)', () => {
     // Component sets state='error' which renders invalidReason inside the
     // input. Assert any error-style message shows up near the input.
     const errorText = page
-      .locator('kc-input[label="Contract Address"]')
+      .locator('.import-token-container')
       .locator('text=/invalid|not valid|enter a valid/i')
       .first();
     await expect(errorText).toBeVisible({ timeout: 10_000 });

--- a/openspec/changes/wallet-e2e-tests/tasks.md
+++ b/openspec/changes/wallet-e2e-tests/tasks.md
@@ -68,7 +68,8 @@ Split into 2a–2e so each PR is independently ship-able.
 ## PR 4 — Settings + Token Import + Address Book + Misc
 
 - [ ] `e2e/settings.spec.ts` — export seed behind password, export private key behind password, network switch (TN10/Kasplex/IGRA), wallet deletion confirmation flow
-- [ ] `e2e/token-import.spec.ts` — import ERC20 by address (covers #182), reject invalid address, remove imported token, referral capture fire-and-forget (covers #186)
+- [x] `e2e/token-import.spec.ts` (PR 4b) — opens import flow on L2, Look Up disabled on empty input, invalid-hex error (covers #182 entry-point regression). Full import + remove flow deferred until L2 RPC connection behavior is confirmed.
+- [x] `helpers/network.ts` — `switchToL2()` (dev-mode network selector)
 - [ ] `e2e/address-book.spec.ts` — add / edit / delete contacts, use contact in send flow
 - [ ] `e2e/pending-tx.spec.ts` — pending-transactions banner appears during broadcast and clears on confirmation
 - [ ] `e2e/asset-detail.spec.ts` — click asset → detail view, transaction history drill-down, copy address


### PR DESCRIPTION
## Summary

Sixth PR in the wallet E2E rollout. Three UI-level tests for the ERC20 **token import** flow (the feature shipped as KCW-26 in #182). UI-only — skips cleanly if the dev-mode network selector isn't present (prod builds).

## Tests added

| Test | What it asserts |
|------|-----------------|
| `opens import token flow from L2 ERC20 assets` | Click Import Token on the empty L2 ERC20 tab renders the Contract Address input + Look Up Token button |
| `Look Up button stays disabled while address input is empty` | Pure form-state gating |
| `invalid hex address surfaces an error on look-up` | Filling garbage + Look Up shows an invalid-address message and `.token-card` does NOT render |

## New helper: `e2e/helpers/network.ts`

- `switchToL2(page, /Kasplex/i)` — opens the dev-only network selector in wrapper-header, clicks the L2 option. Required before any token-import test because the empty-state Import Token button only renders on L2.

## beforeEach flow

1. Clear wallet state
2. Create a fresh wallet
3. `test.skip()` if the `.network-info` dev selector isn't visible (prod build)
4. `switchToL2()`

## Deferred to follow-up PRs

- **Full import success path** — needs L2 RPC metadata fetch to complete. Shares the WebSocket concern flagged in PR #195
- **Remove imported token** — needs import success first
- **Referral capture** (#186) — separate spec watching for `api-defi` calls on wallet create/import

## Test plan

- [x] `npx playwright test --list --project=chromium` → +3 tests
- [x] `npx tsc --noEmit --project e2e/tsconfig.json` clean
- [ ] CI chromium / webkit / firefox green
- [ ] mobile-safari can fail (non-blocking per #197)

## Notes

- Each test adds ~30s for wallet creation + L2 switch; total ~110s per project
- Skips on prod builds (no dev network selector) — doesn't fail forks / external contributors
- Covers the PR #182 regression at the entry-point / validation level. Full mint → list → remove cycle needs RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)