### PR TITLE
feat: add runtime Kaspa network configuration

### DIFF
--- a/src/app/classes/AppWallet.ts
+++ b/src/app/classes/AppWallet.ts
@@ -296,6 +296,12 @@ export class AppWallet {
     this.mempoolTransactionsSignal.set(undefined);
   }
 
+  resetL1NetworkState(): void {
+    this.balanceSignal.set(undefined);
+    this.walletStateBalance.set(undefined);
+    this.mempoolTransactionsSignal.set(undefined);
+  }
+
   isCurrentlyActive(): boolean {
     return this.isCurrentlyActiveSingal();
   }

--- a/src/app/config/consts.ts
+++ b/src/app/config/consts.ts
@@ -7,6 +7,7 @@ export const LOCAL_STORAGE_KEYS = {
   ALLOWED_APPLICATIONS: 'allowedApplications',
   IS_L2_DISPLAY: 'isL2Display',
   RPC_URL: 'rpcUrl',
+  KASPA_L1_NETWORK: 'kaspaL1Network',
   REFERRAL_CODE: 'referralCode',
 };
 

--- a/src/app/core/app.config.ts
+++ b/src/app/core/app.config.ts
@@ -19,6 +19,12 @@ const defaultL1Network =
     (network) => network.network === environment.kaspaNetwork,
   ) ?? environment.l1Config.networks?.[0];
 
+if (!defaultL1Network) {
+  throw new Error(
+    'No Kaspa L1 networks configured. Check environment.l1Config.networks.',
+  );
+}
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
@@ -37,7 +43,7 @@ export const appConfig: ApplicationConfig = {
     },
     {
       provide: DEFI_API_BASE_URL,
-      useValue: defaultL1Network?.kaspaComDefiApiBaseurl,
+      useValue: defaultL1Network.kaspaComDefiApiBaseurl,
     },
     {
       provide: LOGOS_URL,

--- a/src/app/core/app.config.ts
+++ b/src/app/core/app.config.ts
@@ -14,6 +14,11 @@ import { V2TMP_ROUTES } from '../v2/v2.routes';
 import { environment } from '../../environments/environment';
 import { DEFI_API_BASE_URL, LOGOS_URL } from '../config/injection-tokens';
 
+const defaultL1Network =
+  environment.l1Config.networks?.find(
+    (network) => network.network === environment.kaspaNetwork,
+  ) ?? environment.l1Config.networks?.[0];
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
@@ -32,7 +37,7 @@ export const appConfig: ApplicationConfig = {
     },
     {
       provide: DEFI_API_BASE_URL,
-      useValue: environment.kaspaComDefiApiBaseurl,
+      useValue: defaultL1Network?.kaspaComDefiApiBaseurl,
     },
     {
       provide: LOGOS_URL,

--- a/src/app/services/address-resolution.service.ts
+++ b/src/app/services/address-resolution.service.ts
@@ -3,9 +3,8 @@ import { UtilsHelper } from './utils.service';
 import { KnsApiService } from './kns-api/kns-api.service';
 import { firstValueFrom } from 'rxjs';
 import { default as Graphemer } from 'graphemer';
-import { environment } from '../../environments/environment';
-import { KASPA_NETWORKS } from '../config/consts';
 import { WalletService } from './wallet.service';
+import { KaspaL1NetworkService } from './kaspa-netwrok-services/kaspa-l1-network.service';
 
 export interface AddressResolutionResult {
   effectiveAddress: string | null;
@@ -20,6 +19,7 @@ export class AddressResolutionService {
   private readonly knsApi = inject(KnsApiService);
   private readonly graphemer = new Graphemer();
   private readonly walletService = inject(WalletService);
+  private readonly kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   isKaspaAddress(input: string): boolean {
     return this.utils.isValidWalletAddress(input);
@@ -88,7 +88,7 @@ export class AddressResolutionService {
     }
 
     // Provide specific error based on network and address format
-    const isMainnet = environment.kaspaNetwork === KASPA_NETWORKS.MAINNET;
+    const isMainnet = this.kaspaL1NetworkService.isMainnet();
     const expectedPrefix = isMainnet ? 'kaspa:' : 'kaspatest:';
     const wrongPrefix = isMainnet ? 'kaspatest:' : 'kaspa:';
 

--- a/src/app/services/asset-metadata/krc721-metadata.service.ts
+++ b/src/app/services/asset-metadata/krc721-metadata.service.ts
@@ -5,7 +5,7 @@ import { Krc721ApiService } from '../krc721-api/krc721-api.service';
 import { Krc721Nft, Krc721Metadata } from '../krc721-api/dtos/krc721-nft.dto';
 import { L1_ASSET_KEYS } from '../assets-manager/assets-stores/l1-assets-store.service';
 import { AssetsManagerService } from '../assets-manager/assets-manager.service';
-import { environment } from '../../../environments/environment';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 export interface Krc721NftWithMetadata extends Krc721Nft {
   metadataLoaded?: boolean;
@@ -16,6 +16,7 @@ export interface Krc721NftWithMetadata extends Krc721Nft {
 })
 export class Krc721MetadataService extends BaseAssetMetadataService<Krc721Nft, Krc721Metadata> {
   private krc721Service = inject(Krc721ApiService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
   
   constructor(protected assetsManager: AssetsManagerService) {
     super(assetsManager.getAllAssetStores().l1, L1_ASSET_KEYS.krc721);
@@ -103,12 +104,13 @@ export class Krc721MetadataService extends BaseAssetMetadataService<Krc721Nft, K
   }
 
   private buildCachedImageUrl(tick?: string, tokenId?: string): string {
-    if (!tick || !tokenId || !environment.krc721CacheStreamUrl) {
+    const cacheStreamUrl = this.kaspaL1NetworkService.getKrc721CacheStreamUrl();
+    if (!tick || !tokenId || !cacheStreamUrl) {
       return '';
     }
 
     const normalizedTick = encodeURIComponent(tick.toUpperCase());
     const normalizedTokenId = encodeURIComponent(tokenId);
-    return `${environment.krc721CacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
+    return `${cacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
   }
-} 
+}

--- a/src/app/services/assets-manager/assets-manager.service.ts
+++ b/src/app/services/assets-manager/assets-manager.service.ts
@@ -7,6 +7,7 @@ import { AppWallet } from "../../classes/AppWallet";
 import { L1AssetsStoreService } from "./assets-stores/l1-assets-store.service";
 import { L2AssetsStoreService } from "./assets-stores/l2-assets-store.service";
 import { EthereumWalletChainManager } from "../etherium-services/etherium-wallet-chain.manager";
+import { KaspaL1NetworkService } from "../kaspa-netwrok-services/kaspa-l1-network.service";
 
 @Injectable({
     providedIn: 'root',
@@ -17,6 +18,7 @@ export class AssetsManagerService {
     private l1AssetsStore = inject(L1AssetsStoreService);
     private l2AssetsStore = inject(L2AssetsStoreService);
     private ethereumWalletChainManager = inject(EthereumWalletChainManager);
+    private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
     // Props
     private currentWallet: AppWallet | undefined;
@@ -36,6 +38,8 @@ export class AssetsManagerService {
         toObservable(this.walletService.getCurrentWalletSignal()).subscribe(
             this.onWalletChanged.bind(this));
         toObservable(this.ethereumWalletChainManager.getCurrentChainSignal()).subscribe(
+            this.reloadAllAssets.bind(this));
+        toObservable(this.kaspaL1NetworkService.getCurrentNetworkSignal()).subscribe(
             this.reloadAllAssets.bind(this));
     }
 

--- a/src/app/services/assets-manager/assets-stores/base-assets-store.service.ts
+++ b/src/app/services/assets-manager/assets-stores/base-assets-store.service.ts
@@ -64,11 +64,15 @@ export abstract class BaseAssetsStoreService<T extends BaseAssetStoreData> {
         };
     }
 
-    private notifyAssetListeners<K extends keyof T>(
+    protected notifyAssetListeners<K extends keyof T>(
         key: K,
         items: T[K][] | undefined,
     ): void {
         this.assetListeners[key]?.forEach((listener) => listener(items));
+    }
+
+    protected shouldLoadAsset(key: keyof T): boolean {
+        return true;
     }
 
     protected clearAllAssets(): void {
@@ -143,6 +147,13 @@ export abstract class BaseAssetsStoreService<T extends BaseAssetStoreData> {
             return;
         }
 
+        if (!this.shouldLoadAsset(key)) {
+            this.data[key].set([]);
+            this.notifyAssetListeners(key, []);
+            this.assetsLoaderInfo[key].loading.set(false);
+            return;
+        }
+
         this.assetsLoaderInfo[key].loading.set(true);
 
         try {
@@ -169,6 +180,13 @@ export abstract class BaseAssetsStoreService<T extends BaseAssetStoreData> {
         token = this.loadAssetTokens[key],
     ) {
         if (!this.isActiveLoad(key, generation, token)) {
+            return;
+        }
+
+        if (!this.shouldLoadAsset(key)) {
+            this.data[key].set([]);
+            this.notifyAssetListeners(key, []);
+            this.assetsLoaderInfo[key].loading.set(false);
             return;
         }
 

--- a/src/app/services/assets-manager/assets-stores/l1-assets-store.service.ts
+++ b/src/app/services/assets-manager/assets-stores/l1-assets-store.service.ts
@@ -9,6 +9,7 @@ import { KasplexKrc20Service } from "../../kasplex-api/kasplex-api.service";
 import { Krc721ApiService } from "../../krc721-api/krc721-api.service";
 import { KnsApiService } from "../../kns-api/kns-api.service";
 import { KaspaComApiService } from "../../kaspacom-api/kaspacom-api.service";
+import { KaspaL1NetworkService } from "../../kaspa-netwrok-services/kaspa-l1-network.service";
 import { L1AssetType } from "../enums/l1-asset-type.enum";
 import { L1_PAGINATION_CONFIG } from "../interfaces/pagination-state.interface";
 import _ from 'lodash';
@@ -44,6 +45,7 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
     protected krc721ApiService = inject(Krc721ApiService);
     protected knsApiService = inject(KnsApiService);
     protected kaspacomApiService = inject(KaspaComApiService);
+    protected kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
     // Pagination state for KRC721
     private krc721NextCursor: WritableSignal<number | undefined> = signal(undefined);
@@ -75,9 +77,33 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
     private krc20LoadedPages: WritableSignal<number> = signal(0); // Track pages loaded
 
     private readonly KRC20_PAGE_SIZE = L1_PAGINATION_CONFIG.krc20.pageSize;
+    private assetRequestGeneration = 0;
 
     constructor() {
         super();
+    }
+
+    public override startLoadingAllAssets(): void {
+        this.assetRequestGeneration++;
+        super.startLoadingAllAssets();
+    }
+
+    public override stopLoadingAllAssetsAndClear(): void {
+        this.assetRequestGeneration++;
+        super.stopLoadingAllAssetsAndClear();
+    }
+
+    private isCurrentAssetRequest(generation: number): boolean {
+        return generation === this.assetRequestGeneration;
+    }
+
+    private staleLoadMoreResult(nextCursor?: number | string): LoadMoreStoreResult {
+        return {
+            success: false,
+            itemsAdded: 0,
+            hasMore: false,
+            nextCursor,
+        };
     }
 
     protected override getLoadFunctionAssetsNames(): { [K in keyof L1AssetStoreData]: string } {
@@ -88,11 +114,36 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
         }
     }
 
+    protected override shouldLoadAsset(key: keyof L1AssetStoreData): boolean {
+        if (key === L1_ASSET_KEYS.krc20) {
+            return this.kaspaL1NetworkService.supportsKrc20Assets();
+        }
+        if (key === L1_ASSET_KEYS.krc721) {
+            return this.kaspaL1NetworkService.supportsKrc721Assets();
+        }
+        if (key === L1_ASSET_KEYS.kns) {
+            return this.kaspaL1NetworkService.supportsKnsAssets();
+        }
+        return true;
+    }
+
+    public supportsAssetType(assetType: L1AssetType): boolean {
+        return this.shouldLoadAsset(assetType as keyof L1AssetStoreData);
+    }
+
     /**
      * Load initial KRC20 tokens (first page only)
      * Smart auto-reload: Fetches as many items as user has already loaded
      */
     protected async getKrc20Info(walletAddress: string): Promise<GetTokenListDto[]> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKrc20Assets()) {
+            this.krc20NextCursor.set(undefined);
+            this.krc20HasMore.set(false);
+            this.krc20LoadedPages.set(0);
+            return [];
+        }
+
         const existingData = this.data['krc20']() as GetTokenListDto[] | undefined;
         const isAutoReload = existingData !== undefined && existingData.length > 0;
 
@@ -109,6 +160,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     null,
                 ),
             );
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return existingData;
+            }
 
             if (response.result && response.result.length > 0) {
                 const freshTokens: GetTokenListDto[] = response.result.map(
@@ -133,6 +187,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     });
                 } catch (error) {
                     console.error('Error fetching token prices during auto-reload:', error);
+                }
+                if (!this.isCurrentAssetRequest(requestGeneration)) {
+                    return existingData;
                 }
 
                 // Smart merge with deduplication
@@ -168,6 +225,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     null,
                 ),
             );
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return [];
+            }
 
             if (response.result && response.result.length > 0) {
                 const tokens: GetTokenListDto[] = response.result.map(
@@ -201,6 +261,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     });
                 } catch (error) {
                     console.error('Error fetching token prices:', error);
+                }
+                if (!this.isCurrentAssetRequest(requestGeneration)) {
+                    return [];
                 }
 
                 return tokens;
@@ -291,6 +354,16 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
      * Called by Krc20ListService when scrolling
      */
     async loadMoreKrc20Tokens(): Promise<LoadMoreStoreResult> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKrc20Assets()) {
+            return {
+                success: false,
+                itemsAdded: 0,
+                hasMore: false,
+                nextCursor: undefined
+            };
+        }
+
         const cursor = this.krc20NextCursor();
         const hasMore = this.krc20HasMore();
 
@@ -313,6 +386,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     'next',
                 ),
             );
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return this.staleLoadMoreResult(cursor ?? undefined);
+            }
 
             if (response.result && response.result.length > 0) {
                 const newTokens: GetTokenListDto[] = response.result.map(
@@ -342,6 +418,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     });
                 } catch (error) {
                     console.error('Error fetching token prices:', error);
+                }
+                if (!this.isCurrentAssetRequest(requestGeneration)) {
+                    return this.staleLoadMoreResult(cursor ?? undefined);
                 }
 
                 // Append to existing data
@@ -385,17 +464,37 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
      * Uses new Portfolio API
      */
     protected async getKrc721Info(walletAddress: string): Promise<Krc721Nft[]> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKrc721Assets()) {
+            this.krc721PortfolioSummary = [];
+            this.krc721PortfolioIndex = 0;
+            this.krc721TokenQueue = [];
+            this.krc721CollectionCache.clear();
+            this.krc721AvailableTickers.set([]);
+            this.krc721NextCursor.set(undefined);
+            this.krc721HasMore.set(false);
+            this.krc721LoadedPages.set(0);
+            return [];
+        }
+
         const existingData = this.data[L1_ASSET_KEYS.krc721]() as Krc721Nft[] | undefined || [];
         const isAutoReload = existingData.length > 0;
 
         try {
             // 1. Fetch summary
-            this.krc721PortfolioSummary = await firstValueFrom(this.krc721ApiService.getPortfolio(walletAddress));
+            const portfolioSummary = await firstValueFrom(this.krc721ApiService.getPortfolio(walletAddress));
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return existingData;
+            }
+            this.krc721PortfolioSummary = portfolioSummary;
 
             // Update available tickers
             this.krc721AvailableTickers.set(this.krc721PortfolioSummary.map(item => item.ticker));
         } catch (e) {
             console.error('Error fetching portfolio summary', e);
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return existingData;
+            }
             if (!isAutoReload) {
                 this.krc721PortfolioSummary = [];
             }
@@ -407,17 +506,20 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
         }
 
         // Initial fetch logic
-        return this.fetchInitialKrc721Data(walletAddress);
+        return this.fetchInitialKrc721Data(walletAddress, requestGeneration);
     }
 
-    private async fetchInitialKrc721Data(walletAddress: string): Promise<Krc721Nft[]> {
+    private async fetchInitialKrc721Data(walletAddress: string, requestGeneration: number): Promise<Krc721Nft[]> {
         // Reset internal state for fresh load
         this.krc721PortfolioIndex = 0;
         this.krc721TokenQueue = [];
         this.krc721CollectionCache.clear();
 
         // 2. Fetch first batch
-        const nfts = await this.fetchNextKrc721Batch(walletAddress);
+        const nfts = await this.fetchNextKrc721Batch(walletAddress, this.KRC721_PAGE_SIZE, requestGeneration);
+        if (!this.isCurrentAssetRequest(requestGeneration)) {
+            return [];
+        }
 
         // Update pagination
         this.krc721NextCursor.set(this.krc721PortfolioIndex);
@@ -583,6 +685,16 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
      * Called by Krc721ListService when scrolling
      */
     async loadMoreKrc721Nfts(): Promise<LoadMoreStoreResult> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKrc721Assets()) {
+            return {
+                success: false,
+                itemsAdded: 0,
+                hasMore: false,
+                nextCursor: undefined
+            };
+        }
+
         if (!this.krc721HasMore()) {
             return {
                 success: false,
@@ -594,7 +706,10 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
 
         try {
             const walletAddress = this.getWalletAddress();
-            const newNfts = await this.fetchNextKrc721Batch(walletAddress);
+            const newNfts = await this.fetchNextKrc721Batch(walletAddress, this.KRC721_PAGE_SIZE, requestGeneration);
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return this.staleLoadMoreResult(this.krc721PortfolioIndex);
+            }
 
             if (newNfts.length > 0) {
                 // Append to existing data
@@ -638,6 +753,15 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
      * Smart auto-reload: Fetches as many domains as user has already loaded
      */
     protected async getKnsInfo(walletAddress: string): Promise<KnsDomainAsset[]> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKnsAssets()) {
+            this.knsCurrentPage.set(1);
+            this.knsTotalPages.set(0);
+            this.knsHasMore.set(false);
+            this.knsLoadedPages.set(0);
+            return [];
+        }
+
         const existingData = this.data['kns']() as KnsDomainAsset[] | undefined;
         const isAutoReload = existingData !== undefined && existingData.length > 0;
 
@@ -657,6 +781,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                         this.KNS_PAGE_SIZE
                     )
                 );
+                if (!this.isCurrentAssetRequest(requestGeneration)) {
+                    return existingData;
+                }
 
                 if (response.data) {
                     allFreshDomains.push(...(response.data.assets || []));
@@ -700,6 +827,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     this.KNS_PAGE_SIZE
                 )
             );
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return [];
+            }
 
             if (response.data) {
                 const domains = response.data.assets || [];
@@ -722,6 +852,16 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
      * Called by KnsListService when scrolling
      */
     async loadMoreKnsDomains(): Promise<LoadMoreStoreResult> {
+        const requestGeneration = this.assetRequestGeneration;
+        if (!this.kaspaL1NetworkService.supportsKnsAssets()) {
+            return {
+                success: false,
+                itemsAdded: 0,
+                hasMore: false,
+                nextCursor: undefined
+            };
+        }
+
         const currentPage = this.knsCurrentPage();
         const totalPages = this.knsTotalPages();
         const hasMore = this.knsHasMore();
@@ -746,6 +886,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                     this.KNS_PAGE_SIZE
                 )
             );
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return this.staleLoadMoreResult(currentPage);
+            }
 
             if (response.data) {
                 const newDomains = response.data.assets || [];
@@ -791,16 +934,26 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
     /**
      * Helper to fetch next batch of KRC721 tokens from portfolio
      */
-    private async fetchNextKrc721Batch(walletAddress: string, targetCount = this.KRC721_PAGE_SIZE): Promise<Krc721Nft[]> {
+    private async fetchNextKrc721Batch(
+        walletAddress: string,
+        targetCount = this.KRC721_PAGE_SIZE,
+        requestGeneration = this.assetRequestGeneration,
+    ): Promise<Krc721Nft[]> {
         const results: Krc721Nft[] = [];
 
         // 1. Drain queue first
         while (this.krc721TokenQueue.length > 0 && results.length < targetCount) {
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return [];
+            }
             results.push(this.krc721TokenQueue.shift()!);
         }
 
         // 2. Fetch more if needed
         while (results.length < targetCount && this.krc721PortfolioIndex < this.krc721PortfolioSummary.length) {
+            if (!this.isCurrentAssetRequest(requestGeneration)) {
+                return [];
+            }
             const item = this.krc721PortfolioSummary[this.krc721PortfolioIndex];
             this.krc721PortfolioIndex++;
 
@@ -810,6 +963,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                 if (totalSupply === undefined) {
                     try {
                         const collectionDetails = await firstValueFrom(this.krc721ApiService.getCollectionDetails(item.ticker));
+                        if (!this.isCurrentAssetRequest(requestGeneration)) {
+                            return [];
+                        }
                         if (collectionDetails && collectionDetails.message === 'success') {
                             // Use max supply if totalSupply is missing, or minted if available
                             const supply = collectionDetails.result.totalSupply || collectionDetails.result.max || collectionDetails.result.minted;
@@ -825,6 +981,9 @@ export class L1AssetsStoreService extends BaseAssetsStoreService<L1AssetStoreDat
                 let details;
                 try {
                     details = await firstValueFrom(this.krc721ApiService.getPortfolioDetails(walletAddress, item.ticker));
+                    if (!this.isCurrentAssetRequest(requestGeneration)) {
+                        return [];
+                    }
                 } catch (e) {
                     // ignore error
                 }

--- a/src/app/services/assets-manager/base-l1-list.service.ts
+++ b/src/app/services/assets-manager/base-l1-list.service.ts
@@ -88,12 +88,13 @@ export abstract class BaseL1ListService<TAsset> {
   }
 
   reset(): void {
+    const shouldLoad = this.shouldLoadCurrentAsset();
     this.paginationStateSignal.set({
       cursor: undefined,
-      hasMore: true,
+      hasMore: shouldLoad,
       isLoading: false,
       pageSize: this.config.pageSize,
-      initialLoadComplete: false,
+      initialLoadComplete: !shouldLoad,
     });
     if (this.mergeFlagResetTimeout) {
       clearTimeout(this.mergeFlagResetTimeout);
@@ -109,6 +110,11 @@ export abstract class BaseL1ListService<TAsset> {
   }
 
   async loadInitial(): Promise<void> {
+    if (!this.shouldLoadCurrentAsset()) {
+      this.markUnsupportedAssetComplete();
+      return;
+    }
+
     if (this.paginationStateSignal().initialLoadComplete) {
       return;
     }
@@ -135,6 +141,17 @@ export abstract class BaseL1ListService<TAsset> {
 
   async loadMore(): Promise<LoadMoreResult> {
     const stateSnapshot = this.paginationStateSignal();
+
+    if (!this.shouldLoadCurrentAsset()) {
+      this.markUnsupportedAssetComplete();
+      return {
+        success: false,
+        itemsAdded: 0,
+        totalItems: this.itemsSignal().length,
+        hasMore: false,
+        status: PaginationStatus.IDLE,
+      };
+    }
 
     if (stateSnapshot.isLoading || !stateSnapshot.hasMore) {
       return {
@@ -198,6 +215,26 @@ export abstract class BaseL1ListService<TAsset> {
     return this.itemsSignal;
   }
 
+  private shouldLoadCurrentAsset(): boolean {
+    return this.l1AssetsStore.supportsAssetType(this.assetType);
+  }
+
+  private markUnsupportedAssetComplete(): void {
+    this.paginationStateSignal.set({
+      cursor: undefined,
+      hasMore: false,
+      isLoading: false,
+      pageSize: this.config.pageSize,
+      initialLoadComplete: true,
+    });
+    if (this.mergeFlagResetTimeout) {
+      clearTimeout(this.mergeFlagResetTimeout);
+      this.mergeFlagResetTimeout = undefined;
+    }
+    this.dataGrewFromMergeSignal.set(false);
+    this.previousLength = 0;
+  }
+
   private setupWalletWatcher(): void {
     effect(() => {
       const wallet = this.walletService.getCurrentWallet();
@@ -255,4 +292,3 @@ export abstract class BaseL1ListService<TAsset> {
     this.previousLength = currentLength;
   }
 }
-

--- a/src/app/services/assets-manager/base-l1-list.service.ts
+++ b/src/app/services/assets-manager/base-l1-list.service.ts
@@ -250,6 +250,16 @@ export abstract class BaseL1ListService<TAsset> {
   }
 
   private handleItemsUpdated(items: TAsset[] | undefined): void {
+    // The store emits `undefined` only when it is cleared (e.g. on an L1
+    // network switch). Reset pagination so the new network starts from a clean
+    // state instead of inheriting the previous network's hasMore/cursor/
+    // initialLoadComplete flags, which would otherwise block load-more when the
+    // address prefix is unchanged across the switch (e.g. TN10 -> TN12).
+    if (items === undefined) {
+      this.reset();
+      return;
+    }
+
     const currentState = this.paginationStateSignal();
     const hasItems = Array.isArray(items);
     const currentLength = hasItems ? items!.length : 0;

--- a/src/app/services/kaspa-api/kaspa-api.service.ts
+++ b/src/app/services/kaspa-api/kaspa-api.service.ts
@@ -1,14 +1,19 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { catchError, map, Observable, of } from 'rxjs';
-import { environment } from '../../../environments/environment';
 import { FullTransactionResponse } from './dtos/full-transaction-response.dto';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Injectable({ providedIn: 'root' })
 export class KaspaApiService {
-  baseurl = environment.kaspaApiBaseurl;
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
+  ) {}
 
-  constructor(private readonly httpClient: HttpClient) {}
+  get baseurl(): string {
+    return this.kaspaL1NetworkService.getKaspaApiBaseurl();
+  }
 
   getFullTransactions(walletAddress: string, resolvePreviousOutputs: string = 'light', limit: number = 10): Observable<FullTransactionResponse> {
     const url = `${this.baseurl}/addresses/${walletAddress}/full-transactions?resolve_previous_outpoints=${resolvePreviousOutputs}&limit=${limit}`;

--- a/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { L1NetworkConfigInterface } from '../../../environments/environment.interface';
+import { KASPA_NETWORKS, LOCAL_STORAGE_KEYS } from '../../config/consts';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class KaspaL1NetworkService {
+  private readonly networks: L1NetworkConfigInterface[] =
+    environment.l1Config.networks?.length
+      ? environment.l1Config.networks
+      : [];
+
+  private readonly currentNetworkSignal: WritableSignal<L1NetworkConfigInterface> =
+    signal(this.resolveInitialNetwork());
+
+  getAvailableNetworks(): L1NetworkConfigInterface[] {
+    return this.networks;
+  }
+
+  getCurrentNetworkSignal(): Signal<L1NetworkConfigInterface> {
+    return this.currentNetworkSignal.asReadonly();
+  }
+
+  getCurrentNetwork(): L1NetworkConfigInterface {
+    return this.currentNetworkSignal();
+  }
+
+  getNetworkId(): string {
+    return this.getCurrentNetwork().network;
+  }
+
+  isMainnet(): boolean {
+    return this.getNetworkId() === KASPA_NETWORKS.MAINNET;
+  }
+
+  getKaspaApiBaseurl(): string {
+    return this.getCurrentNetwork().kaspaApiBaseurl;
+  }
+
+  getKaspaComApiBaseurl(): string {
+    return this.getCurrentNetwork().kaspaComApiBaseurl;
+  }
+
+  getKaspaComDefiApiBaseurl(): string {
+    return this.getCurrentNetwork().kaspaComDefiApiBaseurl;
+  }
+
+  getKasplexApiBaseurl(): string | undefined {
+    return this.getCurrentNetwork().kasplexApiBaseurl;
+  }
+
+  getKrc721ApiBaseurl(): string | undefined {
+    return this.getCurrentNetwork().krc721ApiBaseurl;
+  }
+
+  getKrc721CacheStreamUrl(): string | undefined {
+    return this.getCurrentNetwork().krc721CacheStreamUrl;
+  }
+
+  getKnsApiBaseurl(): string | undefined {
+    return this.getCurrentNetwork().knsApiBaseurl;
+  }
+
+  getKaspaExplorerBaseurl(): string {
+    return this.getCurrentNetwork().kaspaExplorerBaseurl;
+  }
+
+  supportsKrc20Assets(): boolean {
+    return !!this.getKasplexApiBaseurl();
+  }
+
+  supportsKrc721Assets(): boolean {
+    return !!this.getKrc721ApiBaseurl();
+  }
+
+  supportsKnsAssets(): boolean {
+    return !!this.getKnsApiBaseurl();
+  }
+
+  setCurrentNetwork(network: string): boolean {
+    const nextNetwork = this.networks.find((item) => item.network === network);
+    if (!nextNetwork) {
+      return false;
+    }
+
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.KASPA_L1_NETWORK, network);
+    } catch (err) {
+      console.warn('Failed saving Kaspa L1 network to localStorage', err);
+    }
+
+    this.currentNetworkSignal.set(nextNetwork);
+    return true;
+  }
+
+  private resolveInitialNetwork(): L1NetworkConfigInterface {
+    const defaultNetwork =
+      this.networks.find((item) => item.network === environment.kaspaNetwork) ??
+      this.networks[0];
+
+    try {
+      const storedNetwork = localStorage.getItem(
+        LOCAL_STORAGE_KEYS.KASPA_L1_NETWORK,
+      );
+      return (
+        this.networks.find((item) => item.network === storedNetwork) ??
+        defaultNetwork
+      );
+    } catch (err) {
+      console.warn('Failed reading Kaspa L1 network from localStorage', err);
+      return defaultNetwork;
+    }
+  }
+}

--- a/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
@@ -96,6 +96,12 @@ export class KaspaL1NetworkService {
   }
 
   private resolveInitialNetwork(): L1NetworkConfigInterface {
+    if (!this.networks.length) {
+      throw new Error(
+        'No Kaspa L1 networks configured. Check environment.l1Config.networks.',
+      );
+    }
+
     const defaultNetwork =
       this.networks.find((item) => item.network === environment.kaspaNetwork) ??
       this.networks[0];

--- a/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-l1-network.service.ts
@@ -16,7 +16,7 @@ export class KaspaL1NetworkService {
     signal(this.resolveInitialNetwork());
 
   getAvailableNetworks(): L1NetworkConfigInterface[] {
-    return this.networks;
+    return [...this.networks];
   }
 
   getCurrentNetworkSignal(): Signal<L1NetworkConfigInterface> {

--- a/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
@@ -13,6 +13,8 @@ const MAX_RECONNECT_DELAY = 30 * 1000;
 })
 export class KaspaNetworkConnectionManagerService implements OnDestroy {
   private connectionPromise?: Promise<void>;
+  private connectionGeneration = 0;
+  private activeConnectingRpc?: RpcClient;
   private reconnectTimeout?: ReturnType<typeof setTimeout>;
   private reconnectScheduledFor?: number;
   private reconnectAttempts = 0;
@@ -79,7 +81,15 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
     });
   }
 
-  private scheduleReconnect(reason: string, delay?: number): void {
+  private scheduleReconnect(
+    reason: string,
+    delay?: number,
+    generation = this.connectionGeneration,
+  ): void {
+    if (generation !== this.connectionGeneration) {
+      return;
+    }
+
     if (this.reconnectTimeout) {
       // Backoff retries (no explicit delay) yield to whatever is already scheduled.
       // Explicit-delay callers (online/visibility resume) preempt only if sooner.
@@ -99,6 +109,10 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
     const reconnectDelay = delay ?? this.getReconnectDelay();
     this.reconnectScheduledFor = Date.now() + reconnectDelay;
     this.reconnectTimeout = setTimeout(() => {
+      if (generation !== this.connectionGeneration) {
+        return;
+      }
+
       this.reconnectTimeout = undefined;
       this.reconnectScheduledFor = undefined;
 
@@ -128,7 +142,10 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
     return Math.min(exponentialDelay + jitter, MAX_RECONNECT_DELAY);
   }
 
-  private async handleConnection(forceRefresh = false): Promise<void> {
+  private async handleConnection(
+    forceRefresh = false,
+    generation = this.connectionGeneration,
+  ): Promise<void> {
     console.log('Trying to connect to RPC...');
 
     const currentRpc = forceRefresh
@@ -139,12 +156,18 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
       throw new Error('RPC client is not initialized');
     }
 
+    if (generation !== this.connectionGeneration) {
+      await this.disconnectRpc(currentRpc);
+      throw new Error('RPC client was replaced before connecting');
+    }
+
+    this.activeConnectingRpc = currentRpc;
     this.attachDisconnectHandler(currentRpc);
 
     try {
       await this.withTimeout(currentRpc.connect(), CONNECTION_TIMEOUT, 'Rpc connection timeout');
 
-      if (this.rpcService.getRpc() !== currentRpc) {
+      if (generation !== this.connectionGeneration || this.rpcService.getRpc() !== currentRpc) {
         await this.disconnectRpc(currentRpc);
         throw new Error('RPC client was replaced while connecting');
       }
@@ -155,11 +178,27 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
       }
     } catch (err) {
       await this.disconnectRpc(currentRpc);
-      this.setSignalStatusIfChanged(RpcConnectionStatus.DISCONNECTED);
-      this.scheduleReconnect('connection-failure');
+      if (this.activeConnectingRpc === currentRpc) {
+        this.activeConnectingRpc = undefined;
+      }
+      if (generation === this.connectionGeneration) {
+        this.setSignalStatusIfChanged(RpcConnectionStatus.DISCONNECTED);
+        this.scheduleReconnect('connection-failure', undefined, generation);
+      }
       throw err;
     }
 
+    if (generation !== this.connectionGeneration) {
+      await this.disconnectRpc(currentRpc);
+      if (this.activeConnectingRpc === currentRpc) {
+        this.activeConnectingRpc = undefined;
+      }
+      throw new Error('RPC client was replaced while connecting');
+    }
+
+    if (this.activeConnectingRpc === currentRpc) {
+      this.activeConnectingRpc = undefined;
+    }
     this.reconnectAttempts = 0;
     this.setSignalStatusIfChanged(RpcConnectionStatus.CONNECTED);
     console.log('RPC Connected Successfully');
@@ -219,21 +258,37 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
       return;
     }
 
+    if (forceRefresh) {
+      this.connectionGeneration++;
+      this.clearReconnectTimeout();
+      this.reconnectAttempts = 0;
+      if (this.activeConnectingRpc) {
+        void this.disconnectRpc(this.activeConnectingRpc);
+        this.activeConnectingRpc = undefined;
+      }
+      this.connectionPromise = undefined;
+    }
+
     if (this.connectionPromise) {
       return this.connectionPromise;
     }
 
+    const generation = this.connectionGeneration;
     this.clearReconnectTimeout();
 
     this.setSignalStatusIfChanged(RpcConnectionStatus.CONNECTING);
 
-    this.connectionPromise = this.handleConnection(forceRefresh)
+    this.connectionPromise = this.handleConnection(forceRefresh, generation)
       .catch((err) => {
-        this.setSignalStatusIfChanged(RpcConnectionStatus.DISCONNECTED);
+        if (generation === this.connectionGeneration) {
+          this.setSignalStatusIfChanged(RpcConnectionStatus.DISCONNECTED);
+        }
         throw err;
       })
       .finally(() => {
-        this.connectionPromise = undefined;
+        if (generation === this.connectionGeneration) {
+          this.connectionPromise = undefined;
+        }
       });
 
     return this.connectionPromise;

--- a/src/app/services/kaspa-netwrok-services/rpc.service.ts
+++ b/src/app/services/kaspa-netwrok-services/rpc.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Encoding, Resolver, RpcClient } from '../../../../public/kaspa/kaspa';
-import { environment } from '../../../environments/environment';
 import { LOCAL_STORAGE_KEYS } from '../../config/consts';
+import { KaspaL1NetworkService } from './kaspa-l1-network.service';
 
 @Injectable({
   providedIn: 'root',
@@ -10,8 +10,8 @@ export class RpcService {
   private RPC?: RpcClient;
   private network: string;
 
-  constructor() {
-    this.network = environment.kaspaNetwork;
+  constructor(private readonly kaspaL1NetworkService: KaspaL1NetworkService) {
+    this.network = this.kaspaL1NetworkService.getNetworkId();
     this.refreshRpc();
   }
 
@@ -21,6 +21,7 @@ export class RpcService {
 
   refreshRpc() {
     const previousRpc = this.RPC;
+    this.network = this.kaspaL1NetworkService.getNetworkId();
     let storedRpcUrl: string | null = null;
     try {
       storedRpcUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL);
@@ -45,6 +46,23 @@ export class RpcService {
     this.disconnectRpc(previousRpc);
 
     return this.getRpc();
+  }
+
+  setNetwork(network: string): boolean {
+    if (!this.kaspaL1NetworkService.setCurrentNetwork(network)) {
+      return false;
+    }
+
+    this.network = this.kaspaL1NetworkService.getNetworkId();
+
+    try {
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.RPC_URL);
+    } catch (err) {
+      console.warn('Failed clearing custom RPC URL from localStorage', err);
+    }
+
+    this.refreshRpc();
+    return true;
   }
 
   private disconnectRpc(rpc: RpcClient | undefined): void {

--- a/src/app/services/kaspacom-api/kaspacom-api.service.ts
+++ b/src/app/services/kaspacom-api/kaspacom-api.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-import { environment } from '../../../environments/environment';
 import { Krc20PortfolioResponse } from './dtos/krc20-prortfolio';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 
 export type TokenLogoResult = { ticker: string, logo: string };
@@ -10,9 +10,14 @@ export type TokenLogosResult = TokenLogoResult[];
 
 @Injectable({ providedIn: 'root' })
 export class KaspaComApiService {
-  baseurl = environment.kaspaComApiBaseurl;
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
+  ) { }
 
-  constructor(private readonly httpClient: HttpClient) { }
+  get baseurl(): string {
+    return this.kaspaL1NetworkService.getKaspaComApiBaseurl();
+  }
 
 
   async getTokensPrices(

--- a/src/app/services/kaspacom-api/kaspacom-defi-api.service.ts
+++ b/src/app/services/kaspacom-api/kaspacom-defi-api.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom, map, catchError, of } from 'rxjs';
-import { environment } from '../../../environments/environment';
 import { DexApiWalletToken } from './dtos/dex-api-wallet-tokens.interface';
 import { EthereumWalletChainManager } from '../etherium-services/etherium-wallet-chain.manager';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 export interface DexTokenSearchResult {
   id: string;
@@ -76,12 +76,15 @@ const EXPLORER_CONTROLLER = 'explorer';
 
 @Injectable({ providedIn: 'root' })
 export class KaspaComDefiApiService {
-  baseurl = environment.kaspaComDefiApiBaseurl;
-
   constructor(
     private readonly httpClient: HttpClient,
     private readonly ethereumWalletChainManager: EthereumWalletChainManager,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
   ) {}
+
+  get baseurl(): string {
+    return this.kaspaL1NetworkService.getKaspaComDefiApiBaseurl();
+  }
 
   private buildHttpParamsWithNetwork(params?: Record<string, any>): HttpParams {
     const chainId = this.ethereumWalletChainManager.getCurrentChainSignal()();

--- a/src/app/services/kasplex-api/kasplex-api.service.ts
+++ b/src/app/services/kasplex-api/kasplex-api.service.ts
@@ -6,16 +6,25 @@ import {
   GetTokenInfoResponse,
   GetTokenListResponse,
 } from './dtos/token-list-info.dto';
-import { environment } from '../../../environments/environment';
 import { ListingInfoResponse } from './dtos/listing-info-response.dto';
 import { OperationDetailsResponse } from './dtos/operation-details-response';
 import { GetWalletOperationsResponse } from './dtos/get-wallet-operations-response.dto';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Injectable({ providedIn: 'root' })
 export class KasplexKrc20Service {
-  baseurl = environment.kasplexApiBaseurl;
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
+  ) {}
 
-  constructor(private readonly httpClient: HttpClient) {}
+  get baseurl(): string | undefined {
+    return this.kaspaL1NetworkService.getKasplexApiBaseurl();
+  }
+
+  private emptyTokenListResponse(): GetTokenListResponse {
+    return { message: 'successful', prev: null, next: null, result: [] };
+  }
 
   getWalletTokenList(
     address: string,
@@ -27,6 +36,10 @@ export class KasplexKrc20Service {
       queryParam = `?${direction}=${paginationKey}`;
     }
 
+    if (!this.baseurl) {
+      return of(this.emptyTokenListResponse());
+    }
+
     const url = `${this.baseurl}/krc20/address/${address}/tokenlist${queryParam}`;
 
     return this.httpClient.get<GetTokenListResponse>(url)
@@ -36,6 +49,10 @@ export class KasplexKrc20Service {
     address: string,
     ticker: string
   ): Observable<GetTokenWalletInfoResponse> {
+    if (!this.baseurl) {
+      return of({ message: 'successful', result: [] });
+    }
+
     const url = `${this.baseurl}/krc20/address/${address}/token/${ticker}`;
     return this.httpClient.get<GetTokenWalletInfoResponse>(url);
   }
@@ -44,6 +61,10 @@ export class KasplexKrc20Service {
     address: string,
     ticker?: string,
   ): Observable<GetWalletOperationsResponse> {
+
+    if (!this.baseurl) {
+      return of({ message: 'successful', prev: '', next: '', result: [] });
+    }
 
     const url = `${this.baseurl}/krc20/oplist`;
 
@@ -57,6 +78,10 @@ export class KasplexKrc20Service {
   }
 
   getTokenInfo(ticker: string): Observable<GetTokenInfoResponse> {
+    if (!this.baseurl) {
+      return of({ message: 'successful' });
+    }
+
     const url = `${this.baseurl}/krc20/token/${ticker}`;
 
     return this.httpClient.get<GetTokenInfoResponse>(url);
@@ -67,6 +92,10 @@ export class KasplexKrc20Service {
     walletAddress?: string,
     txid?: string
   ): Observable<ListingInfoResponse> {
+    if (!this.baseurl) {
+      return of({ message: 'successful', prev: '', next: '', result: [] });
+    }
+
     const url = `${this.baseurl}/krc20/market/${ticker}`;
 
     const params: { address?: string; txid?: string } = {};
@@ -85,6 +114,10 @@ export class KasplexKrc20Service {
   getOperationDetails(
     operationTransactionId: string
   ): Observable<OperationDetailsResponse> {
+    if (!this.baseurl) {
+      return of({ message: 'successful', result: [] });
+    }
+
     const url = `${this.baseurl}/krc20/op/${operationTransactionId}`;
 
     return this.httpClient.get<OperationDetailsResponse>(url);

--- a/src/app/services/kns-api/kns-api.service.ts
+++ b/src/app/services/kns-api/kns-api.service.ts
@@ -53,8 +53,14 @@ export class KnsApiService {
       .get<KnsDomainResponse>(`${this.baseUrl}/api/v1/asset/${assetId}/detail`)
       .pipe(
         catchError((error) => {
+          // Only a 404 means "asset not found"; surface other failures
+          // (transient 5xx/network) so callers' try/catch can distinguish an
+          // API error from a missing asset.
+          if (error?.status === 404) {
+            return of({ data: null as any });
+          }
           console.error(`Error fetching asset by ID ${assetId}:`, error);
-          return of({ data: null as any });
+          return throwError(() => error);
         })
       );
   }

--- a/src/app/services/kns-api/kns-api.service.ts
+++ b/src/app/services/kns-api/kns-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, catchError, of, map } from 'rxjs';
+import { Observable, catchError, of, map, throwError } from 'rxjs';
 import {
   KnsDomainAsset,
   KnsDomainsResponse,
@@ -44,7 +44,9 @@ export class KnsApiService {
    */
   fetchAssetByAssetId(assetId: string): Observable<KnsDomainResponse> {
     if (!this.baseUrl) {
-      return of({ data: null as any });
+      return throwError(
+        () => new Error('KNS is not supported on the current network'),
+      );
     }
 
     return this.httpClient

--- a/src/app/services/kns-api/kns-api.service.ts
+++ b/src/app/services/kns-api/kns-api.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, of, map } from 'rxjs';
-import { environment } from '../../../environments/environment';
 import {
   KnsDomainAsset,
   KnsDomainsResponse,
@@ -13,17 +12,41 @@ import {
   KnsWalletAssetsStatus,
   KnsDomainCollection
 } from './dtos/kns-domain.dto';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Injectable({ providedIn: 'root' })
 export class KnsApiService {
-  private baseUrl = environment.knsApiBaseurl;
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
+  ) {}
 
-  constructor(private readonly httpClient: HttpClient) {}
+  private get baseUrl(): string | undefined {
+    return this.kaspaL1NetworkService.getKnsApiBaseurl();
+  }
+
+  private emptyDomainsResponse(page = 1, pageSize = 20): KnsDomainsResponse {
+    return {
+      data: {
+        assets: [],
+        pagination: {
+          currentPage: page,
+          totalPages: 0,
+          totalItems: 0,
+          itemsPerPage: pageSize,
+        },
+      },
+    };
+  }
 
   /**
    * Fetch asset details by asset ID
    */
   fetchAssetByAssetId(assetId: string): Observable<KnsDomainResponse> {
+    if (!this.baseUrl) {
+      return of({ data: null as any });
+    }
+
     return this.httpClient
       .get<KnsDomainResponse>(`${this.baseUrl}/api/v1/asset/${assetId}/detail`)
       .pipe(
@@ -44,6 +67,10 @@ export class KnsApiService {
     asset?: string,
     status?: KnsWalletAssetsStatus
   ): Observable<KnsDomainsResponse> {
+    if (!this.baseUrl) {
+      return of(this.emptyDomainsResponse(page, pageSize));
+    }
+
     if (pageSize > 100) {
       throw new Error('Max page size is 100');
     }
@@ -93,6 +120,10 @@ export class KnsApiService {
     asset?: string,
     owner?: string
   ): Observable<KnsDomainsResponse> {
+    if (!this.baseUrl) {
+      return of(this.emptyDomainsResponse(page, pageSize));
+    }
+
     let params = new HttpParams()
       .set('page', page.toString())
       .set('pageSize', pageSize.toString())
@@ -138,6 +169,10 @@ export class KnsApiService {
    * Expects domain to be URL-encoded as per KNS documentation requirements
    */
   fetchDomainInfo(domain: string): Observable<KnsDomainAsset | undefined> {
+    if (!this.baseUrl) {
+      return of(undefined);
+    }
+
     // Decode the domain to get the original form for comparison
     const decodedDomain = decodeURIComponent(domain);
     const decodedDomainWithoutSuffix = decodedDomain.replace('.kas', '');
@@ -167,6 +202,10 @@ export class KnsApiService {
     assetId: string,
     textRecords: { [key: string]: string }
   ): Observable<{ success: boolean; message?: string }> {
+    if (!this.baseUrl) {
+      return of({ success: false, message: 'KNS is not supported on the selected network' });
+    }
+
     return this.httpClient
       .post<{ success: boolean; message?: string }>(
         `${this.baseUrl}/api/v1/asset/${assetId}/text`,
@@ -187,6 +226,10 @@ export class KnsApiService {
     assetId: string,
     toAddress: string
   ): Observable<{ success: boolean; txId?: string; message?: string }> {
+    if (!this.baseUrl) {
+      return of({ success: false, message: 'KNS is not supported on the selected network' });
+    }
+
     return this.httpClient
       .post<{ success: boolean; txId?: string; message?: string }>(
         `${this.baseUrl}/api/v1/asset/${assetId}/transfer`,

--- a/src/app/services/krc721-api/krc721-api.service.ts
+++ b/src/app/services/krc721-api/krc721-api.service.ts
@@ -100,7 +100,9 @@ export class Krc721ApiService {
 
   getCollectionDetails(tick: string): Observable<Krc721CollectionResponse> {
     if (!this.baseUrl) {
-      return of({ message: 'error', result: null as any });
+      return throwError(
+        () => new Error('KRC721 is not supported on the current network'),
+      );
     }
 
     return this.httpClient

--- a/src/app/services/krc721-api/krc721-api.service.ts
+++ b/src/app/services/krc721-api/krc721-api.service.ts
@@ -118,7 +118,9 @@ export class Krc721ApiService {
   // NFTs / Tokens
   getTokenDetails(tick: string, tokenId: string): Observable<Krc721NftResponse> {
     if (!this.baseUrl) {
-      return of({ message: 'error', result: null as any });
+      return throwError(
+        () => new Error('KRC721 is not supported on the current network'),
+      );
     }
 
     return this.httpClient
@@ -227,7 +229,9 @@ export class Krc721ApiService {
 
   getOperationByScore(score: string): Observable<{ message: string; result: Krc721Operation }> {
     if (!this.baseUrl) {
-      return of({ message: 'error', result: null as any });
+      return throwError(
+        () => new Error('KRC721 is not supported on the current network'),
+      );
     }
 
     return this.httpClient
@@ -242,7 +246,9 @@ export class Krc721ApiService {
 
   getOperationByTxId(txId: string): Observable<{ message: string; result: Krc721Operation }> {
     if (!this.baseUrl) {
-      return of({ message: 'error', result: null as any });
+      return throwError(
+        () => new Error('KRC721 is not supported on the current network'),
+      );
     }
 
     return this.httpClient

--- a/src/app/services/krc721-api/krc721-api.service.ts
+++ b/src/app/services/krc721-api/krc721-api.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, of, throwError } from 'rxjs';
-import { environment } from '../../../environments/environment';
 import { 
   Krc721Collection, 
   Krc721CollectionResponse, 
@@ -19,16 +18,33 @@ import {
   Krc721OperationsResponse 
 } from './dtos/krc721-operations.dto';
 import { Krc721PortfolioDetailResponse, Krc721PortfolioResponse } from './dtos/krc721-portfolio.dto';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Injectable({ providedIn: 'root' })
 export class Krc721ApiService {
-  private baseUrl = environment.krc721ApiBaseurl;
-  private kaspaComBaseUrl = environment.kaspaComApiBaseurl;
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
+  ) {}
 
-  constructor(private readonly httpClient: HttpClient) {}
+  private get baseUrl(): string | undefined {
+    return this.kaspaL1NetworkService.getKrc721ApiBaseurl();
+  }
+
+  private get kaspaComBaseUrl(): string | undefined {
+    return this.kaspaL1NetworkService.getKaspaComApiBaseurl();
+  }
+
+  private get cacheStreamUrl(): string | undefined {
+    return this.kaspaL1NetworkService.getKrc721CacheStreamUrl();
+  }
 
   // Portfolio
   getPortfolio(address: string): Observable<Krc721PortfolioResponse> {
+    if (!this.baseUrl || !this.kaspaComBaseUrl) {
+      return of([]);
+    }
+
     const params = new HttpParams().set('walletAddress', address);
     return this.httpClient.get<Krc721PortfolioResponse>(`${this.kaspaComBaseUrl}/krc721/portfolio`, { params })
       .pipe(
@@ -40,6 +56,10 @@ export class Krc721ApiService {
   }
 
   getPortfolioDetails(address: string, ticker: string): Observable<Krc721PortfolioDetailResponse> {
+    if (!this.baseUrl || !this.kaspaComBaseUrl) {
+      return of([]);
+    }
+
     const params = new HttpParams()
       .set('walletAddress', address)
       .set('ticker', ticker.toUpperCase()); // Ensure ticker is uppercase
@@ -59,6 +79,10 @@ export class Krc721ApiService {
     limit: number = 50,
     direction: 'forward' | 'backward' = 'forward'
   ): Observable<Krc721CollectionsResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     const params = new HttpParams()
       .set('offset', offset.toString())
       .set('limit', limit.toString())
@@ -75,6 +99,10 @@ export class Krc721ApiService {
   }
 
   getCollectionDetails(tick: string): Observable<Krc721CollectionResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: null as any });
+    }
+
     return this.httpClient
       .get<Krc721CollectionResponse>(`${this.baseUrl}/nfts/${tick}`)
       .pipe(
@@ -87,6 +115,10 @@ export class Krc721ApiService {
 
   // NFTs / Tokens
   getTokenDetails(tick: string, tokenId: string): Observable<Krc721NftResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: null as any });
+    }
+
     return this.httpClient
       .get<Krc721NftResponse>(`${this.baseUrl}/nfts/${tick}/${tokenId}`)
       .pipe(
@@ -104,6 +136,10 @@ export class Krc721ApiService {
     limit?: number,
     direction: 'forward' | 'backward' = 'forward'
   ): Observable<Krc721NftsResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     let params = new HttpParams();
     if (offset !== undefined) params = params.set('offset', offset.toString());
     if (limit !== undefined) params = params.set('limit', limit.toString());
@@ -123,6 +159,10 @@ export class Krc721ApiService {
     address: string,
     tick: string
   ): Observable<Krc721NftsResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     return this.httpClient
       .get<Krc721NftsResponse>(`${this.baseUrl}/address/${address}/${tick}`)
       .pipe(
@@ -142,6 +182,10 @@ export class Krc721ApiService {
     offset?: number,
     limit?: number
   ): Observable<Krc721TokenOwnersResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     let params = new HttpParams();
     if (offset !== undefined) params = params.set('offset', offset.toString());
     if (limit !== undefined) params = params.set('limit', limit.toString());
@@ -161,6 +205,10 @@ export class Krc721ApiService {
     offset?: string,
     direction: 'forward' | 'backward' = 'forward'
   ): Observable<Krc721OperationsResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     let params = new HttpParams();
     if (offset) params = params.set('offset', offset);
     params = params.set('direction', direction);
@@ -176,6 +224,10 @@ export class Krc721ApiService {
   }
 
   getOperationByScore(score: string): Observable<{ message: string; result: Krc721Operation }> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: null as any });
+    }
+
     return this.httpClient
       .get<{ message: string; result: Krc721Operation }>(`${this.baseUrl}/ops/score/${score}`)
       .pipe(
@@ -187,6 +239,10 @@ export class Krc721ApiService {
   }
 
   getOperationByTxId(txId: string): Observable<{ message: string; result: Krc721Operation }> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: null as any });
+    }
+
     return this.httpClient
       .get<{ message: string; result: Krc721Operation }>(`${this.baseUrl}/ops/txid/${txId}`)
       .pipe(
@@ -202,6 +258,10 @@ export class Krc721ApiService {
     address: string,
     tick: string
   ): Observable<{ message: string; result: string }> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: '0' });
+    }
+
     return this.httpClient
       .get<{ message: string; result: string }>(`${this.baseUrl}/royalties/${address}/${tick}`)
       .pipe(
@@ -219,6 +279,10 @@ export class Krc721ApiService {
   getRejectionReason(
     txId: string
   ): Observable<{ message: string; result: string }> {
+    if (!this.baseUrl) {
+      return of({ message: 'error', result: '' });
+    }
+
     return this.httpClient
       .get<{ message: string; result: string }>(`${this.baseUrl}/rejections/txid/${txId}`)
       .pipe(
@@ -235,6 +299,10 @@ export class Krc721ApiService {
     tokenId: string,
     offset?: string
   ): Observable<Krc721TokenOwnersResponse> {
+    if (!this.baseUrl) {
+      return of({ message: 'success', result: [] });
+    }
+
     let params = new HttpParams();
     if (offset) params = params.set('offset', offset);
 
@@ -279,7 +347,11 @@ export class Krc721ApiService {
   // Load NFT metadata from cache
   getNftMetadata(tick: string, tokenId: string): Observable<any> {
 
-    const metadataUrl = `${environment.krc721CacheStreamUrl}/metadata/${tick}/${tokenId}`;
+    if (!this.cacheStreamUrl) {
+      return of(null);
+    }
+
+    const metadataUrl = `${this.cacheStreamUrl}/metadata/${tick}/${tokenId}`;
     
     return this.httpClient
       .get<any>(metadataUrl)

--- a/src/app/services/krc721-api/krc721-api.service.ts
+++ b/src/app/services/krc721-api/krc721-api.service.ts
@@ -109,8 +109,14 @@ export class Krc721ApiService {
       .get<Krc721CollectionResponse>(`${this.baseUrl}/nfts/${tick}`)
       .pipe(
         catchError((error) => {
+          // Only a 404 means "ticker not found"; surface other failures
+          // (transient 5xx/network) so callers' try/catch can react rather
+          // than misclassifying them as an available ticker.
+          if (error?.status === 404) {
+            return of({ message: 'error', result: null as any });
+          }
           console.error(`Error fetching collection details for ${tick}:`, error);
-          return of({ message: 'error', result: null as any });
+          return throwError(() => error);
         })
       );
   }
@@ -127,8 +133,13 @@ export class Krc721ApiService {
       .get<Krc721NftResponse>(`${this.baseUrl}/nfts/${tick}/${tokenId}`)
       .pipe(
         catchError((error) => {
+          // Only a 404 means "token not found"; surface other failures so
+          // ownership validation doesn't treat a transient error as not-found.
+          if (error?.status === 404) {
+            return of({ message: 'error', result: null as any });
+          }
           console.error(`Error fetching token details for ${tick}/${tokenId}:`, error);
-          return of({ message: 'error', result: null as any });
+          return throwError(() => error);
         })
       );
   }

--- a/src/app/services/l2-services/l2-token-prices.service.ts
+++ b/src/app/services/l2-services/l2-token-prices.service.ts
@@ -16,6 +16,7 @@ import type {
   VerifiedTokenExternalUsdPriceInterface,
   VerifiedTokenInterface,
 } from '../../../environments/environment.interface';
+import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
 
 const NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 const LP_PAIR_ABI = [
@@ -57,6 +58,7 @@ export class L2TokenPricesService implements OnDestroy {
   private chainManager = inject(EthereumWalletChainManager);
   private kaspaPrice = inject(KaspaPriceService);
   private http = inject(HttpClient);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   // Cache stores KAS amounts (the expensive on-chain part), keyed by `chainId:address`
   private _kasAmounts = signal<Map<string, CachedKasAmount>>(new Map());
@@ -436,7 +438,7 @@ export class L2TokenPricesService implements OnDestroy {
         routerAddress: cc.swapContracts.routerAddress,
         factoryAddress: cc.swapContracts.factoryAddress,
         proxyAddress: cc.swapContracts.proxyAddress,
-        badckendApiUrl: environment.kaspaComDefiApiBaseurl,
+        badckendApiUrl: this.kaspaL1NetworkService.getKaspaComDefiApiBaseurl(),
         blockExplorerUrl: cc.blockExplorerUrl,
         defiApiNetworkName: cc.defiApiNetworkName,
         nativeToken: {

--- a/src/app/services/l2-services/l2-token-prices.service.ts
+++ b/src/app/services/l2-services/l2-token-prices.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, OnDestroy, signal } from '@angular/core';
+import { computed, effect, inject, Injectable, OnDestroy, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { Contract, formatUnits, JsonRpcProvider } from 'ethers';
@@ -98,6 +98,16 @@ export class L2TokenPricesService implements OnDestroy {
   private contextByChain = new Map<string, ChainSwapContext>();
   // Map value: backoff expiry timestamp ms — address is skipped until Date.now() exceeds it
   private readonly _nonLpAddresses = new Map<string, number>();
+
+  constructor() {
+    // Cached swap contexts bake in the L1-derived DeFi base URL, so rebuild
+    // them whenever the selected L1 network changes — otherwise swap/pairs
+    // requests keep hitting the previous network's DeFi endpoint.
+    effect(() => {
+      this.kaspaL1NetworkService.getCurrentNetworkSignal()();
+      this.contextByChain.clear();
+    });
+  }
 
   async getPriceMap(
     tokens: Erc20Token[],

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { environment } from '../../environments/environment';
-import { KASPA_NETWORKS } from '../config/consts';
+import { KaspaL1NetworkService } from './kaspa-netwrok-services/kaspa-l1-network.service';
 
 const WALLET_ADDRESS_VALIDATION_REGEX_MAINNET = /^kaspa:(q|p)[a-z0-9]{54,90}$/;
 const WALLET_ADDRESS_VALIDATION_REGEX_TESTNET =
@@ -10,6 +9,8 @@ const WALLET_ADDRESS_VALIDATION_REGEX_TESTNET =
   providedIn: 'root',
 })
 export class UtilsHelper {
+  private readonly kaspaL1NetworkService = inject(KaspaL1NetworkService);
+
   async retryOnError<T>(
     fn: () => Promise<T>,
     times: number = 5,
@@ -57,7 +58,7 @@ export class UtilsHelper {
 
   isValidWalletAddress(address: string) {
     const regex =
-      environment.kaspaNetwork == KASPA_NETWORKS.MAINNET
+      this.kaspaL1NetworkService.isMainnet()
         ? WALLET_ADDRESS_VALIDATION_REGEX_MAINNET
         : WALLET_ADDRESS_VALIDATION_REGEX_TESTNET;
 
@@ -98,9 +99,7 @@ export class UtilsHelper {
     } else {
       if (!this.isValidWalletAddress(address)) {
         const expectedPrefix =
-          environment.kaspaNetwork === KASPA_NETWORKS.MAINNET
-            ? 'kaspa:'
-            : 'kaspatest:';
+          this.kaspaL1NetworkService.isMainnet() ? 'kaspa:' : 'kaspatest:';
         return `Invalid Kaspa address format. Expected format: ${expectedPrefix}[address]`;
       }
     }

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -23,6 +23,7 @@ import { EthereumWalletChainManager } from './etherium-services/etherium-wallet-
 import { KaspaNetworkConnectionManagerService } from './kaspa-netwrok-services/kaspa-network-connection-manager.service';
 import { KaspaWalletMnemonicActionsService } from './kaspa-netwrok-services/kaspa-wallet-mnemonic-actions.service';
 import { MonitorService } from './monitor.service';
+import { KaspaL1NetworkService } from './kaspa-netwrok-services/kaspa-l1-network.service';
 
 export enum VIEW_METHOD {
   L1 = 'l1',
@@ -47,6 +48,7 @@ export class WalletService {
     private readonly injector: EnvironmentInjector,
     private readonly etheriumChainManager: EthereumWalletChainManager,
     private readonly monitorService: MonitorService,
+    private readonly kaspaL1NetworkService: KaspaL1NetworkService,
   ) {
     let isL2View =
       localStorage.getItem(LOCAL_STORAGE_KEYS.IS_L2_DISPLAY) === 'true';
@@ -782,6 +784,7 @@ export class WalletService {
   }
 
   public getCurrentDisplayWalletAddress = computed(() => {
+    this.kaspaL1NetworkService.getCurrentNetworkSignal()();
     return this.isL2DisplaySignal()
       ? this.currentWalletSignal()?.getL2WalletAddress()
       : this.currentWalletSignal()?.getAddress();

--- a/src/app/v2/pages/app/common/wrapper-header/wrapper-header.component.ts
+++ b/src/app/v2/pages/app/common/wrapper-header/wrapper-header.component.ts
@@ -12,6 +12,7 @@ import { WalletProfileOrbComponent } from '../../../../shared/ui/wallet-profile-
 import { FlowPageId } from '../flow-page/flow-page.registry';
 import { DesktopViewService } from '../../../../services/desktop-view.service';
 import { CHAIN_ID_LOGOS } from '../../../../shared/network-selection-modal/chain-id-logos';
+import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Component({
   selector: 'app-wrapper-header',
@@ -33,6 +34,7 @@ export class WrapperHeaderComponent {
   flowPagesService = inject(FlowPagesService);
   ethereumWalletChainManager = inject(EthereumWalletChainManager);
   desktopViewService = inject(DesktopViewService);
+  kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   // Use signals for reactive updates
   currentWallet = this.walletService.getCurrentWalletSignal();
@@ -48,9 +50,12 @@ export class WrapperHeaderComponent {
         icon: envConfig?.icon || CHAIN_ID_LOGOS[normalizedId] || null,
       };
     }
+
+    const l1Network = this.kaspaL1NetworkService.getCurrentNetworkSignal()();
+
     return {
-      name: environment.l1Config.shortName,
-      icon: environment.l1Config.icon,
+      name: l1Network.shortName,
+      icon: l1Network.icon,
     };
   });
 

--- a/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-nft/send-nft.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-nft/send-nft.component.ts
@@ -12,10 +12,10 @@ import { Router } from '@angular/router';
 import { ERROR_CODES, ERROR_CODES_MESSAGES } from '@kaspacom/wallet-messages';
 import { KcButtonComponent, KcCheckboxComponent } from 'kaspacom-ui';
 import { firstValueFrom } from 'rxjs';
-import { environment } from '../../../../../../../../../../../environments/environment';
 import { AddressResolutionResult } from '../../../../../../../../../../services/address-resolution.service';
 import { AssetsManagerService } from '../../../../../../../../../../services/assets-manager/assets-manager.service';
 import { L1_ASSET_KEYS } from '../../../../../../../../../../services/assets-manager/assets-stores/l1-assets-store.service';
+import { KaspaL1NetworkService } from '../../../../../../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 import { Krc721ApiService } from '../../../../../../../../../../services/krc721-api/krc721-api.service';
 import { MessagePopupService } from '../../../../../../../../../../services/message-popup.service';
 import { Krc721WalletActionService } from '../../../../../../../../../../services/protocols/krc721/krc721-wallet-actions.service';
@@ -58,6 +58,7 @@ export class SendNftComponent
   private qrScannerService = inject(QrScannerService);
   private router = inject(Router);
   private assetsManagerService = inject(AssetsManagerService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   nft = signal<INft | undefined>(undefined);
   loading = signal<boolean>(true);
@@ -416,12 +417,13 @@ export class SendNftComponent
   }
 
   private buildCachedImageUrl(tick?: string, tokenId?: string): string {
-    if (!tick || !tokenId || !environment.krc721CacheStreamUrl) {
+    const cacheStreamUrl = this.kaspaL1NetworkService.getKrc721CacheStreamUrl();
+    if (!tick || !tokenId || !cacheStreamUrl) {
       return '';
     }
 
     const normalizedTick = encodeURIComponent(tick.toUpperCase());
     const normalizedTokenId = encodeURIComponent(tokenId);
-    return `${environment.krc721CacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
+    return `${cacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
   }
 }

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/kns-asset/kns-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/kns-asset/kns-asset.component.ts
@@ -9,9 +9,9 @@ import { FlowPagesService } from '../../../../../../../services/flow-pages.servi
 import { KnsApiService } from '../../../../../../../../services/kns-api/kns-api.service';
 import { KnsDomainAsset } from '../../../../../../../../services/kns-api/dtos/kns-domain.dto';
 import { CopyButtonComponent } from '../../../../../../../shared/ui/copy-button/copy-button.component';
-import { environment } from '../../../../../../../../../environments/environment';
 import { AssetsManagerService } from '../../../../../../../../services/assets-manager/assets-manager.service';
 import { L1_ASSET_KEYS } from '../../../../../../../../services/assets-manager/assets-stores/l1-assets-store.service';
+import { KaspaL1NetworkService } from '../../../../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Component({
   selector: 'app-kns-asset',
@@ -30,6 +30,7 @@ export class KnsAssetComponent extends BaseAssetPageComponent implements OnInit 
   private knsService = inject(KnsApiService);
   private flowPagesService = inject(FlowPagesService);
   private assetsManagerService = inject(AssetsManagerService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   private assetId: string = '';
 
@@ -197,7 +198,7 @@ export class KnsAssetComponent extends BaseAssetPageComponent implements OnInit 
     const detail = this.knsDetail();
     if (!detail?.transactionId) return;
 
-    const explorerUrl = `${environment.kaspaExplorerBaseurl}/txs/${detail.transactionId}`;
+    const explorerUrl = `${this.kaspaL1NetworkService.getKaspaExplorerBaseurl()}/txs/${detail.transactionId}`;
     window.open(explorerUrl, '_blank');
   }
 

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/krc20-asset/krc20-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/krc20-asset/krc20-asset.component.ts
@@ -8,12 +8,12 @@ import { SkeletonComponent } from '../../../../../../../shared/ui/skeleton/skele
 import { KasplexKrc20Service } from '../../../../../../../../services/kasplex-api/kasplex-api.service';
 import { FlowPagesService } from '../../../../../../../services/flow-pages.service';
 import { OperationDetails } from '../../../../../../../../services/kasplex-api/dtos/operation-details-response';
-import { environment } from '../../../../../../../../../environments/environment';
 import { KcLabeledTabsComponent, TabItem } from '../../../../../../../shared/ui/kc-labeled-tabs/kc-labeled-tabs.component';
 import { KaspaNetworkActionsService } from '../../../../../../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
 import { AssetsManagerService } from '../../../../../../../../services/assets-manager/assets-manager.service';
 import { L1_ASSET_KEYS } from '../../../../../../../../services/assets-manager/assets-stores/l1-assets-store.service';
 import { Krc20TokenLogoComponent } from '../../logo/krc20-token-logo/krc20-token-logo.component';
+import { KaspaL1NetworkService } from '../../../../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 interface TokenInfo {
   tick: string;
@@ -50,6 +50,7 @@ export class Krc20AssetComponent extends BaseAssetPageComponent implements OnIni
   private flowPagesService = inject(FlowPagesService);
   private kaspaNetworkActionsService = inject(KaspaNetworkActionsService);
   private assetsManagerService = inject(AssetsManagerService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   ticker: string | null = null;
 
@@ -321,7 +322,7 @@ export class Krc20AssetComponent extends BaseAssetPageComponent implements OnIni
 
     if (!transaction.id) return;
 
-    const explorerUrl = `${environment.kaspaExplorerBaseurl}/txs/${transaction.id}`;
+    const explorerUrl = `${this.kaspaL1NetworkService.getKaspaExplorerBaseurl()}/txs/${transaction.id}`;
     window.open(explorerUrl, '_blank');
   }
 }

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
@@ -113,14 +113,19 @@ export class Krc721AssetComponent extends BaseAssetPageComponent implements OnIn
       console.log('Loading rarity info for', this.tick, this.tokenId, 'address:', address);
 
       // 1. Get Collection details for total supply
-      this.krc721Service.getCollectionDetails(this.tick).subscribe(response => {
-        console.log('Collection details response:', response);
-        if (response.message === 'success') {
-          // Use max supply if totalSupply is missing, or minted if available
-          const supply = response.result.totalSupply || response.result.max || response.result.minted;
-          this.totalSupply.set(parseInt(supply));
-          console.log('Total supply set to:', parseInt(supply));
-        }
+      this.krc721Service.getCollectionDetails(this.tick).subscribe({
+        next: (response) => {
+          console.log('Collection details response:', response);
+          if (response.message === 'success') {
+            // Use max supply if totalSupply is missing, or minted if available
+            const supply = response.result.totalSupply || response.result.max || response.result.minted;
+            this.totalSupply.set(parseInt(supply));
+            console.log('Total supply set to:', parseInt(supply));
+          }
+        },
+        error: (err) => {
+          console.warn('Failed loading KRC721 collection details', err);
+        },
       });
 
       // 2. Get Portfolio details for rarity rank

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
@@ -8,7 +8,7 @@ import { NftRankTagComponent } from './components/nft-rank-tag/nft-rank-tag.comp
 import { BaseAssetPageComponent } from '../../../../../common/base-asset-page/base-asset-page.component';
 import { Krc721ApiService } from '../../../../../../../../services/krc721-api/krc721-api.service';
 import { FlowPagesService } from '../../../../../../../services/flow-pages.service';
-import { environment } from '../../../../../../../../../environments/environment';
+import { KaspaL1NetworkService } from '../../../../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 interface NftMetadata {
   name?: string;
@@ -38,6 +38,7 @@ export class Krc721AssetComponent extends BaseAssetPageComponent implements OnIn
   private route = inject(ActivatedRoute);
   private krc721Service = inject(Krc721ApiService);
   private flowPagesService = inject(FlowPagesService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   private tick: string = '';
   private tokenId: string = '';
@@ -247,13 +248,14 @@ export class Krc721AssetComponent extends BaseAssetPageComponent implements OnIn
   }
 
   private buildCachedImageUrl(): string {
-    if (!this.tick || !this.tokenId || !environment.krc721CacheStreamUrl) {
+    const cacheStreamUrl = this.kaspaL1NetworkService.getKrc721CacheStreamUrl();
+    if (!this.tick || !this.tokenId || !cacheStreamUrl) {
       return '';
     }
 
     const normalizedTick = encodeURIComponent(this.tick.toUpperCase());
     const normalizedTokenId = encodeURIComponent(this.tokenId);
-    return `${environment.krc721CacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
+    return `${cacheStreamUrl}/optimized/${normalizedTick}/${normalizedTokenId}`;
   }
 
   // Open NFT in explorer (currently not implemented as transaction ID is not readily available)

--- a/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.ts
+++ b/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.ts
@@ -6,9 +6,9 @@ import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.compo
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { KaspaApiService } from '../../../../../services/kaspa-api/kaspa-api.service';
 import { FullTransactionResponseItem } from '../../../../../services/kaspa-api/dtos/full-transaction-response.dto';
-import { environment } from '../../../../../../environments/environment';
 import { KaspaNetworkActionsService } from '../../../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
 import { WalletService } from '../../../../../services/wallet.service';
+import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Component({
   selector: 'app-kaspa-transaction-details',
@@ -27,6 +27,7 @@ export class KaspaTransactionDetailsComponent implements OnInit {
   private kaspaApiService = inject(KaspaApiService);
   private kaspaNetworkActionsService = inject(KaspaNetworkActionsService);
   private walletService = inject(WalletService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   protected transactionId: string | null = null;
   protected transactionDetails = signal<FullTransactionResponseItem | null>(null);
@@ -110,7 +111,7 @@ export class KaspaTransactionDetailsComponent implements OnInit {
   protected openTransactionInExplorer(): void {
     const transaction = this.transactionDetails();
     if (transaction) {
-      const explorerUrl = `${environment.kaspaExplorerBaseurl}/txs/${transaction.transaction_id}`;
+      const explorerUrl = `${this.kaspaL1NetworkService.getKaspaExplorerBaseurl()}/txs/${transaction.transaction_id}`;
       window.open(explorerUrl, '_blank');
     }
   }

--- a/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.ts
+++ b/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.ts
@@ -7,8 +7,8 @@ import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.compo
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { KasplexKrc20Service } from '../../../../../services/kasplex-api/kasplex-api.service';
 import { OperationDetails } from '../../../../../services/kasplex-api/dtos/operation-details-response';
-import { environment } from '../../../../../../environments/environment';
 import { KaspaNetworkActionsService } from '../../../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
+import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Component({
   selector: 'app-krc20-transaction-details',
@@ -26,6 +26,7 @@ export class Krc20TransactionDetailsComponent implements OnInit {
   private router = inject(Router);
   private kasplexService = inject(KasplexKrc20Service);
   private kaspaNetworkActionsService = inject(KaspaNetworkActionsService);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   protected ticker: string | null = null;
   protected transactionId: string | null = null;
@@ -123,7 +124,7 @@ export class Krc20TransactionDetailsComponent implements OnInit {
   protected openTransactionInExplorer(): void {
     const operation = this.operationDetails();
     if (operation) {
-      const explorerUrl = `${environment.kaspaExplorerBaseurl}/txs/${operation.hashRev}`;
+      const explorerUrl = `${this.kaspaL1NetworkService.getKaspaExplorerBaseurl()}/txs/${operation.hashRev}`;
       window.open(explorerUrl, '_blank');
     }
   }

--- a/src/app/v2/pages/app/home/utxo-asset/utxo-asset.component.ts
+++ b/src/app/v2/pages/app/home/utxo-asset/utxo-asset.component.ts
@@ -6,7 +6,7 @@ import { BaseAssetPageComponent, AssetDetail } from '../../common/base-asset-pag
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.component';
 import { UtxoEntryReference } from '../../../../../../../public/kaspa/kaspa';
-import { environment } from '../../../../../../environments/environment';
+import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 @Component({
   selector: 'app-utxo-asset',
@@ -21,6 +21,7 @@ import { environment } from '../../../../../../environments/environment';
 })
 export class UtxoAssetComponent extends BaseAssetPageComponent implements OnInit {
   protected route = inject(ActivatedRoute);
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   private transactionId: string = '';
   protected utxo = computed<UtxoEntryReference | null>(() => {
@@ -122,7 +123,7 @@ export class UtxoAssetComponent extends BaseAssetPageComponent implements OnInit
     const utxoData = this.utxo();
     if (!utxoData?.outpoint?.transactionId) return;
 
-    const explorerUrl = `${environment.kaspaExplorerBaseurl}/txs/${utxoData.outpoint.transactionId}`;
+    const explorerUrl = `${this.kaspaL1NetworkService.getKaspaExplorerBaseurl()}/txs/${utxoData.outpoint.transactionId}`;
     window.open(explorerUrl, '_blank');
   }
 

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
@@ -4,20 +4,21 @@
     <!-- L1 Network -->
     <h3 class="network-group-title">L1 Network</h3>
     <div class="networks-list">
-      <div class="network-item" [class.selected]="!isCurrentNetworkL2()"
+      <div *ngFor="let network of l1Networks" class="network-item"
+        [class.selected]="isCurrentL1Network(network)"
         role="button"
         tabindex="0"
-        (click)="setL1Network()"
-        (keydown.enter)="setL1Network()"
-        (keydown.space)="onL1SpaceKey($event)">
+        (click)="setL1Network(network)"
+        (keydown.enter)="setL1Network(network)"
+        (keydown.space)="onL1SpaceKey($event, network)">
         <div class="network-icon">
-          <img [src]="l1Config.icon" [alt]="l1Config.shortName" class="chain-icon" />
+          <img [src]="network.icon" [alt]="network.shortName" class="chain-icon" />
         </div>
         <div class="network-info">
-          <div class="network-name">{{ l1Config.shortName }}</div>
+          <div class="network-name">{{ network.shortName }}</div>
         </div>
         <div class="network-status">
-          <kc-icon *ngIf="!isCurrentNetworkL2()" [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
+          <kc-icon *ngIf="isCurrentL1Network(network)" [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
         </div>
       </div>
     </div>

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -167,6 +167,10 @@ export class NetworkSelectionModalComponent implements OnInit {
   }
 
   async setL1Network(network: L1NetworkConfigInterface): Promise<void> {
+    if (this.isCurrentL1Network(network)) {
+      return;
+    }
+
     const switchGeneration = ++this.l1NetworkSwitchGeneration;
     const currentWallet = this.walletService.getCurrentWallet();
     currentWallet?.resetL1NetworkState();

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -171,11 +171,15 @@ export class NetworkSelectionModalComponent implements OnInit {
       return;
     }
 
+    if (!this.rpcService.setNetwork(network.network)) {
+      console.warn('Failed switching to Kaspa L1 network', network.network);
+      return;
+    }
+
     const switchGeneration = ++this.l1NetworkSwitchGeneration;
     const currentWallet = this.walletService.getCurrentWallet();
     currentWallet?.resetL1NetworkState();
 
-    this.rpcService.setNetwork(network.network);
     this.walletService.setL2Display(false);
     this.ethereumWalletChainManager.setCurrentChain(undefined);
     this.onCloseAfterNetworkChanged();
@@ -195,12 +199,14 @@ export class NetworkSelectionModalComponent implements OnInit {
       return;
     }
 
-    await this.kaspaConnectionManagerService
+    const connected = await this.kaspaConnectionManagerService
       .waitForConnection(true)
+      .then(() => true)
       .catch((err) => {
         console.warn('Failed connecting to selected Kaspa L1 network', err);
+        return false;
       });
-    if (switchGeneration !== this.l1NetworkSwitchGeneration) {
+    if (!connected || switchGeneration !== this.l1NetworkSwitchGeneration) {
       return;
     }
 

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -179,7 +179,11 @@ export class NetworkSelectionModalComponent implements OnInit {
     this.walletService.setL2Display(false);
     this.ethereumWalletChainManager.setCurrentChain(undefined);
     this.onCloseAfterNetworkChanged();
-    void this.reloadSelectedL1Network(currentWallet, switchGeneration);
+    void this.reloadSelectedL1Network(currentWallet, switchGeneration).catch(
+      (err) => {
+        console.warn('Failed reloading selected Kaspa L1 network', err);
+      },
+    );
   }
 
   private async reloadSelectedL1Network(
@@ -205,7 +209,7 @@ export class NetworkSelectionModalComponent implements OnInit {
       return;
     }
 
-    currentWallet?.startListiningToWalletActions();
+    await currentWallet?.startListiningToWalletActions();
   }
 
   setL2Network(network: EIP1193ProviderChain): void {

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -8,9 +8,13 @@ import { EthereumWalletChainManager } from '../../../services/etherium-services/
 import { EIP1193ProviderChain } from '@kaspacom/wallet-messages';
 import { WalletService } from '../../../services/wallet.service';
 import { Router } from '@angular/router';
-import { environment } from '../../../../environments/environment';
 import { CHAIN_ID_LOGOS } from './chain-id-logos';
 import { COINGECKO_PRICE_URL, NATIVE_TOKEN_COINGECKO_IDS } from './coingecko-native-ids';
+import { L1NetworkConfigInterface } from '../../../../environments/environment.interface';
+import { RpcService } from '../../../services/kaspa-netwrok-services/rpc.service';
+import { KaspaNetworkConnectionManagerService } from '../../../services/kaspa-netwrok-services/kaspa-network-connection-manager.service';
+import { KaspaL1NetworkService } from '../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
+import { AppWallet } from '../../../classes/AppWallet';
 
 const PRICE_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -32,8 +36,14 @@ export class NetworkSelectionModalComponent implements OnInit {
   private walletService = inject(WalletService);
   private router = inject(Router);
   private http = inject(HttpClient);
+  private rpcService = inject(RpcService);
+  private kaspaConnectionManagerService = inject(
+    KaspaNetworkConnectionManagerService,
+  );
+  private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
-  protected l1Config = environment.l1Config;
+  protected l1Networks = this.kaspaL1NetworkService.getAvailableNetworks();
+  private l1NetworkSwitchGeneration = 0;
 
   // Reactive: re-derives whenever a custom chain is added or removed
   protected networks = computed<EIP1193ProviderChain[]>(() => {
@@ -51,6 +61,9 @@ export class NetworkSelectionModalComponent implements OnInit {
   );
   currentL2Network = computed(() =>
     this.ethereumWalletChainManager.getCurrentChainSignal()(),
+  );
+  currentL1Network = computed(() =>
+    this.kaspaL1NetworkService.getCurrentNetworkSignal()(),
   );
 
   ngOnInit(): void {
@@ -146,10 +159,49 @@ export class NetworkSelectionModalComponent implements OnInit {
     return this.nativePrices.get(chainId) ?? null;
   }
 
-  setL1Network(): void {
+  isCurrentL1Network(network: L1NetworkConfigInterface): boolean {
+    return (
+      !this.isCurrentNetworkL2() &&
+      this.currentL1Network().network === network.network
+    );
+  }
+
+  async setL1Network(network: L1NetworkConfigInterface): Promise<void> {
+    const switchGeneration = ++this.l1NetworkSwitchGeneration;
+    const currentWallet = this.walletService.getCurrentWallet();
+    currentWallet?.resetL1NetworkState();
+
+    this.rpcService.setNetwork(network.network);
     this.walletService.setL2Display(false);
     this.ethereumWalletChainManager.setCurrentChain(undefined);
     this.onCloseAfterNetworkChanged();
+    void this.reloadSelectedL1Network(currentWallet, switchGeneration);
+  }
+
+  private async reloadSelectedL1Network(
+    currentWallet: AppWallet | undefined,
+    switchGeneration: number,
+  ): Promise<void> {
+    await currentWallet?.stopListiningToWalletActions();
+    if (switchGeneration !== this.l1NetworkSwitchGeneration) {
+      return;
+    }
+
+    await this.kaspaConnectionManagerService
+      .waitForConnection(true)
+      .catch((err) => {
+        console.warn('Failed connecting to selected Kaspa L1 network', err);
+      });
+    if (switchGeneration !== this.l1NetworkSwitchGeneration) {
+      return;
+    }
+
+    await currentWallet?.refreshUtxosBalance();
+    if (switchGeneration !== this.l1NetworkSwitchGeneration) {
+      return;
+    }
+
+    currentWallet?.startListiningToWalletActions();
   }
 
   setL2Network(network: EIP1193ProviderChain): void {
@@ -159,9 +211,9 @@ export class NetworkSelectionModalComponent implements OnInit {
     this.onCloseAfterNetworkChanged();
   }
 
-  onL1SpaceKey(event: Event): void {
+  onL1SpaceKey(event: Event, network: L1NetworkConfigInterface): void {
     event.preventDefault();
-    this.setL1Network();
+    this.setL1Network(network);
   }
 
   onNetworkEnterKey(event: Event, network: EIP1193ProviderChain): void {

--- a/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.html
+++ b/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.html
@@ -14,11 +14,11 @@
 } @else {
   <div
     class="wallet-profile-orb"
-    [style.background]="l1AvatarError() ? l1AvatarConfig().bgColor : null"
+    [style.background]="(l1AvatarError() || !l1AvatarBaseUrl()) ? l1AvatarConfig().bgColor : null"
   >
-    @if (!l1AvatarError()) {
+    @if (!l1AvatarError() && l1AvatarBaseUrl()) {
       <img
-        [src]="l1AvatarBaseUrl + '/' + l1AvatarConfig().tokenId"
+        [src]="l1AvatarBaseUrl() + '/' + l1AvatarConfig().tokenId"
         alt="Wallet avatar"
         [style.filter]="l1AvatarConfig().imgFilter"
         (error)="onL1AvatarError()"

--- a/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.ts
+++ b/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { WalletService } from '../../../../services/wallet.service';
 import { environment } from '../../../../../environments/environment';
+import { KaspaL1NetworkService } from '../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 interface AvatarConfig {
   shapeIndex: number;
@@ -75,8 +76,9 @@ function computeL1Avatar(address: string): L1AvatarConfig {
 })
 export class WalletProfileOrbComponent {
   private walletService = inject(WalletService);
+  private l1NetworkService = inject(KaspaL1NetworkService);
 
-  readonly l1AvatarBaseUrl = `${environment.krc721CacheStreamUrl}/optimized/${encodeURIComponent(environment.l1AvatarCollection.toUpperCase())}`;
+  readonly l1AvatarBaseUrl = `${this.l1NetworkService.getKrc721CacheStreamUrl()}/optimized/${encodeURIComponent(this.l1NetworkService.getCurrentNetwork().l1AvatarCollection.toUpperCase())}`;
 
   isL2 = this.walletService.getIsL2DisplaySignal();
   walletAddress = this.walletService.getCurrentDisplayWalletAddressAsString;

--- a/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.ts
+++ b/src/app/v2/shared/ui/wallet-profile-orb/wallet-profile-orb.component.ts
@@ -1,6 +1,5 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { WalletService } from '../../../../services/wallet.service';
-import { environment } from '../../../../../environments/environment';
 import { KaspaL1NetworkService } from '../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 
 interface AvatarConfig {
@@ -78,7 +77,15 @@ export class WalletProfileOrbComponent {
   private walletService = inject(WalletService);
   private l1NetworkService = inject(KaspaL1NetworkService);
 
-  readonly l1AvatarBaseUrl = `${this.l1NetworkService.getKrc721CacheStreamUrl()}/optimized/${encodeURIComponent(this.l1NetworkService.getCurrentNetwork().l1AvatarCollection.toUpperCase())}`;
+  // Reactive: re-derives on L1 network switch; null when the selected
+  // network has no KRC721 cache stream (e.g. TN12) so no broken URL is built.
+  readonly l1AvatarBaseUrl = computed<string | null>(() => {
+    const network = this.l1NetworkService.getCurrentNetworkSignal()();
+    if (!network.krc721CacheStreamUrl) {
+      return null;
+    }
+    return `${network.krc721CacheStreamUrl}/optimized/${encodeURIComponent(network.l1AvatarCollection.toUpperCase())}`;
+  });
 
   isL2 = this.walletService.getIsL2DisplaySignal();
   walletAddress = this.walletService.getCurrentDisplayWalletAddressAsString;
@@ -90,6 +97,7 @@ export class WalletProfileOrbComponent {
   constructor() {
     effect(() => {
       this.walletAddress();
+      this.l1NetworkService.getCurrentNetworkSignal()();
       this.l1AvatarError.set(false);
     });
   }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,19 +1,11 @@
 import { KASPA_NETWORKS } from '../app/config/consts';
 import { Environment } from './environment.interface';
+import { DEVELOPMENT_L1_NETWORKS } from './l1-network-configurations';
 
 export const environment: Environment = {
   isProduction: false,
   consentScriptUrl: 'https://dev.kaspa.com/js/modules/kaspa-consent.min.js',
   consentCssUrl: 'https://dev.kaspa.com/css/consent.min.css',
-  kaspaComApiBaseurl: 'https://dev-api.kaspa.com',
-  kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
-  kasplexApiBaseurl: 'https://tn10api.kasplex.org/v1',
-  kaspaApiBaseurl: 'https://api-tn10.kaspa.org',
-  krc721ApiBaseurl: 'https://testnet-10.krc721.stream/api/v1/krc721/testnet-10',
-  krc721CacheStreamUrl: 'https://cache.krc721.stream/krc721/testnet-10',
-  l1AvatarCollection: 'PEPINO',
-  knsApiBaseurl: 'https://api.knsdomains.org/tn10',
-  kaspaExplorerBaseurl: 'https://explorer-tn10.kaspa.org',
   logosUrl: 'https://erc20-logo-dev.s3.eu-central-1.amazonaws.com/',
   kaspaNetwork: KASPA_NETWORKS.TESTNET10,
   allowedDomains: [
@@ -25,6 +17,7 @@ export const environment: Environment = {
   l1Config: {
     shortName: 'Kaspa L1',
     icon: 'images/tokens-logos/KAS.png',
+    networks: DEVELOPMENT_L1_NETWORKS,
   },
   l2Configs: [
     {

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -46,6 +46,23 @@ export interface L2ConfigInterface {
 export interface L1ConfigInterface {
   shortName: string;
   icon: string;
+  network?: string;
+  networks?: L1NetworkConfigInterface[];
+}
+
+export interface L1NetworkConfigInterface {
+  network: string;
+  shortName: string;
+  icon: string;
+  kaspaComApiBaseurl: string;
+  kaspaComDefiApiBaseurl: string;
+  kasplexApiBaseurl?: string;
+  kaspaApiBaseurl: string;
+  krc721ApiBaseurl?: string;
+  krc721CacheStreamUrl?: string;
+  knsApiBaseurl?: string;
+  kaspaExplorerBaseurl: string;
+  l1AvatarCollection: string;
 }
 
 export interface Environment {
@@ -55,15 +72,6 @@ export interface Environment {
   addressableKey?: string;
   consentScriptUrl?: string;
   consentCssUrl?: string;
-  kaspaComApiBaseurl: string;
-  kaspaComDefiApiBaseurl: string;
-  kasplexApiBaseurl: string;
-  kaspaApiBaseurl: string;
-  krc721ApiBaseurl: string;
-  krc721CacheStreamUrl: string;
-  l1AvatarCollection: string;
-  knsApiBaseurl: string;
-  kaspaExplorerBaseurl: string;
   kaspaNetwork: string;
   logosUrl: string;
   allowedDomains: string[];

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -46,8 +46,7 @@ export interface L2ConfigInterface {
 export interface L1ConfigInterface {
   shortName: string;
   icon: string;
-  network?: string;
-  networks?: L1NetworkConfigInterface[];
+  networks: L1NetworkConfigInterface[];
 }
 
 export interface L1NetworkConfigInterface {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 import { KASPA_NETWORKS } from '../app/config/consts';
 import { Environment } from './environment.interface';
+import { PRODUCTION_L1_NETWORKS } from './l1-network-configurations';
 
 export const environment: Environment = {
   isProduction: true,
@@ -8,21 +9,13 @@ export const environment: Environment = {
   segmentKey: 'VjcBOF7puALWzPyE19iNkCLseTTDfVga',
   clarityKey: 'v3s9mm1mn8',
   addressableKey: '2e716db8140e460fa988107810e59824',
-  kaspaComApiBaseurl: 'https://api.kaspa.com',
-  kaspaComDefiApiBaseurl: 'https://api-defi.kaspa.com',
-  kasplexApiBaseurl: 'https://api.kasplex.org/v1',
-  kaspaApiBaseurl: 'https://api.kaspa.org',
-  krc721ApiBaseurl: 'https://mainnet.krc721.stream/api/v1/krc721/mainnet',
-  krc721CacheStreamUrl: 'https://cache.krc721.stream/krc721/mainnet',
-  l1AvatarCollection: 'YONATOSHI',
-  knsApiBaseurl: 'https://api.knsdomains.org/mainnet',
-  kaspaExplorerBaseurl: 'https://explorer.kaspa.org',
   kaspaNetwork: KASPA_NETWORKS.MAINNET,
   logosUrl: 'https://erc20-logo.s3.us-east-1.amazonaws.com/',
   allowedDomains: ['wallet.kaspa.com'],
   l1Config: {
     shortName: 'Kaspa L1',
     icon: 'images/tokens-logos/KAS.png',
+    networks: PRODUCTION_L1_NETWORKS,
   },
   l2Configs: [
     {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,25 +1,18 @@
 import { KASPA_NETWORKS } from '../app/config/consts';
 import { Environment } from './environment.interface';
+import { PRODUCTION_L1_NETWORKS } from './l1-network-configurations';
 
 export const environment: Environment = {
   isProduction: true,
   consentScriptUrl: 'https://dev.kaspa.com/js/modules/kaspa-consent.min.js',
   consentCssUrl: 'https://dev.kaspa.com/css/consent.min.css',
-  kaspaComApiBaseurl: 'https://api.kaspa.com',
-  kaspaComDefiApiBaseurl: 'https://api-defi.kaspa.com',
-  kasplexApiBaseurl: 'https://api.kasplex.org/v1',
-  kaspaApiBaseurl: 'https://api.kaspa.org',
-  krc721ApiBaseurl: 'https://mainnet.krc721.stream/api/v1/krc721/mainnet',
-  krc721CacheStreamUrl: 'https://cache.krc721.stream/krc721/mainnet',
-  l1AvatarCollection: 'YONATOSHI',
-  knsApiBaseurl: 'https://api.knsdomains.org/mainnet',
-  kaspaExplorerBaseurl: 'https://explorer.kaspa.org',
   logosUrl: 'https://erc20-logo-dev.s3.eu-central-1.amazonaws.com/',
   kaspaNetwork: KASPA_NETWORKS.MAINNET,
   allowedDomains: ['wallet.kaspa.com'],
   l1Config: {
     shortName: 'Kaspa L1',
     icon: 'images/tokens-logos/KAS.png',
+    networks: PRODUCTION_L1_NETWORKS,
   },
   l2Configs: [
     {

--- a/src/environments/l1-network-configurations.ts
+++ b/src/environments/l1-network-configurations.ts
@@ -1,0 +1,54 @@
+import { KASPA_NETWORKS } from '../app/config/consts';
+import { L1NetworkConfigInterface } from './environment.interface';
+
+export const KASPA_MAINNET_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
+  network: KASPA_NETWORKS.MAINNET,
+  shortName: 'Kaspa Mainnet',
+  icon: 'images/tokens-logos/KAS.png',
+  kaspaComApiBaseurl: 'https://api.kaspa.com',
+  kaspaComDefiApiBaseurl: 'https://api-defi.kaspa.com',
+  kasplexApiBaseurl: 'https://api.kasplex.org/v1',
+  kaspaApiBaseurl: 'https://api.kaspa.org',
+  krc721ApiBaseurl: 'https://mainnet.krc721.stream/api/v1/krc721/mainnet',
+  krc721CacheStreamUrl: 'https://cache.krc721.stream/krc721/mainnet',
+  knsApiBaseurl: 'https://api.knsdomains.org/mainnet',
+  kaspaExplorerBaseurl: 'https://explorer.kaspa.org',
+  l1AvatarCollection: 'YONATOSHI',
+};
+
+export const KASPA_TN10_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
+  network: KASPA_NETWORKS.TESTNET10,
+  shortName: 'Kaspa TN10',
+  icon: 'images/tokens-logos/KAS.png',
+  kaspaComApiBaseurl: 'https://dev-api.kaspa.com',
+  kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
+  kasplexApiBaseurl: 'https://tn10api.kasplex.org/v1',
+  kaspaApiBaseurl: 'https://api-tn10.kaspa.org',
+  krc721ApiBaseurl: 'https://testnet-10.krc721.stream/api/v1/krc721/testnet-10',
+  krc721CacheStreamUrl: 'https://cache.krc721.stream/krc721/testnet-10',
+  knsApiBaseurl: 'https://api.knsdomains.org/tn10',
+  kaspaExplorerBaseurl: 'https://explorer-tn10.kaspa.org',
+  l1AvatarCollection: 'PEPINO'
+};
+
+export const KASPA_TN12_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
+  network: KASPA_NETWORKS.TESTNET12,
+  shortName: 'Kaspa TN12',
+  icon: 'images/tokens-logos/KAS.png',
+  kaspaComApiBaseurl: 'https://dev-api.kaspa.com',
+  kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
+  kaspaApiBaseurl: 'https://api-tn12.kaspa.org',
+  kaspaExplorerBaseurl: 'https://tn12.kaspa.stream',
+  l1AvatarCollection: 'PEPINO'
+};
+
+export const PRODUCTION_L1_NETWORKS: L1NetworkConfigInterface[] = [
+  KASPA_MAINNET_L1_NETWORK_CONFIG,
+  KASPA_TN10_L1_NETWORK_CONFIG,
+];
+
+export const DEVELOPMENT_L1_NETWORKS: L1NetworkConfigInterface[] = [
+  KASPA_TN10_L1_NETWORK_CONFIG,
+  KASPA_TN12_L1_NETWORK_CONFIG,
+  KASPA_MAINNET_L1_NETWORK_CONFIG,
+];

--- a/src/environments/l1-network-configurations.ts
+++ b/src/environments/l1-network-configurations.ts
@@ -44,7 +44,6 @@ export const KASPA_TN12_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
 
 export const PRODUCTION_L1_NETWORKS: L1NetworkConfigInterface[] = [
   KASPA_MAINNET_L1_NETWORK_CONFIG,
-  KASPA_TN10_L1_NETWORK_CONFIG,
 ];
 
 export const DEVELOPMENT_L1_NETWORKS: L1NetworkConfigInterface[] = [


### PR DESCRIPTION
## Summary
- Adds runtime Kaspa L1 network selection in the existing network switcher.
- Moves all L1 resource URLs into per-network configuration constants so dev/prod selectable networks are controlled by PRODUCTION_L1_NETWORKS / DEVELOPMENT_L1_NETWORKS.
- Registers mainnet, TN10, and TN12; TN12 has no KNS/KRC resource URLs, so unsupported asset stores and list pagination states complete as empty immediately.
- Rebuilds the Kaspa RPC client with the selected network ID and Resolver.
- Closes the network dialog immediately on L1 switch, clears wallet/asset state, then reconnects and reloads in the background.
- Cancels in-flight/stale L1 switch and RPC connect attempts so only the latest selected network can connect, publish status, or schedule reconnects.
- Invalidates stale L1 asset API responses so KRC20/KRC721/KNS initial loads, auto-reloads, and load-more calls cannot write assets from a previous network.

## Verification
- npm ci
- npm run build:dev
- npx ng build

Note: both Angular builds pass. The remaining duplicate toString warnings come from the existing generated public/kaspa/kaspa.js file.