### PR TITLE
fix(seo): wallet h1 + meta description, noindex non-prod hosts

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
+<h1 class="visually-hidden">KaspaCom Web Wallet — self-custody Kaspa (KAS) wallet</h1>
 <app-startup-background-canvas></app-startup-background-canvas>
 <div class="application-container">
     <ng-container *ngIf="isAllowedDomain() && !incompatibleBrowserReason(); else notSupported">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
   Renderer2,
   inject,
 } from '@angular/core';
+import { Meta } from '@angular/platform-browser';
 import { RouterOutlet } from '@angular/router';
 import { KaspaNetworkActionsService } from './services/kaspa-netwrok-services/kaspa-network-actions.service';
 import { environment } from '../environments/environment';
@@ -46,6 +47,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   ethereumWalletChainManager = inject(EthereumWalletChainManager);
   assetsManager = inject(AssetsManagerService);
   consentService = inject(ConsentService);
+  private readonly meta = inject(Meta);
   private referralService = inject(ReferralService);
   private teardownLoader?: VoidFunction;
 
@@ -58,6 +60,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   async ngOnInit() {
     console.log('App component initialized');
+
+    this.applyIndexingPolicy();
 
     if (!this.isAllowedDomain()) {
       return;
@@ -102,6 +106,17 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   isAllowedDomain(): boolean {
     return environment.allowedDomains.includes(window.location.hostname);
+  }
+
+  // Only the canonical production host should be indexed by search engines.
+  // dev-wallet.kaspa.com, localhost and preview hosts get noindex,nofollow.
+  private applyIndexingPolicy(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (window.location.hostname !== 'wallet.kaspa.com') {
+      this.meta.updateTag({ name: 'robots', content: 'noindex, nofollow' });
+    }
   }
 
   incompatibleBrowserReason(): string | undefined {

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>KaspaCom Web Wallet</title>
+    <meta name="description" content="KaspaCom Web Wallet — a fast, self-custody (non-custodial) browser wallet for Kaspa (KAS), KRC-20 tokens, KRC-721 NFTs and KNS domains. Send, receive, swap and manage your Kaspa assets securely." />
     <base href="/" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -234,3 +234,18 @@ button {
   color: var(--primary);
   filter: drop-shadow(0 6px 18px rgba(111, 199, 186, 0.4));
 }
+
+// SEO/a11y: page heading present in the DOM for crawlers + screen readers,
+// kept out of the visual layout.
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Why
Bing Webmaster flagged **wallet.kaspa.com** for a missing `<h1>` and missing `<meta name=description>`, and was also indexing **dev-wallet.kaspa.com** (a non-prod environment that should not appear in search).

## Changes
- **Meta description** (`src/index.html`): keyword-rich `<meta name="description">` — *"…self-custody browser wallet for Kaspa (KAS), KRC-20, KRC-721 and KNS domains…"*. Static, so it's in the SSR-served HTML for all routes.
- **`<h1>`** (`app.component.html`): an always-rendered **visually-hidden** `<h1>` in the app shell, so every route has a crawlable heading without altering the wallet UI (new `.visually-hidden` utility in `styles.scss`).
- **noindex non-prod** (`app.component.ts`): sets `<meta name=robots content="noindex, nofollow">` whenever the host isn't the canonical `wallet.kaspa.com` — i.e. dev-wallet, localhost and preview hosts. Prod indexing is unchanged.

## Verification
`npm run build:dev` passes (Angular SSR build, no errors).

## Note
This handles the **dev-wallet noindex** at the app layer (works for SSR + client). `api.kaspa.com/api-docs` (Swagger) is a separate backend concern — recommend a `noindex` response header there (api-defi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)