### PR TITLE
fix: show L2 priority fee on swap approval

### DIFF
--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.html
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.html
@@ -7,8 +7,17 @@
       <app-swap-approval
         [swapContext]="swapContext()!"
         [isLoading]="isLoading()"
+        [canApprove]="isAvailableForApproval()"
         (approve)="onAccept()"
         (reject)="onReject()">
+        <ng-container *ngIf="isActionHasL2PriorityFee()">
+          <l2-priority-fee-selection
+            [action]="approvalConfig()!.action"
+            [wallet]="wallet()"
+            (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
+            (gasLimitSelected)="setL2GasLimit($event)">
+          </l2-priority-fee-selection>
+        </ng-container>
       </app-swap-approval>
     </ng-container>
 
@@ -92,7 +101,6 @@
           [wallet]="wallet()"
           (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
           (gasLimitSelected)="setL2GasLimit($event)">
-        >
         </l2-priority-fee-selection>
       </ng-container>
 

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.html
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.html
@@ -95,6 +95,8 @@
       </div>
     </div>
 
+    <ng-content></ng-content>
+
     <!-- Action Buttons -->
     <div class="action-buttons-section">
       <div class="action-buttons">
@@ -103,7 +105,7 @@
           variant="primary"
           size="lg"
           [isFullWidth]="true"
-          [isDisabled]="isLoading()"
+          [isDisabled]="isLoading() || !canApprove()"
           [isLoading]="isLoading()"
           (buttonClick)="onApprove()">
         </kc-button>

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.ts
@@ -21,6 +21,7 @@ import { CommaFormatterPipe } from '../../../../../../../pipes/comma-formatter.p
 export class SwapApprovalComponent {
   swapContext = input.required<SwapContext>();
   isLoading = input<boolean>(false);
+  canApprove = input<boolean>(true);
 
   approve = output<void>();
   reject = output<void>();


### PR DESCRIPTION
## Summary
- project the existing L2 priority fee selector into the custom swap approval UI
- gate the swap approve button with the same approval availability computed used by regular transaction approvals
- keep reject available while fee data is missing/invalid
- remove an extra stray template character in the existing regular L2 priority fee selector markup

## Verification
- `npm run build:dev` ✅
- `npm test -- --watch=false --browsers=ChromeHeadless` blocked: local environment has no ChromeHeadless binary / CHROME_BIN configured

## Notes
This keeps the swap approval page using the same `l2-priority-fee-selection` component and `l2PriorityInfo` plumbing as regular L2 transaction approvals.