### PR TITLE
feat(e2e): PR 4c.1 — re-enable row-action + add-account dialog tests

### DIFF
--- a/e2e/multi-wallet.spec.ts
+++ b/e2e/multi-wallet.spec.ts
@@ -29,9 +29,57 @@ test.describe('Multi-wallet management', () => {
     ).not.toHaveText('', { timeout: 5_000 });
   });
 
-  // Row-action controls (export/delete icons) + add-account dialog tests
-  // deferred to PR 4c.1. Initial CI run showed `.wallet-item__export` and
-  // `.floating-orb → app-quick-action-dialog` don't render as the explore
-  // agent's HTML snapshot suggested on a fresh wallet — needs a local
-  // dev-server debug session to pin down the actual rendered state.
+  test('@smoke wallet item exposes address + export + delete controls in the DOM', async ({
+    page,
+  }) => {
+    await openWalletManagement(page);
+
+    // .wallet-item__export and __trash are styled `opacity:0; visibility:hidden`
+    // on desktop and only become visible on row hover (SCSS line 207) or
+    // under `@media (max-width:768px)`. For a regression test we only care
+    // that they are attached to the DOM — a dropped icon would still fail
+    // `.toBeAttached()`. This keeps us viewport- and hover-agnostic.
+    const firstItem = page.locator('.wallet-item').first();
+    await expect(firstItem.locator('.wallet-item__address').first()).toBeVisible();
+    await expect(firstItem.locator('.wallet-item__export').first()).toBeAttached();
+    await expect(firstItem.locator('.wallet-item__trash').first()).toBeAttached();
+  });
+
+  test('@smoke add-account dialog opens from the floating orb and validates input', async ({
+    page,
+  }) => {
+    await openWalletManagement(page);
+
+    const orb = page.locator('.floating-orb').first();
+    const orbVisible = await orb.isVisible().catch(() => false);
+    test.skip(
+      !orbVisible,
+      'floating-orb (add account) not available for this wallet scheme.',
+    );
+
+    await orb.click();
+
+    // The `app-quick-action-dialog` host element is display:inline with
+    // height:0 (Angular portal pattern). The real dialog box is rendered
+    // as the `.quick-action-dialog-content` child with the slideUp
+    // animation — that's what we can assert on.
+    await expect(page.locator('.quick-action-dialog-content').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(/Add account/i).first()).toBeVisible();
+
+    // The add-account dialog's CTA is labeled "Create" (not "Save" as
+    // the explore report guessed).
+    const createBtn = page
+      .locator('.quick-action-dialog-content kc-button', { hasText: 'Create' })
+      .locator('button')
+      .first();
+    await expect(createBtn).toBeDisabled();
+
+    const nameInput = page
+      .locator('.quick-action-dialog-content kc-input input')
+      .first();
+    await nameInput.fill('E2E test account');
+    await expect(createBtn).toBeEnabled();
+  });
 });

--- a/openspec/changes/wallet-e2e-tests/tasks.md
+++ b/openspec/changes/wallet-e2e-tests/tasks.md
@@ -83,7 +83,7 @@ Split into 2a–2e so each PR is independently ship-able.
 - [ ] `e2e/asset-detail.spec.ts` — click asset → detail view, transaction history drill-down, copy address
 - [x] `e2e/multi-wallet.spec.ts` (PR 4c) — wallet-management opens via `.profile-container` click, active wallet renders with `.selected` modifier and a non-empty name
 - [x] `helpers/wallet-management.ts` — `openWalletManagement()` via `.profile-container` click
-- [ ] **PR 4c.1**: row-action icons (`.wallet-item__export` / `.wallet-item__trash`) + `.floating-orb` add-account dialog — initial selectors from explore didn't render as expected on a fresh wallet; needs local dev-server debug
+- [x] **PR 4c.1**: row-action icons asserted via `.toBeAttached()` (they're `visibility: hidden` until `.wallet-item:hover` or `@media < 768px`). Add-account dialog targets `.quick-action-dialog-content` (host is `display: inline, height: 0` portal) and clicks **Create** button (not "Save" as explore reported)
 
 ## PR 5 — Nightly + Mirror + Alerts
 


### PR DESCRIPTION
## Summary

Re-enables the two multi-wallet tests that were deferred in PR #200 because the explore-agent's HTML snapshot had three issues. Debugged locally against `ng serve` and all three tests now pass on chromium.

## The three bugs found

1. **Row-action icons are hover-only on desktop.** `.wallet-item__export` and `.wallet-item__trash` are `opacity: 0; visibility: hidden` by default. They only become visible on `.wallet-item:hover` (SCSS 207-211) or under `@media (max-width: 768px)`. `toBeVisible()` respects `visibility`, so it failed on desktop. Switched to `toBeAttached()` — a dropped icon still fails it, without coupling to viewport or hover state.

2. **`app-quick-action-dialog` host has `display: inline, height: 0`.** It's an Angular portal pattern — the real rendered dialog lives in the child `.quick-action-dialog-content` with the slideUp animation. Assert on the child.

3. **Add-account CTA is labeled "Create", not "Save".** Fixed the selector.

## Tests re-enabled (both `@smoke`)

| Test | What it catches |
|------|------|
| `wallet item exposes address + export + delete controls in the DOM` | Regression that drops any per-row action icon |
| `add-account dialog opens from the floating orb and validates input` | Regression in the quick-action-dialog form or Create button gating |

## Test plan

- [x] Verified locally: all 3 multi-wallet tests pass on chromium via `npm run e2e -- multi-wallet.spec.ts`
- [ ] CI green on chromium / webkit / firefox (expected — locally the assertions are browser-engine agnostic)
- [ ] mobile-safari can fail (non-blocking per #197; also mobile CSS breakpoint kicks in so icons are `visibility: visible` there, which doesn't affect `toBeAttached`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)