### PR TITLE
feat: standardize wallet analytics events

### DIFF
--- a/src/app/services/consent.service.ts
+++ b/src/app/services/consent.service.ts
@@ -1,6 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
-import { filter } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
 declare const KaspaConsentManager: any;
@@ -14,7 +12,7 @@ declare global {
   providedIn: 'root'
 })
 export class ConsentService {
-  constructor(private router: Router) {
+  constructor() {
     this.init();
   }
 
@@ -45,15 +43,6 @@ export class ConsentService {
           clarityKey: (environment as any).clarityKey,
           addressableKey: (environment as any).addressableKey,
           debugMode: !environment.isProduction
-       });
-
-       // Track subsequent navigations
-       this.router.events.pipe(
-         filter((event): event is NavigationEnd => event instanceof NavigationEnd)
-       ).subscribe((event) => {
-          if (window.analytics) {
-             window.analytics.page(event.urlAfterRedirects);
-          }
        });
     }
   }

--- a/src/app/services/monitor.service.spec.ts
+++ b/src/app/services/monitor.service.spec.ts
@@ -79,6 +79,30 @@ describe('MonitorService', () => {
     }
   });
 
+  it('drops `ip` as a whole token but keeps safe keys containing the substring', () => {
+    enableTracking();
+    service.track('Wallet Created', {
+      client_ip: '1.2.3.4',
+      userIp: '5.6.7.8',
+      tip_amount: 10,
+      zip_code: '90210',
+      ship_method: 'air',
+    });
+
+    const props = lastTrackedProps();
+    expect(props['client_ip']).toBeUndefined();
+    expect(props['userIp']).toBeUndefined();
+    expect(props['tip_amount']).toBe(10);
+    expect(props['zip_code']).toBe('90210');
+    expect(props['ship_method']).toBe('air');
+  });
+
+  it('does not track when analytics is a stub without a callable track', () => {
+    (service as any).trackingEnabled = true;
+    (window as any).analytics = {}; // attached but not ready yet
+    expect(() => service.track('Wallet Created')).not.toThrow();
+  });
+
   it('converts bigint values to numbers', () => {
     enableTracking();
     service.track('Transaction Succeeded', { amount: BigInt(5) });

--- a/src/app/services/monitor.service.spec.ts
+++ b/src/app/services/monitor.service.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { MonitorService } from './monitor.service';
+
+describe('MonitorService', () => {
+  let service: MonitorService;
+  let trackSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MonitorService,
+        { provide: Router, useValue: { events: of() } },
+      ],
+    });
+    service = TestBed.inject(MonitorService);
+    trackSpy = jasmine.createSpy('track');
+  });
+
+  afterEach(() => {
+    delete (window as any).analytics;
+  });
+
+  /** Force the post-consent state: tracking enabled + analytics attached. */
+  function enableTracking() {
+    (service as any).trackingEnabled = true;
+    (window as any).analytics = { track: trackSpy };
+  }
+
+  /** Properties Segment received on the most recent track call. */
+  function lastTrackedProps(): Record<string, unknown> {
+    return trackSpy.calls.mostRecent().args[1];
+  }
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('does not track when tracking is disabled', () => {
+    (window as any).analytics = { track: trackSpy };
+    service.track('Wallet Created', { action_source: 'wallet_onboarding' });
+    expect(trackSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not track (or throw) when analytics is not attached yet', () => {
+    (service as any).trackingEnabled = true;
+    expect(() => service.track('Wallet Created')).not.toThrow();
+    expect(trackSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops sensitive properties and keeps safe ones', () => {
+    enableTracking();
+    service.track('Wallet Created', {
+      action_source: 'wallet_onboarding',
+      count: 3,
+      walletAddress: 'kaspa:qr...',
+      auth_provider: 'google',
+      password: 'hunter2',
+      sessionId: 'abc',
+      user_email: 'a@b.com',
+      mnemonic: 'seed words',
+      tx_hash: '0xdeadbeef',
+    });
+
+    const props = lastTrackedProps();
+    expect(props['action_source']).toBe('wallet_onboarding');
+    expect(props['count']).toBe(3);
+    for (const dropped of [
+      'walletAddress',
+      'auth_provider',
+      'password',
+      'sessionId',
+      'user_email',
+      'mnemonic',
+      'tx_hash',
+    ]) {
+      expect(props[dropped]).toBeUndefined();
+    }
+  });
+
+  it('converts bigint values to numbers', () => {
+    enableTracking();
+    service.track('Transaction Succeeded', { amount: BigInt(5) });
+    expect(lastTrackedProps()['amount']).toBe(5);
+  });
+
+  it('normalizes Error values to error_name, not a string error_code', () => {
+    enableTracking();
+    service.track('Transaction Failed', { error: new TypeError('boom') });
+    const error = lastTrackedProps()['error'] as Record<string, unknown>;
+    expect(error['error_name']).toBe('TypeError');
+    expect(error['error_code']).toBeUndefined();
+  });
+
+  it('attaches common product properties', () => {
+    enableTracking();
+    service.track('Wallet Created');
+    const props = lastTrackedProps();
+    expect(props['app']).toBe('wallet');
+    expect(props['page_category']).toBeDefined();
+    expect(typeof props['is_mobile']).toBe('boolean');
+  });
+});

--- a/src/app/services/monitor.service.spec.ts
+++ b/src/app/services/monitor.service.spec.ts
@@ -103,10 +103,33 @@ describe('MonitorService', () => {
     expect(() => service.track('Wallet Created')).not.toThrow();
   });
 
-  it('converts bigint values to numbers', () => {
+  it('converts safe bigints to numbers and large ones to strings', () => {
     enableTracking();
-    service.track('Transaction Succeeded', { amount: BigInt(5) });
-    expect(lastTrackedProps()['amount']).toBe(5);
+    service.track('Transaction Succeeded', {
+      small: BigInt(5),
+      huge: BigInt('9007199254740993'), // > Number.MAX_SAFE_INTEGER
+    });
+    const props = lastTrackedProps();
+    expect(props['small']).toBe(5);
+    expect(props['huge']).toBe('9007199254740993');
+  });
+
+  it('masks sensitive route params but keeps static segments', () => {
+    enableTracking();
+    service.trackPageView(
+      '/app/home/asset/erc20/0xabcdef0123456789abcdef0123456789abcdef01',
+    );
+    expect(lastTrackedProps()['route']).toBe('/app/home/asset/erc20/:id');
+
+    service.trackPageView(
+      '/app/home/transaction/kaspa/' + 'a'.repeat(64),
+    );
+    expect(lastTrackedProps()['route']).toBe(
+      '/app/home/transaction/kaspa/:id',
+    );
+
+    service.trackPageView('/app/home/asset/krc20/KASPER');
+    expect(lastTrackedProps()['route']).toBe('/app/home/asset/krc20/KASPER');
   });
 
   it('normalizes Error values to error_name, not a string error_code', () => {

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -9,11 +9,11 @@ import { environment } from '../../environments/environment';
 export class MonitorService {
   private readonly trackingEnabled = this.isTrackingEnabled();
   private readonly disallowedPropertyPattern =
-    /address|wallet|email|ip|device|session|token|secret|private|mnemonic|seed|signature|authorization|tx|transaction|hash/i;
+    /address|wallet|email|ip|device|session|token|secret|private|mnemonic|seed|signature|auth|password|tx|transaction|hash/i;
 
   constructor(private router: Router) {
     if (this.trackingEnabled) {
-      this.trackPageView(window.location.pathname);
+      this.trackInitialPageView();
       this.router.events
         .pipe(
           filter(
@@ -22,6 +22,23 @@ export class MonitorService {
         )
         .subscribe((event) => this.trackPageView(event.urlAfterRedirects));
     }
+  }
+
+  /**
+   * `window.analytics` is attached by KaspaConsentManager only after the user
+   * grants consent (the consent script loads asynchronously), so tracking the
+   * initial page view immediately would drop it. Wait until analytics is
+   * available, then emit the current page view once. Capped so it stops if
+   * consent is never granted.
+   */
+  private trackInitialPageView(attemptsLeft = 60): void {
+    if (typeof window === 'undefined') return;
+    if (this.analytics) {
+      this.trackPageView(window.location.pathname);
+      return;
+    }
+    if (attemptsLeft <= 0) return;
+    setTimeout(() => this.trackInitialPageView(attemptsLeft - 1), 1000);
   }
 
   /**

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -8,8 +8,12 @@ import { environment } from '../../environments/environment';
 })
 export class MonitorService {
   private readonly trackingEnabled = this.isTrackingEnabled();
+  // Substring match for unambiguous sensitive fragments.
   private readonly disallowedPropertyPattern =
-    /address|wallet|email|ip|device|session|token|secret|private|mnemonic|seed|signature|auth|password|tx|transaction|hash/i;
+    /address|wallet|email|device|session|token|secret|private|mnemonic|seed|signature|auth|password|tx|transaction|hash/i;
+  // Short, ambiguous fragments matched only as whole tokens, so safe keys
+  // like `tip_amount` / `zip_code` / `ship_method` are not dropped.
+  private readonly disallowedTokens = new Set(['ip']);
 
   constructor(private router: Router) {
     if (this.trackingEnabled) {
@@ -33,7 +37,7 @@ export class MonitorService {
    */
   private trackInitialPageView(attemptsLeft = 60): void {
     if (typeof window === 'undefined') return;
-    if (this.analytics) {
+    if (this.isAnalyticsReady()) {
       this.trackPageView(window.location.pathname);
       return;
     }
@@ -53,6 +57,15 @@ export class MonitorService {
       : undefined;
   }
 
+  /**
+   * `window.analytics` may briefly be a stub/queue without a callable `track`
+   * before Segment finishes attaching, so check the method exists before
+   * emitting (and before stopping the initial-page-view retry loop).
+   */
+  private isAnalyticsReady(): boolean {
+    return typeof this.analytics?.track === 'function';
+  }
+
   trackPageView(route: string) {
     this.track('Page Viewed', {
       route: this.sanitizeRoute(route),
@@ -61,7 +74,7 @@ export class MonitorService {
   }
 
   track(event: string, properties?: Record<string, unknown>) {
-    if (!this.trackingEnabled || !this.analytics) return;
+    if (!this.trackingEnabled || !this.isAnalyticsReady()) return;
 
     try {
       this.analytics.track(event, {
@@ -91,12 +104,20 @@ export class MonitorService {
       return Object.entries(value as Record<string, unknown>).reduce<
         Record<string, unknown>
       >((safe, [key, entry]) => {
-        if (this.disallowedPropertyPattern.test(key)) return safe;
+        if (this.isDisallowedKey(key)) return safe;
         safe[key] = this.normalizeProperties(entry);
         return safe;
       }, {});
     }
     return value;
+  }
+
+  private isDisallowedKey(key: string): boolean {
+    if (this.disallowedPropertyPattern.test(key)) return true;
+    return key
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .split(/[^a-zA-Z0-9]+/)
+      .some((token) => this.disallowedTokens.has(token.toLowerCase()));
   }
 
   private getCommonProperties(): Record<string, unknown> {

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -90,7 +90,14 @@ export class MonitorService {
   }
 
   private normalizeProperties(value: unknown): unknown {
-    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'bigint') {
+      // Crypto amounts/fees can exceed Number.MAX_SAFE_INTEGER; keep a number
+      // only when it round-trips safely, otherwise serialize as a string.
+      return value <= BigInt(Number.MAX_SAFE_INTEGER) &&
+        value >= BigInt(Number.MIN_SAFE_INTEGER)
+        ? Number(value)
+        : value.toString();
+    }
     if (value instanceof Error) {
       return {
         error_name: value.name || 'Error',
@@ -140,7 +147,23 @@ export class MonitorService {
   }
 
   private sanitizeRoute(route: string): string {
-    return (route || '/').split('?')[0].split('#')[0] || '/';
+    const path = (route || '/').split('?')[0].split('#')[0] || '/';
+    // Mask likely-sensitive path params (addresses, tx ids, long hex/opaque
+    // ids) so they don't leak via the `route` attached to every event, while
+    // keeping static segments and short public ones (e.g. tickers).
+    const masked = path
+      .split('/')
+      .map((segment) => (this.isSensitiveSegment(segment) ? ':id' : segment))
+      .join('/');
+    return masked || '/';
+  }
+
+  private isSensitiveSegment(segment: string): boolean {
+    if (!segment) return false;
+    if (segment.includes(':')) return true; // kaspa:... addresses
+    if (/^0x[0-9a-fA-F]{6,}$/.test(segment)) return true; // evm address / hash
+    if (/^[0-9a-fA-F]{16,}$/.test(segment)) return true; // long hex tx ids
+    return segment.length >= 24; // long opaque ids / addresses
   }
 
   private getPageCategory(route: string): string {

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -80,7 +80,7 @@ export class MonitorService {
     if (typeof value === 'bigint') return Number(value);
     if (value instanceof Error) {
       return {
-        error_code: value.name || 'Error',
+        error_name: value.name || 'Error',
         error_category: 'unknown',
       };
     }

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -31,7 +31,9 @@ export class MonitorService {
    * post-consent path instead of loading a second Segment instance.
    */
   private get analytics(): any {
-    return typeof window !== 'undefined' ? window.analytics : undefined;
+    return typeof window !== 'undefined'
+      ? (window as any).analytics
+      : undefined;
   }
 
   trackPageView(route: string) {

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -1,40 +1,136 @@
-import { Injectable } from "@angular/core";
-import { AnalyticsBrowser } from '@segment/analytics-next'
-import { environment } from "../../environments/environment";
-
+import { Injectable } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { AnalyticsBrowser } from '@segment/analytics-next';
+import { filter } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 @Injectable({
-    providedIn: 'root',
+  providedIn: 'root',
 })
 export class MonitorService {
-    private analytics: AnalyticsBrowser | undefined;
+  private analytics: AnalyticsBrowser | undefined;
+  private readonly disallowedPropertyPattern =
+    /address|wallet|email|ip|device|session|token|secret|private|mnemonic|seed|signature|authorization|tx|transaction|hash/i;
 
-    constructor() {
-        if (environment.segmentKey) {
-            this.analytics = AnalyticsBrowser.load({ writeKey: environment.segmentKey });
-        }
+  constructor(private router: Router) {
+    if (this.isTrackingEnabled() && environment.segmentKey) {
+      this.analytics = AnalyticsBrowser.load({
+        writeKey: environment.segmentKey,
+      });
+      this.trackPageView(window.location.pathname);
+      this.router.events
+        .pipe(
+          filter(
+            (event): event is NavigationEnd => event instanceof NavigationEnd,
+          ),
+        )
+        .subscribe((event) => this.trackPageView(event.urlAfterRedirects));
     }
+  }
 
-    normalizeProperties(obj: any): any {
-        if (typeof obj === 'object') {
-            Object.keys(obj).forEach(key => {
-                if (typeof obj[key] === 'bigint') {
-                    obj[key] = Number(obj[key]);
-                } else if (typeof obj[key] === 'object' && obj[key] !== null && obj[key] !== undefined) {
-                    obj[key] = this.normalizeProperties(obj[key]);
-                }
-            });
-        }
-        return obj;
-    }
+  trackPageView(route: string) {
+    this.track('Page Viewed', {
+      route: this.sanitizeRoute(route),
+      page_category: this.getPageCategory(route),
+    });
+  }
 
-    track(event: string, properties?: any) {
-        if (this.analytics) {
-            try {
-                this.analytics.track(event, this.normalizeProperties(properties));
-            } catch (error) {
-                console.error('Error tracking event:', event, properties, error);
-            }
-        }
+  track(event: string, properties?: Record<string, unknown>) {
+    if (!this.analytics) return;
+
+    try {
+      this.analytics.track(event, {
+        ...this.getCommonProperties(),
+        ...(this.normalizeProperties(properties || {}) as Record<
+          string,
+          unknown
+        >),
+      });
+    } catch (error) {
+      console.error('Error tracking event:', event, error);
     }
+  }
+
+  private normalizeProperties(value: unknown): unknown {
+    if (typeof value === 'bigint') return Number(value);
+    if (value instanceof Error) {
+      return {
+        error_code: value.name || 'Error',
+        error_category: 'unknown',
+      };
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.normalizeProperties(item));
+    }
+    if (value && typeof value === 'object') {
+      return Object.entries(value as Record<string, unknown>).reduce<
+        Record<string, unknown>
+      >((safe, [key, entry]) => {
+        if (this.disallowedPropertyPattern.test(key)) return safe;
+        safe[key] = this.normalizeProperties(entry);
+        return safe;
+      }, {});
+    }
+    return value;
+  }
+
+  private getCommonProperties(): Record<string, unknown> {
+    return {
+      app: 'wallet',
+      environment: environment.isProduction ? 'production' : 'development',
+      route: this.sanitizeRoute(window.location.pathname),
+      page_category: this.getPageCategory(window.location.pathname),
+      referrer_domain: this.getReferrerDomain(),
+      is_mobile: window.matchMedia('(max-width: 767px)').matches,
+      ...this.getUtmProperties(),
+    };
+  }
+
+  private isTrackingEnabled(): boolean {
+    if (!environment.segmentKey) return false;
+    if (!environment.isProduction) return false;
+    const hostname = window.location.hostname;
+    return (
+      !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname) &&
+      !hostname.endsWith('.local')
+    );
+  }
+
+  private sanitizeRoute(route: string): string {
+    return (route || '/').split('?')[0].split('#')[0] || '/';
+  }
+
+  private getPageCategory(route: string): string {
+    const cleanRoute = this.sanitizeRoute(route);
+    if (cleanRoute.includes('/onboarding')) return 'wallet_onboarding';
+    if (cleanRoute.includes('/activity')) return 'wallet_activity';
+    if (cleanRoute.includes('/asset/')) return 'wallet_asset';
+    if (cleanRoute.includes('/transaction/')) return 'wallet_transaction';
+    if (cleanRoute.includes('/app/home')) return 'wallet_home';
+    return cleanRoute === '/' ? 'wallet_root' : 'wallet_other';
+  }
+
+  private getReferrerDomain(): string | undefined {
+    if (!document.referrer) return undefined;
+    try {
+      return new URL(document.referrer).hostname;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private getUtmProperties(): Record<string, string> {
+    const params = new URLSearchParams(window.location.search);
+    return [
+      'utm_source',
+      'utm_medium',
+      'utm_campaign',
+      'utm_content',
+      'utm_term',
+    ].reduce<Record<string, string>>((acc, key) => {
+      const value = params.get(key);
+      if (value) acc[key] = value;
+      return acc;
+    }, {});
+  }
 }

--- a/src/app/services/monitor.service.ts
+++ b/src/app/services/monitor.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { AnalyticsBrowser } from '@segment/analytics-next';
 import { filter } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
@@ -8,15 +7,12 @@ import { environment } from '../../environments/environment';
   providedIn: 'root',
 })
 export class MonitorService {
-  private analytics: AnalyticsBrowser | undefined;
+  private readonly trackingEnabled = this.isTrackingEnabled();
   private readonly disallowedPropertyPattern =
     /address|wallet|email|ip|device|session|token|secret|private|mnemonic|seed|signature|authorization|tx|transaction|hash/i;
 
   constructor(private router: Router) {
-    if (this.isTrackingEnabled() && environment.segmentKey) {
-      this.analytics = AnalyticsBrowser.load({
-        writeKey: environment.segmentKey,
-      });
+    if (this.trackingEnabled) {
       this.trackPageView(window.location.pathname);
       this.router.events
         .pipe(
@@ -28,6 +24,16 @@ export class MonitorService {
     }
   }
 
+  /**
+   * The Segment instance is loaded once by KaspaConsentManager (see
+   * ConsentService) only after the user grants consent, exposed as
+   * `window.analytics`. Reading it here keeps tracking behind that single
+   * post-consent path instead of loading a second Segment instance.
+   */
+  private get analytics(): any {
+    return typeof window !== 'undefined' ? window.analytics : undefined;
+  }
+
   trackPageView(route: string) {
     this.track('Page Viewed', {
       route: this.sanitizeRoute(route),
@@ -36,7 +42,7 @@ export class MonitorService {
   }
 
   track(event: string, properties?: Record<string, unknown>) {
-    if (!this.analytics) return;
+    if (!this.trackingEnabled || !this.analytics) return;
 
     try {
       this.analytics.track(event, {
@@ -87,13 +93,10 @@ export class MonitorService {
   }
 
   private isTrackingEnabled(): boolean {
+    if (typeof window === 'undefined') return false;
     if (!environment.segmentKey) return false;
     if (!environment.isProduction) return false;
-    const hostname = window.location.hostname;
-    return (
-      !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname) &&
-      !hostname.endsWith('.local')
-    );
+    return environment.allowedDomains.includes(window.location.hostname);
   }
 
   private sanitizeRoute(route: string): string {

--- a/src/app/services/wallet-action.service.ts
+++ b/src/app/services/wallet-action.service.ts
@@ -320,9 +320,12 @@ export class WalletActionService {
     if (!isUsingV2Flow) {
       await this.showTransactionLoaderToUser(0, currentWalletAddress);
     }
-    this.monitorService.track('Transaction Started', {
-      action_type: action.type,
-    });
+    const isTransaction = this.isTransactionAction(action);
+    if (isTransaction) {
+      this.monitorService.track('Transaction Started', {
+        action_type: action.type,
+      });
+    }
 
     let actionResult: WalletActionResultWithError;
     try {
@@ -341,12 +344,14 @@ export class WalletActionService {
     } catch (error) {
       console.error('Error executing wallet action:', error);
 
-      this.monitorService.track('Transaction Failed', {
-        action_type: action.type,
-        error_category: 'unknown',
-        error_code: ERROR_CODES.GENERAL.UNKNOWN_ERROR,
-        error_name: error instanceof Error ? error.name : 'UnknownError',
-      });
+      if (isTransaction) {
+        this.monitorService.track('Transaction Failed', {
+          action_type: action.type,
+          error_category: 'unknown',
+          error_code: ERROR_CODES.GENERAL.UNKNOWN_ERROR,
+          error_name: error instanceof Error ? error.name : 'UnknownError',
+        });
+      }
 
       if (isUsingV2Flow) {
         const fallbackMessage =
@@ -368,11 +373,13 @@ export class WalletActionService {
     }
 
     if (!actionResult.success) {
-      this.monitorService.track('Transaction Failed', {
-        action_type: action.type,
-        error_code: actionResult.errorCode,
-        error_category: 'wallet_action',
-      });
+      if (isTransaction) {
+        this.monitorService.track('Transaction Failed', {
+          action_type: action.type,
+          error_code: actionResult.errorCode,
+          error_category: 'wallet_action',
+        });
+      }
 
       if (isUsingV2Flow) {
         const errorMessage = actionResult.errorCode
@@ -396,9 +403,11 @@ export class WalletActionService {
       );
     }
 
-    this.monitorService.track('Transaction Succeeded', {
-      action_type: action.type,
-    });
+    if (isTransaction) {
+      this.monitorService.track('Transaction Succeeded', {
+        action_type: action.type,
+      });
+    }
 
     return { ...actionResult, isUsingV2Flow };
   }
@@ -933,6 +942,29 @@ export class WalletActionService {
     return {
       isValidated: true,
     };
+  }
+
+  /**
+   * Whether an action produces an on-chain transaction, so the `Transaction *`
+   * analytics events stay scoped to true transaction outcomes. Non-transaction
+   * actions (sign message, app approval, non-send EIP-1193 methods like
+   * add/switch chain) are excluded to avoid polluting transaction metrics.
+   */
+  private isTransactionAction(action: WalletAction): boolean {
+    switch (action.type) {
+      case WalletActionType.TRANSFER_KAS:
+      case WalletActionType.COMPOUND_UTXOS:
+      case WalletActionType.SIGN_PSKT_TRANSACTION:
+      case WalletActionType.COMMIT_REVEAL:
+        return true;
+      case WalletActionType.EIP1193_PROVIDER_REQUEST:
+        return (
+          action.data.method === EIP1193RequestType.SEND_TRANSACTION ||
+          action.data.method === EIP1193RequestType.KAS_SEND_TRANSACTION
+        );
+      default:
+        return false;
+    }
   }
 
   private getActionSteps(action: WalletAction): number {

--- a/src/app/services/wallet-action.service.ts
+++ b/src/app/services/wallet-action.service.ts
@@ -321,7 +321,7 @@ export class WalletActionService {
       await this.showTransactionLoaderToUser(0, currentWalletAddress);
     }
     this.monitorService.track('Transaction Started', {
-      action_type: action,
+      action_type: action.type,
     });
 
     let actionResult: WalletActionResultWithError;
@@ -342,7 +342,7 @@ export class WalletActionService {
       console.error('Error executing wallet action:', error);
 
       this.monitorService.track('Transaction Failed', {
-        action_type: action,
+        action_type: action.type,
         error_category: 'unknown',
         error_code: error instanceof Error ? error.name : 'UnknownError',
       });
@@ -368,7 +368,7 @@ export class WalletActionService {
 
     if (!actionResult.success) {
       this.monitorService.track('Transaction Failed', {
-        action_type: action,
+        action_type: action.type,
         error_code: actionResult.errorCode,
         error_category: 'wallet_action',
       });
@@ -396,7 +396,7 @@ export class WalletActionService {
     }
 
     this.monitorService.track('Transaction Succeeded', {
-      action_type: action,
+      action_type: action.type,
     });
 
     return { ...actionResult, isUsingV2Flow };

--- a/src/app/services/wallet-action.service.ts
+++ b/src/app/services/wallet-action.service.ts
@@ -344,7 +344,8 @@ export class WalletActionService {
       this.monitorService.track('Transaction Failed', {
         action_type: action.type,
         error_category: 'unknown',
-        error_code: error instanceof Error ? error.name : 'UnknownError',
+        error_code: ERROR_CODES.GENERAL.UNKNOWN_ERROR,
+        error_name: error instanceof Error ? error.name : 'UnknownError',
       });
 
       if (isUsingV2Flow) {

--- a/src/app/services/wallet-action.service.ts
+++ b/src/app/services/wallet-action.service.ts
@@ -58,10 +58,10 @@ export class WalletActionService {
   }>({});
   private actionToApprove = signal<
     | {
-      action: WalletAction;
-      resolve: (data: { isApproved: boolean; priorityFee?: bigint }) => void;
-      additionalParams?: { [parmName: string]: any };
-    }
+        action: WalletAction;
+        resolve: (data: { isApproved: boolean; priorityFee?: bigint }) => void;
+        additionalParams?: { [parmName: string]: any };
+      }
     | undefined
   >(undefined);
 
@@ -320,6 +320,9 @@ export class WalletActionService {
     if (!isUsingV2Flow) {
       await this.showTransactionLoaderToUser(0, currentWalletAddress);
     }
+    this.monitorService.track('Transaction Started', {
+      action_type: action,
+    });
 
     let actionResult: WalletActionResultWithError;
     try {
@@ -339,8 +342,9 @@ export class WalletActionService {
       console.error('Error executing wallet action:', error);
 
       this.monitorService.track('Transaction Failed', {
-        action,
-        error: error,
+        action_type: action,
+        error_category: 'unknown',
+        error_code: error instanceof Error ? error.name : 'UnknownError',
       });
 
       if (isUsingV2Flow) {
@@ -364,8 +368,9 @@ export class WalletActionService {
 
     if (!actionResult.success) {
       this.monitorService.track('Transaction Failed', {
-        action,
-        actionResult,
+        action_type: action,
+        error_code: actionResult.errorCode,
+        error_category: 'wallet_action',
       });
 
       if (isUsingV2Flow) {
@@ -390,9 +395,8 @@ export class WalletActionService {
       );
     }
 
-    this.monitorService.track('Transaction Success', {
-      action,
-      actionResult,
+    this.monitorService.track('Transaction Succeeded', {
+      action_type: action,
     });
 
     return { ...actionResult, isUsingV2Flow };
@@ -464,13 +468,13 @@ export class WalletActionService {
 
   getActionToApproveSignal(): Signal<
     | {
-      action: WalletAction;
-      resolve: (data: {
-        isApproved: boolean;
-        priorityFee?: bigint;
-        additionalParams?: { [parmName: string]: any };
-      }) => void;
-    }
+        action: WalletAction;
+        resolve: (data: {
+          isApproved: boolean;
+          priorityFee?: bigint;
+          additionalParams?: { [parmName: string]: any };
+        }) => void;
+      }
     | undefined
   > {
     return this.actionToApprove.asReadonly();
@@ -895,7 +899,11 @@ export class WalletActionService {
     }
 
     for (const input of transaction.inputs) {
-      const utxoAddress = input.utxo.address || this.kaspaNetworkActionsService.getWalletAddressFromScriptPublicKey(input.utxo.scriptPublicKey);
+      const utxoAddress =
+        input.utxo.address ||
+        this.kaspaNetworkActionsService.getWalletAddressFromScriptPublicKey(
+          input.utxo.scriptPublicKey,
+        );
 
       if (!utxoAddress) {
         return {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -141,14 +141,13 @@ export class WalletService {
 
     const result = await this.saveWalletData(walletData);
 
-    this.monitorService.track(
-      isNewWallet ? 'Wallet Created' : 'Wallet Imported',
-      {
-        action_source: 'wallet_onboarding',
-      },
-    );
-
     if (result) {
+      this.monitorService.track(
+        isNewWallet ? 'Wallet Created' : 'Wallet Imported',
+        {
+          action_source: 'wallet_onboarding',
+        },
+      );
       return { sucess: true };
     } else {
       return { sucess: false, error: 'Error adding wallet' };
@@ -228,7 +227,7 @@ export class WalletService {
       newAccount,
     ]);
 
-    this.monitorService.track('Wallet Imported', {
+    this.monitorService.track('Wallet Account Added', {
       action_source: 'add_wallet_account',
     });
 

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -141,12 +141,6 @@ export class WalletService {
 
     const result = await this.saveWalletData(walletData);
 
-    const wallet = this.createAppWalletFromSavedWalletData(
-      walletData,
-      true,
-      walletData.accounts?.[0],
-    );
-
     this.monitorService.track(
       isNewWallet ? 'Wallet Created' : 'Wallet Imported',
       {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -1,6 +1,16 @@
-import { computed, EnvironmentInjector, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import {
+  computed,
+  EnvironmentInjector,
+  Injectable,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
 import { PasswordManagerService } from './password-manager.service';
-import { SavedWalletAccount, SavedWalletData, } from '../types/saved-wallet-data';
+import {
+  SavedWalletAccount,
+  SavedWalletData,
+} from '../types/saved-wallet-data';
 import { AppWallet } from '../classes/AppWallet';
 import { LOCAL_STORAGE_KEYS } from '../config/consts';
 import { AssetType, TransferableAsset } from '../types/transferable-asset';
@@ -8,7 +18,7 @@ import { KasplexKrc20Service } from './kasplex-api/kasplex-api.service';
 import { firstValueFrom } from 'rxjs';
 import { UtilsHelper } from './utils.service';
 import { RpcConnectionStatus } from '../types/kaspa-network/rpc-connection-status.enum';
-import { cloneDeep } from "lodash";
+import { cloneDeep } from 'lodash';
 import { EthereumWalletChainManager } from './etherium-services/etherium-wallet-chain.manager';
 import { KaspaNetworkConnectionManagerService } from './kaspa-netwrok-services/kaspa-network-connection-manager.service';
 import { KaspaWalletMnemonicActionsService } from './kaspa-netwrok-services/kaspa-wallet-mnemonic-actions.service';
@@ -38,7 +48,8 @@ export class WalletService {
     private readonly etheriumChainManager: EthereumWalletChainManager,
     private readonly monitorService: MonitorService,
   ) {
-    let isL2View = localStorage.getItem(LOCAL_STORAGE_KEYS.IS_L2_DISPLAY) === 'true';
+    let isL2View =
+      localStorage.getItem(LOCAL_STORAGE_KEYS.IS_L2_DISPLAY) === 'true';
 
     const urlParams = new URLSearchParams(window.location.search);
     const viewTypeParam = urlParams.get('view');
@@ -126,7 +137,7 @@ export class WalletService {
       password: passphrase,
       version: 1,
       accounts: accountData ? [accountData] : undefined,
-    }
+    };
 
     const result = await this.saveWalletData(walletData);
 
@@ -136,12 +147,12 @@ export class WalletService {
       walletData.accounts?.[0],
     );
 
-
-    this.monitorService.track('Wallet Added', {
-      walletAddressL1: wallet?.getAddress(),
-      walletAddressL2: wallet?.getL2WalletAddress(),
-      isNew: isNewWallet,
-    });
+    this.monitorService.track(
+      isNewWallet ? 'Wallet Created' : 'Wallet Imported',
+      {
+        action_source: 'wallet_onboarding',
+      },
+    );
 
     if (result) {
       return { sucess: true };
@@ -158,10 +169,17 @@ export class WalletService {
     passphrase?: string,
     isNewWallet?: boolean,
   ): Promise<{ sucess: boolean; error?: string }> {
-    return await this.addWallet(name, undefined, mnemonic, passphrase, {
-      name: accountName,
-      derivedPath: derivedPath,
-    }, isNewWallet);
+    return await this.addWallet(
+      name,
+      undefined,
+      mnemonic,
+      passphrase,
+      {
+        name: accountName,
+        derivedPath: derivedPath,
+      },
+      isNewWallet,
+    );
   }
 
   async addWalletAccount(
@@ -216,9 +234,8 @@ export class WalletService {
       newAccount,
     ]);
 
-    this.monitorService.track('Wallet Account Added', {
-      walletAddressL1: newAccount?.getAddress(),
-      walletAddressL2: newAccount?.getL2WalletAddress(),
+    this.monitorService.track('Wallet Imported', {
+      action_source: 'add_wallet_account',
     });
 
     return {
@@ -379,7 +396,9 @@ export class WalletService {
   async loadWallets(loadBalance: boolean = false): Promise<void> {
     // If wallets are already loaded, don't reload them to prevent state corruption
     if (this.isWalletLoaded) {
-      console.warn('loadWallets() called but wallets are already loaded. Ignoring to prevent state corruption.');
+      console.warn(
+        'loadWallets() called but wallets are already loaded. Ignoring to prevent state corruption.',
+      );
       return;
     }
 
@@ -636,7 +655,7 @@ export class WalletService {
       // Update all wallet instances in allWalletsSignal
       this.allWalletsSignal.update((wallets) => {
         if (!wallets) return wallets;
-        return wallets.map(w => {
+        return wallets.map((w) => {
           if (w.getId() === walletData.id) {
             w.setName(walletData.name);
             return cloneDeep(w);
@@ -745,7 +764,6 @@ export class WalletService {
     );
   }
 
-
   setL2Display(value: boolean) {
     localStorage.setItem(LOCAL_STORAGE_KEYS.IS_L2_DISPLAY, value.toString());
     this.isL2DisplaySignal.set(value);
@@ -761,18 +779,22 @@ export class WalletService {
 
   getCurrentDisplayNativeTokenName(): string {
     if (this.isL2DisplaySignal()) {
-      return this.etheriumChainManager.getCurrentWalletProvider()?.getConfig().nativeCurrency.symbol || 'KAS';
+      return (
+        this.etheriumChainManager.getCurrentWalletProvider()?.getConfig()
+          .nativeCurrency.symbol || 'KAS'
+      );
     } else {
       return 'KAS';
     }
   }
 
   public getCurrentDisplayWalletAddress = computed(() => {
-    return this.isL2DisplaySignal() ? this.currentWalletSignal()?.getL2WalletAddress() : this.currentWalletSignal()?.getAddress();
+    return this.isL2DisplaySignal()
+      ? this.currentWalletSignal()?.getL2WalletAddress()
+      : this.currentWalletSignal()?.getAddress();
   });
 
   public getCurrentDisplayWalletAddressAsString = computed(() => {
     return this.getCurrentDisplayWalletAddress() || '';
-  })
-
+  });
 }

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
@@ -256,7 +256,7 @@ export class OnboardingPageV2Component implements AfterViewInit, OnDestroy {
         await this.walletService.selectCurrentWalletFromLocalStorageNullsafe();
       }
 
-      this.monitorService.track('User Logged In', {
+      this.monitorService.track('Wallet Logged In', {
         isIframe: IFrameCommunicationApp.isIframe(),
       });
 

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
@@ -257,7 +257,7 @@ export class OnboardingPageV2Component implements AfterViewInit, OnDestroy {
       }
 
       this.monitorService.track('Wallet Logged In', {
-        isIframe: IFrameCommunicationApp.isIframe(),
+        is_iframe: IFrameCommunicationApp.isIframe(),
       });
 
       await this.router.navigate(['./app/home']);


### PR DESCRIPTION
## What changed
- Standardized wallet analytics through `MonitorService` using canonical Mixpanel/Segment event names.
- Added common product properties: `app`, `environment`, sanitized route, page category, referrer domain, mobile flag, UTM fields.
- Blocks production analytics on localhost/dev by default.
- Sanitizes sensitive properties before tracking; removed raw wallet address tracking from wallet create/import/account flows.
- Renamed core semantic events to taxonomy names: `Page Viewed`, `Wallet Created`, `Wallet Imported`, `Wallet Logged In`, `Transaction Started/Succeeded/Failed`.
- Keeps manual instrumentation limited to wallet lifecycle and transaction outcomes; generic button/link clicks are left to analytics vendor autocapture/session replay.

## Why
Make wallet analytics decision-grade for acquisition, activation, retention, and failed-action analysis without leaking wallet-sensitive identifiers or scattering manual click snippets through UI buttons.

## Quality Gates
**Quality Tier:** 2 — multi-file analytics instrumentation.

| Gate | Status | Notes |
| --- | --- | --- |
| G1: Tests Written | ✅ Added | `monitor.service.spec.ts` added covering tracking gating, sensitive-property sanitization (incl. `ip` token vs substring), bigint/Error normalization, and analytics-readiness guard. |
| G2: Build | ✅ PASS | `npm run build:dev` exit 0. Existing warnings only: duplicate WASM `toString`, wrapper-header optional-chain warnings. Re-run after click-tracking review. |
| G3: Tests Run | ⚠️ Not run | Build passed; unit/e2e not run before this PR. |
| G4: Self-Review | ✅ PASS | Checked diff for raw wallet address removal, dev blocking, event taxonomy alignment, and no generic manual button tracking. |
| G5: Cross-Model Review | ⚠️ Pending | Not run yet; can be delegated to PR review agent. |

## Privacy
- No raw wallet addresses are intentionally sent as business analytics properties.
- Sanitizer drops suspicious keys matching wallet/address/email/IP/device/session/token/secret/private/mnemonic/seed/signature/auth/tx/hash.