### PR TITLE
fix: rename dev wallet testnet chain to Igra

### DIFF
--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -85,7 +85,7 @@ export const environment: Environment = {
     {
       sdkName: 'igra-testnet',
       icon: 'images/chains/igra.svg',
-      shortName: 'Galleon',
+      shortName: 'Igra',
       l1TransactionPrefix: 'igra',
       verifiedTokens: [
         {


### PR DESCRIPTION
## Summary
- Rename only the dev-wallet network picker/header label from "Galleon" to "Igra"
- Leave chain ID, EIP-1193 chain name, RPC, explorer, and network keys unchanged

## Verification
- npm run build:dev

Build passed with existing duplicate `toString` warnings from `public/kaspa/kaspa.js`.
