### PR TITLE
fix: address review issues from PR #192

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,7 +1,7 @@
 # Wallet E2E Tests
 
 Playwright E2E suite for `kaspacom-web-wallet`. Part of the
-[wallet-e2e-tests](../openspec/changes/wallet-e2e-tests/proposal.md) change.
+[wallet-e2e-tests](../openspec/archive/wallet-e2e-tests/proposal.md) change.
 
 ## Running locally
 
@@ -20,24 +20,27 @@ npm run e2e -- --ui          # Playwright UI mode
 
 The dev server is started automatically via `webServer` in `playwright.config.ts`.
 To run against an already-running server, set `E2E_SKIP_SERVER=1` and
-`E2E_BASE_URL=http://localhost:4200`.
+`E2E_BASE_URL=http://127.0.0.1:4200`. The default base URL uses `127.0.0.1`
+(not `localhost`) to avoid IPv6 `::1` / IPv4 mismatches with the Angular
+dev server, which binds to IPv4 only — see `playwright.config.ts`.
 
 ## Environment variables
 
 | Var | Purpose | Default |
 |-----|---------|---------|
 | `E2E_PORT` | Port for auto-started dev server | `4200` |
-| `E2E_BASE_URL` | Override base URL | `http://localhost:<E2E_PORT>` |
+| `E2E_BASE_URL` | Override base URL | `http://127.0.0.1:<E2E_PORT>` |
 | `E2E_SKIP_SERVER` | Skip auto-starting the dev server | unset |
-| `KASPA_E2E_SEED` | (PR 2+) Pre-funded testnet seed for send/swap tests | unset |
+| `KASPA_E2E_SEED` | Pre-funded testnet seed for funded-wallet tests | unset |
 
 Secrets go in `.env.e2e` at repo root (gitignored).
 
 ## Scope
 
-Current suite: **onboarding only** (create, import, login, lock). Send / swap /
-approval / iframe / settings land in follow-up PRs per the
-[tasks list](../openspec/changes/wallet-e2e-tests/tasks.md).
+Current suite covers onboarding (create, import, login, lock), settings,
+iframe communication, ERC-20 token import, multi-wallet management, and
+funded-wallet send/swap flows. See the [tasks list](../openspec/archive/wallet-e2e-tests/tasks.md)
+for the breakdown.
 
 ## CI
 

--- a/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.ts
+++ b/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.ts
@@ -91,8 +91,12 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
   protected gasFeeOtions = computed(() => {
     if (!this.feeData) return undefined;
 
-    const baseFee = this.feeData.maxPriorityFeePerGas;
-    if (baseFee === null || baseFee === undefined) return undefined;
+    // EIP-1559 exposes maxPriorityFeePerGas; legacy chains only expose
+    // gasPrice. Require at least one to be present so we can render a
+    // sensible fee option list.
+    if (this.feeData.maxPriorityFeePerGas == null && this.feeData.gasPrice == null) {
+      return undefined;
+    }
 
     const maxPriorityFeePerGas = this.feeData.maxPriorityFeePerGas || 0n;
 

--- a/src/app/services/communication-service/allowed-applications.service.ts
+++ b/src/app/services/communication-service/allowed-applications.service.ts
@@ -9,11 +9,14 @@ export class AllowedApplicationsService {
     private sessionAppLocations: { [appId: string]: string[] } = {};
 
     constructor() {
-        const allowedApplications = localStorage.getItem(LOCAL_STORAGE_KEYS.ALLOWED_APPLICATIONS);
-        if (allowedApplications) {
-            this.persistedAppLocations = JSON.parse(allowedApplications);
-        } else {
-            this.persistedAppLocations = {};
+        this.persistedAppLocations = {};
+        try {
+            const allowedApplications = localStorage.getItem(LOCAL_STORAGE_KEYS.ALLOWED_APPLICATIONS);
+            if (allowedApplications) {
+                this.persistedAppLocations = JSON.parse(allowedApplications);
+            }
+        } catch (err) {
+            console.warn('Failed loading allowed applications from localStorage', err);
         }
     }
 
@@ -45,6 +48,10 @@ export class AllowedApplicationsService {
     }
 
     private saveToLocalStorage() {
-        localStorage.setItem(LOCAL_STORAGE_KEYS.ALLOWED_APPLICATIONS, JSON.stringify(this.persistedAppLocations));
+        try {
+            localStorage.setItem(LOCAL_STORAGE_KEYS.ALLOWED_APPLICATIONS, JSON.stringify(this.persistedAppLocations));
+        } catch (err) {
+            console.warn('Failed persisting allowed applications to localStorage', err);
+        }
     }
 }

--- a/src/app/services/etherium-services/etherium-wallet-actions.service.ts
+++ b/src/app/services/etherium-services/etherium-wallet-actions.service.ts
@@ -130,20 +130,14 @@ export class EthereumWalletActionsService {
 
         case EIP1193RequestType.GET_ESTIMATE_GAS:
           const estimateGasTransaction = request.params?.[0] as any;
+          const provider = this.ethereumWalletChainManager.getCurrentWalletProvider()!;
           const wallet = await this.walletService
             .getCurrentWallet()
             ?.getL2Wallet();
 
-          if (!wallet) {
-            return createEIP1193Response<T>(undefined, {
-              code: ERROR_CODES.EIP1193.INTERNAL_ERROR,
-              message: 'Failed to get wallet',
-            });
-          }
-
-          const gas = await this.ethereumWalletChainManager
-            .getCurrentWalletProvider()!
-            .estimateGas(wallet, estimateGasTransaction as TransactionRequest);
+          const gas = wallet
+            ? await provider.estimateGas(wallet, estimateGasTransaction as TransactionRequest)
+            : BigInt(await provider.ethEstimateGas(estimateGasTransaction));
           return createEIP1193Response<T>(ethers.toQuantity(gas));
 
         case EIP1193RequestType.GET_TRANSACTION_BY_HASH:

--- a/src/app/services/kaspa-netwrok-services/rpc.service.ts
+++ b/src/app/services/kaspa-netwrok-services/rpc.service.ts
@@ -21,10 +21,16 @@ export class RpcService {
 
   refreshRpc() {
     const previousRpc = this.RPC;
+    let storedRpcUrl: string | null = null;
+    try {
+      storedRpcUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL);
+    } catch (err) {
+      console.warn('Failed reading RPC URL from localStorage', err);
+    }
 
-    if (localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL)) {
+    if (storedRpcUrl) {
       this.RPC = new RpcClient({
-        url: localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL) || '',
+        url: storedRpcUrl,
         encoding: Encoding.Borsh,
         networkId: this.network,
       });

--- a/src/app/services/kaspacom-api/gecko-terminal-api.service.ts
+++ b/src/app/services/kaspacom-api/gecko-terminal-api.service.ts
@@ -85,9 +85,12 @@ export class GeckoTerminalApiService {
   }
 
   private calcPriceChange(candles: GeckoOhlcvEntry[], periods: number): number | null {
-    if (candles.length < 2) return null;
+    // Need at least `periods + 1` candles to span the requested window;
+    // otherwise the change would be measured over an incomplete period
+    // and silently misrepresented as the full window.
+    if (candles.length < periods + 1) return null;
     const newest = candles[candles.length - 1];
-    const oldest = candles[Math.max(0, candles.length - 1 - periods)];
+    const oldest = candles[candles.length - 1 - periods];
     if (!oldest.open || oldest.open === 0) return null;
     return ((newest.close - oldest.open) / oldest.open) * 100;
   }

--- a/src/app/services/l2-services/l2-token-prices.service.ts
+++ b/src/app/services/l2-services/l2-token-prices.service.ts
@@ -255,7 +255,7 @@ export class L2TokenPricesService implements OnDestroy {
       maxHops: 3,
     });
 
-    const ctx: ChainSwapContext = { service, networkConfig, pairsRefreshedAt: Date.now() };
+    const ctx: ChainSwapContext = { service, networkConfig, pairsRefreshedAt: 0 };
     this.contextByChain.set(chainId, ctx);
     return ctx;
   }

--- a/src/app/services/lfg-tokens-cache-service/lfg-tokens-cache.service.ts
+++ b/src/app/services/lfg-tokens-cache-service/lfg-tokens-cache.service.ts
@@ -23,11 +23,13 @@ import { ImageService } from '../image-service/image.service';
 export class LfgTokensCacheService {
   private readonly imageService = inject(ImageService);
   private readonly CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+  private readonly ERROR_BACKOFF_MS = 30 * 1000; // 30 seconds before retrying after a failure
 
   private cacheLoadedPromise: Promise<LfgTokenResponse> | undefined = undefined;
 
   private tokensCache = new Map<string, LfgToken>();
   private cacheTimestamp: number | null = null;
+  private errorBackoffUntil = 0;
   private responseCache = signal<LfgTokenResponse | null>(null);
 
   constructor(@Inject(DEFI_API_BASE_URL) private baseUrl: string) {}
@@ -82,6 +84,12 @@ export class LfgTokensCacheService {
       return await this.cacheLoadedPromise;
     }
 
+    if (Date.now() < this.errorBackoffUntil && this.responseCache()) {
+      // Recent failure; serve the previous (possibly empty) response
+      // instead of stampeding the backend with retries.
+      return this.responseCache()!;
+    }
+
     this.cacheLoadedPromise = new Promise<LfgTokenResponse>((resolve) => {
       (async () => {
         try {
@@ -92,6 +100,7 @@ export class LfgTokensCacheService {
           // Update cache
           this.responseCache.set(response);
           this.cacheTimestamp = Date.now();
+          this.errorBackoffUntil = 0;
 
           // Rebuild token lookup map
           this.tokensCache.clear();
@@ -102,6 +111,7 @@ export class LfgTokensCacheService {
           resolve(response);
         } catch (error) {
           console.error('Failed to fetch LFG tokens from backend:', error);
+          this.errorBackoffUntil = Date.now() + this.ERROR_BACKOFF_MS;
           // Return empty response to prevent failures downstream
           const emptyResponse: LfgTokenResponse = {
             name: '',
@@ -112,6 +122,9 @@ export class LfgTokensCacheService {
             keywords: [],
             tokens: [],
           };
+          if (!this.responseCache()) {
+            this.responseCache.set(emptyResponse);
+          }
           resolve(emptyResponse);
         }
       })();
@@ -141,6 +154,7 @@ export class LfgTokensCacheService {
     this.tokensCache.clear();
     this.responseCache.set(null);
     this.cacheTimestamp = null;
+    this.errorBackoffUntil = 0;
     this.cacheLoadedPromise = undefined;
   }
 

--- a/src/app/services/utils/utils.service.ts
+++ b/src/app/services/utils/utils.service.ts
@@ -87,6 +87,15 @@ export class UtilsService {
       ticker = 'KAS';
     }
 
+    const fallbackUrl = './images/kc-all-black.png';
+    const localUrl = this.availableLocalTokensLogos.has(ticker.toUpperCase())
+      ? `./images/tokens-logos/${ticker.toUpperCase()}.png`
+      : '';
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      // Skip backend/S3 lookups for sentinel or invalid addresses.
+      return localUrl || fallbackUrl;
+    }
+
     let lfgTokenUrl = '';
 
     // Try to find logo in LFG tokens array
@@ -113,10 +122,6 @@ export class UtilsService {
     } catch {
       console.error('logo not found for address', address);
     }
-    const fallbackUrl = './images/kc-all-black.png';
-    const localUrl = this.availableLocalTokensLogos.has(ticker.toUpperCase())
-      ? `./images/tokens-logos/${ticker.toUpperCase()}.png`
-      : '';
     const test = (url: string) =>
       new Promise<string>((res) => {
         if (!url) return res('');

--- a/src/app/services/wallet-action.service.ts
+++ b/src/app/services/wallet-action.service.ts
@@ -303,7 +303,6 @@ export class WalletActionService {
       }
 
       action.data.params[0] = actionTransaction;
-      console.log('transaction', action.data.params[0]);
     }
 
     // // Add 2-second delay to allow canvas animation to show before processing

--- a/src/app/v2/pages/app/flows/transaction/send-page/l2-send-assets-container.component.html
+++ b/src/app/v2/pages/app/flows/transaction/send-page/l2-send-assets-container.component.html
@@ -13,7 +13,7 @@
   <div class="send-option-card card-0 card-hover flex full-width align-items-center justify-content-between p-16 cursor-pointer"
        (click)="erc20Click.emit()">
     <div class="send-option-card__info flex align-items-center gap-16">
-      <kc-token-logo [ticker]="'ERC20'" [address]="'0'" [size]="'lg'"></kc-token-logo>
+      <kc-token-logo [ticker]="'ERC20'" [address]="''" [size]="'lg'"></kc-token-logo>
       <div class="flex column gap-4">
         <div class="text-gray-90 typo-text-2">ERC20 tokens</div>
         <div class="text-gray-60 typo-text-1">Send ERC20 tokens on Layer 2</div>


### PR DESCRIPTION
## Summary

Addresses real issues surfaced during code review of #192 (Copilot's review + an additional automated review pass). Targets `develop` so the fixes flow into the release naturally.

## Fixes

- **eth_estimateGas regression** — restored wallet-less RPC pass-through for EIP-1193 `eth_estimateGas` (`etherium-wallet-actions.service.ts`)
- **L2 first price lookup** — seeded `pairsRefreshedAt` with `0` so `ensurePairsReady` actually refreshes pairs on the first call (`l2-token-prices.service.ts`)
- **rpc.service localStorage SecurityError** — guarded with try/catch and read once (`rpc.service.ts`)
- **allowed-applications localStorage** — guarded constructor read + JSON.parse + setItem with try/catch (`allowed-applications.service.ts`)
- **Token logo lookups for sentinel addresses** — `kc-token-logo` no longer fires backend / S3 lookups for non-0x-40hex addresses (`utils.service.ts`, `l2-send-assets-container.component.html`)
- **e2e README** — fixed broken openspec links, `127.0.0.1` default, refreshed scope (`e2e/README.md`)
- **Leftover transaction console.log** — removed from `wallet-action.service.ts`
- **Priority fee selector on legacy chains** — guard no longer hides the fee UI on non-EIP-1559 chains (`l2-priority-fee-selection.component.ts`)
- **`calcPriceChange` silent truncation** — returns `null` when fewer candles than the requested window (`gecko-terminal-api.service.ts`)
- **LFG token cache thundering herd** — 30 s backoff after a fetch failure (`lfg-tokens-cache.service.ts`)

Skipped findings (verified false positives or already addressed in #192):
- KRC721 LIST/SEND op mismatch — intentional protocol design (LIST in commit, SEND in PSKT reveal)
- `base-assets-store` per-key race — fix already present in #192's head
- `app-wrapper` resize listener — already cleaned up in `ngOnDestroy`
- `getCurrentWallet()!` non-null assertion — pre-existing, not introduced by #192

## Test plan

- [ ] EIP-1193 `eth_estimateGas` works for a dApp before any wallet is connected
- [ ] First-ever `getPriceMap` / `getPriceUsd` call on a chain returns prices (no hang)
- [ ] App initializes in Safari private mode / restrictive iframes with localStorage blocked
- [ ] Generic ERC20 row on the L2 send screen no longer logs `logo not found for address 0`
- [ ] Priority fee selector renders on a legacy (non-EIP-1559) chain
- [ ] Token price-change for a young pool returns `null` instead of an incomplete-window value

Robot Generated with [Claude Code](https://claude.com/claude-code)