### PR TITLE
fix(seo): add robots.txt + sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Allow: /
+Disallow:
 
 # Sitemap location
 Sitemap: https://wallet.kaspa.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: https://wallet.kaspa.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://wallet.kaspa.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## What
`wallet.kaspa.com/robots.txt` currently returns 404 (no file — the SPA serves its index for unknown paths). Add a minimal robots.txt + sitemap so crawlers get a clean signal.

## Change
- `public/robots.txt` — `User-agent: *` / `Allow: /` + `Sitemap: https://wallet.kaspa.com/sitemap.xml`.
- `public/sitemap.xml` — lists the wallet root (the only meaningful search-landing page; the rest is transactional/connect-gated app state).

## Notes
- Non-prod hosts (dev-wallet.kaspa.com) are kept out of search by the in-app `robots=noindex,nofollow` meta added in #233 — this static robots.txt only permits crawling; the meta governs indexing.
- `public/` copies to the build root (verified in build output).
- `build:dev` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)