### PR TITLE
feat(e2e): PR 5a — nightly workflow + Telegram failure alert

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,116 @@
+name: Nightly E2E Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 02:00 UTC daily
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # mobile-safari is still a known-flaky viewport (tracked in
+    # openspec/changes/wallet-e2e-tests/tasks.md as PR 3x). Keep it in the
+    # nightly matrix for visibility but don't let it gate the notification.
+    continue-on-error: ${{ matrix.project == 'mobile-safari' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, webkit, firefox, mobile-safari]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - run: npm install
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-v2
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit firefox
+
+      - name: Run full Playwright suite (${{ matrix.project }})
+        run: npx playwright test --project=${{ matrix.project }} --reporter=blob
+        env:
+          CI: 'true'
+          KASPA_E2E_SEED: ${{ secrets.KASPA_E2E_SEED }}
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.project }}
+          path: blob-report/
+          retention-days: 7
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces-${{ matrix.project }}
+          path: test-results/
+          retention-days: 14
+
+  merge-reports:
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - run: npm install
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge reports
+        run: |
+          if [ -d all-blob-reports ] && [ "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            npx playwright merge-reports --reporter html ./all-blob-reports
+          else
+            echo "No blob reports found — skipping merge"
+          fi
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+  notify:
+    # Only alert when the blocking browsers (chromium/webkit/firefox)
+    # actually fail. `continue-on-error` on mobile-safari means it reports
+    # conclusion='success' even when tests inside fail, so this reacts to
+    # the overall test-job `.result`.
+    if: ${{ always() && needs.test.result == 'failure' }}
+    needs: [test, merge-reports]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Telegram notification to Test Engineer topic
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_GROUP_ID }}" \
+            -d message_thread_id="51073" \
+            -d parse_mode="HTML" \
+            -d text="🔴 <b>kaspacom-web-wallet nightly E2E failed</b>%0A%0ARun: <a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View report</a>%0ATriggered: $(date -u +%Y-%m-%d\ %H:%M\ UTC)"

--- a/openspec/changes/wallet-e2e-tests/tasks.md
+++ b/openspec/changes/wallet-e2e-tests/tasks.md
@@ -87,10 +87,17 @@ Split into 2a–2e so each PR is independently ship-able.
 
 ## PR 5 — Nightly + Mirror + Alerts
 
-- [ ] `.github/workflows/e2e-nightly.yml` — runs full suite across Chromium + WebKit + Firefox + Mobile Safari at 02:00 UTC
-- [ ] Nightly workflow posts failure summary to Telegram topic `51073` (Test Engineer) via existing bot webhook
-- [ ] Mirror `@smoke` suite (onboarding + 1 send + 1 swap) into `KASPACOM/E2E-Tests` under new `wallet/` project so cross-repo nightly also exercises wallet
-- [ ] Update `E2E-Tests` README + this `tasks.md` with the final cross-repo relationship
+### PR 5a — Nightly workflow + Telegram alert (this PR)
+
+- [x] `.github/workflows/e2e-nightly.yml` — runs full suite across Chromium + WebKit + Firefox + Mobile Safari at 02:00 UTC
+- [x] Nightly workflow posts failure summary to Telegram topic `51073` (Test Engineer) via bot webhook — pattern cribbed from `KASPACOM/E2E-Tests/.github/workflows/nightly.yml`
+- [x] Merged blob reports into one HTML artifact per nightly run (14-day retention)
+
+### PR 5b — Mirror into central E2E-Tests
+
+- [ ] Add `wallet/` project to `KASPACOM/E2E-Tests/playwright.config.ts` covering the @smoke subset
+- [ ] Update `E2E-Tests` nightly workflow matrix to include `wallet` alongside `defi` / `kaspiano` / `api`
+- [ ] Update `E2E-Tests` README with cross-repo relationship
 - [ ] Archive this OpenSpec change → `openspec/archive/`
 
 ## Post-merge hygiene


### PR DESCRIPTION
## Summary

Eighth PR in the wallet E2E rollout. Daily full-suite E2E run with failure alerts to the Test Engineer Telegram topic. Complements the fast PR-gate smoke matrix.

## What this ships

- **`.github/workflows/e2e-nightly.yml`** — cron `0 2 * * *` (02:00 UTC) + `workflow_dispatch`
- **Matrix:** `[chromium, webkit, firefox, mobile-safari]` × full Playwright suite (not just @smoke)
- `continue-on-error: true` on mobile-safari (still known-flaky per PR #197; tracked as PR 3x)
- `fail-fast: false` so one engine failure doesn't mask another
- **Blob reporter → merged HTML report** artifact (one per nightly run, 14-day retention)
- **Failure traces** uploaded per project (14-day retention)
- **Telegram notify job** posts to `$TELEGRAM_GROUP_ID` topic `51073` via `$TELEGRAM_BOT_TOKEN` on test-job failure

## Pattern

Directly cribbed from `KASPACOM/E2E-Tests/.github/workflows/nightly.yml` — same Telegram secrets (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_GROUP_ID`), same thread_id (`51073`), same reporter flow. Consistent operator experience across repos.

## Not included (follow-up PR 5b)

- Mirror the @smoke subset into `KASPACOM/E2E-Tests` as a `wallet` project for the cross-repo dashboard
- Archive the OpenSpec change

## Test plan

- [x] YAML parses (workflow will appear in Actions tab on merge)
- [ ] First scheduled run (02:00 UTC tomorrow)
- [ ] Manual trigger via `workflow_dispatch` to validate before first cron
- [ ] Force a failure on a branch and confirm the Telegram notify fires

## Notes

- Does not touch `pr-check.yml` — PR gate stays fast
- Secrets used (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_GROUP_ID`) already exist at the org level (same as `KASPA_E2E_SEED`)
- Cache key bumped to `-v2` to stay in sync with pr-check's Playwright cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)