### PR TITLE
fix: preserve user-selected L2 fees through applyFeesSafely

### DIFF
--- a/src/app/services/etherium-services/etherium-handle-action-request.service.ts
+++ b/src/app/services/etherium-services/etherium-handle-action-request.service.ts
@@ -107,14 +107,22 @@ export class EthereumHandleActionRequestService {
             delete tx.accessList;
 
             tx.type = 0;
-            tx.gasPrice = fees.gasPrice;
+            // Preserve user-selected gasPrice if already set on the tx
+            if (tx.gasPrice == null) {
+                tx.gasPrice = fees.gasPrice;
+            }
         } else {
             // EIP-1559 tx → REMOVE legacy field
             delete tx.gasPrice;
 
             tx.type = 2;
-            tx.maxFeePerGas = fees.maxFeePerGas;
-            tx.maxPriorityFeePerGas = fees.maxPriorityFeePerGas;
+            // Preserve user-selected EIP-1559 fees if already set on the tx
+            if (tx.maxFeePerGas == null) {
+                tx.maxFeePerGas = fees.maxFeePerGas;
+            }
+            if (tx.maxPriorityFeePerGas == null) {
+                tx.maxPriorityFeePerGas = fees.maxPriorityFeePerGas;
+            }
         }
     }
 


### PR DESCRIPTION
Approval flow writes user-selected gasLimit, maxPriorityFeePerGas, and maxFeePerGas onto action.data.params[0], but handleSendTransactionRequest unconditionally overwrote those fields with provider defaults via applyFeesSafely, so only gasLimit was actually respected at sign time. Keep user-supplied gasPrice / maxFeePerGas / maxPriorityFeePerGas when they are already set on the populated tx, and only fall back to the normalized provider fees when they are not.