### PR TITLE
Fix wallet-info balance updates

### DIFF
--- a/src/app/services/communication-service/communication-manager.service.ts
+++ b/src/app/services/communication-service/communication-manager.service.ts
@@ -6,6 +6,7 @@ import { KaspaNetworkActionsService } from '../kaspa-netwrok-services/kaspa-netw
 import { AppWallet } from '../../classes/AppWallet';
 import { BalanceData } from '../../types/kaspa-network/balance-event.interface';
 import { Subscription } from 'rxjs';
+import { TotalBalanceWithUtxosInterface } from '../../types/kaspa-network/total-balance-with-utxos.interface';
 import { CommitRevealAction, WalletAction, WalletPsktSignInput } from '../../types/wallet-action';
 import { WalletActionResultWithError } from '../../types/wallet-action-result';
 import { EIP1193ProviderEventEnum, EIP1193ProviderRequestActionResult, EIP1193RequestType, ERROR_CODES, WalletActionRequestPayloadInterface, WalletActionResultType, WalletActionTypeEnum, WalletMessageInterface, WalletMessageTypeEnum } from '@kaspacom/wallet-messages';
@@ -21,8 +22,7 @@ import { ApprovalFlowService } from '../../v2/services/approval-flow.service';
     providedIn: 'root',
 })
 export class CommunicationManagerService {
-    protected walletBalanceObservableSubscription: undefined | Subscription =
-        undefined;
+    protected walletBalanceObservableSubscriptions: Subscription[] = [];
     protected currentWalletIdWithAccount: string | undefined = undefined;
 
     protected walletActionsService: WalletActionService = inject(WalletActionService);
@@ -162,18 +162,26 @@ export class CommunicationManagerService {
 
     protected async onWalletSelected(wallet: AppWallet | undefined) {
         if (wallet?.getIdWithAccount() != this.currentWalletIdWithAccount) {
-            this.walletBalanceObservableSubscription?.unsubscribe();
-            this.walletBalanceObservableSubscription = undefined;
+            this.walletBalanceObservableSubscriptions.forEach(subscription => subscription.unsubscribe());
+            this.walletBalanceObservableSubscriptions = [];
         }
 
         this.currentWalletIdWithAccount = wallet?.getIdWithAccount();
 
 
-        if (wallet && !this.walletBalanceObservableSubscription) {
-            this.walletBalanceObservableSubscription = toObservable(
-                wallet.getWalletUtxoStateBalanceSignal(),
-                { injector: this.injector }
-            ).subscribe(this.onWalletBalanceUpdated.bind(this));
+        if (wallet && !this.walletBalanceObservableSubscriptions.length) {
+            this.walletBalanceObservableSubscriptions.push(
+                toObservable(
+                    wallet.getWalletUtxoStateBalanceSignal(),
+                    { injector: this.injector }
+                ).subscribe(this.onWalletBalanceUpdated.bind(this))
+            );
+            this.walletBalanceObservableSubscriptions.push(
+                toObservable(
+                    wallet.getBalanceSignal(),
+                    { injector: this.injector }
+                ).subscribe(this.onWalletTotalBalanceUpdated.bind(this))
+            );
         }
 
         await this.resetAllowedAppsAndAskForPermission();
@@ -183,6 +191,34 @@ export class CommunicationManagerService {
         await this.sendUpdateWalletInfoEvent(this.walletService.getCurrentWallet());
     }
 
+    protected async onWalletTotalBalanceUpdated(balance: undefined | TotalBalanceWithUtxosInterface) {
+        await this.sendUpdateWalletInfoEvent(this.walletService.getCurrentWallet());
+    }
+
+    protected getWalletInfoBalance(wallet: AppWallet) {
+        const processorBalance = wallet.getUtxoProcessorManager()?.getContext()?.balance;
+
+        if (processorBalance?.mature !== undefined) {
+            return {
+                current: this.kaspaNetworkActionsService.sompiToNumber(processorBalance.mature),
+                pending: this.kaspaNetworkActionsService.sompiToNumber(processorBalance.pending),
+                outgoing: this.kaspaNetworkActionsService.sompiToNumber(processorBalance.outgoing),
+            };
+        }
+
+        const loadedBalance = wallet.getBalanceSignal()();
+
+        if (loadedBalance?.totalBalance !== undefined) {
+            return {
+                current: this.kaspaNetworkActionsService.sompiToNumber(loadedBalance.totalBalance),
+                pending: 0,
+                outgoing: 0,
+            };
+        }
+
+        return null;
+    }
+
     protected async sendUpdateWalletInfoEvent(wallet: AppWallet | undefined, specificApp?: BaseCommunicationApp) {
         const message: WalletMessageInterface = {
             type: WalletMessageTypeEnum.WalletInfo,
@@ -190,19 +226,10 @@ export class CommunicationManagerService {
         };
 
         if (wallet) {
-            const balance = wallet.getUtxoProcessorManager()?.getContext()
-                ?.balance;
             message.payload = {
                 walletAddress: wallet.getAddress(),
                 kasplexL2Address: wallet.getL2WalletStateSignal()()?.address,
-                balance:
-                    balance?.mature === undefined
-                        ? null
-                        : {
-                            current: this.kaspaNetworkActionsService.sompiToNumber(balance.mature),
-                            pending: this.kaspaNetworkActionsService.sompiToNumber(balance.pending),
-                            outgoing: this.kaspaNetworkActionsService.sompiToNumber(balance.outgoing),
-                        },
+                balance: this.getWalletInfoBalance(wallet),
             };
         }
 

--- a/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
@@ -181,6 +181,14 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
       if (this.activeConnectingRpc === currentRpc) {
         this.activeConnectingRpc = undefined;
       }
+
+      if (generation === this.connectionGeneration && this.rpcService.isUsingStoredRpcUrl()) {
+        console.warn('Stored Kaspa RPC failed; falling back to resolver', err);
+        this.rpcService.clearStoredRpcUrl();
+        this.rpcService.refreshRpc();
+        return await this.handleConnection(false, generation);
+      }
+
       if (generation === this.connectionGeneration) {
         this.setSignalStatusIfChanged(RpcConnectionStatus.DISCONNECTED);
         this.scheduleReconnect('connection-failure', undefined, generation);

--- a/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-network-connection-manager.service.ts
@@ -183,9 +183,20 @@ export class KaspaNetworkConnectionManagerService implements OnDestroy {
       }
 
       if (generation === this.connectionGeneration && this.rpcService.isUsingStoredRpcUrl()) {
-        console.warn('Stored Kaspa RPC failed; falling back to resolver', err);
+        console.warn('Stored Kaspa RPC failed; falling back to configured RPC', err);
         this.rpcService.clearStoredRpcUrl();
         this.rpcService.refreshRpc();
+        return await this.handleConnection(false, generation);
+      }
+
+      if (generation === this.connectionGeneration && this.rpcService.isUsingConfiguredRpcUrl()) {
+        if (this.rpcService.useNextConfiguredRpcUrl()) {
+          console.warn('Configured Kaspa RPC failed; trying next configured RPC', err);
+        } else {
+          console.warn('Configured Kaspa RPCs failed; falling back to resolver', err);
+          this.rpcService.useResolver();
+        }
+
         return await this.handleConnection(false, generation);
       }
 

--- a/src/app/services/kaspa-netwrok-services/rpc.service.ts
+++ b/src/app/services/kaspa-netwrok-services/rpc.service.ts
@@ -10,6 +10,9 @@ export class RpcService {
   private RPC?: RpcClient;
   private network: string;
   private usingStoredRpcUrl = false;
+  private usingConfiguredRpcUrl = false;
+  private usingResolver = false;
+  private configuredRpcUrlIndex = 0;
 
   constructor(private readonly kaspaL1NetworkService: KaspaL1NetworkService) {
     this.network = this.kaspaL1NetworkService.getNetworkId();
@@ -20,17 +23,21 @@ export class RpcService {
     return this.RPC;
   }
 
-  refreshRpc() {
+  refreshRpc(options?: { skipStoredRpcUrl?: boolean; useResolver?: boolean }) {
     const previousRpc = this.RPC;
     this.network = this.kaspaL1NetworkService.getNetworkId();
     let storedRpcUrl: string | null = null;
-    try {
-      storedRpcUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL);
-    } catch (err) {
-      console.warn('Failed reading RPC URL from localStorage', err);
+    if (!options?.skipStoredRpcUrl) {
+      try {
+        storedRpcUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.RPC_URL);
+      } catch (err) {
+        console.warn('Failed reading RPC URL from localStorage', err);
+      }
     }
 
     this.usingStoredRpcUrl = !!storedRpcUrl;
+    this.usingConfiguredRpcUrl = false;
+    this.usingResolver = false;
 
     if (this.usingStoredRpcUrl) {
       this.RPC = new RpcClient({
@@ -38,7 +45,17 @@ export class RpcService {
         encoding: Encoding.Borsh,
         networkId: this.network,
       });
+    } else if (!options?.useResolver && this.getConfiguredRpcUrls().length) {
+      const urls = this.getConfiguredRpcUrls();
+      const url = urls[this.configuredRpcUrlIndex] ?? urls[0];
+      this.usingConfiguredRpcUrl = true;
+      this.RPC = new RpcClient({
+        url,
+        encoding: Encoding.Borsh,
+        networkId: this.network,
+      });
     } else {
+      this.usingResolver = true;
       this.RPC = new RpcClient({
         resolver: new Resolver(),
         encoding: Encoding.Borsh,
@@ -49,6 +66,10 @@ export class RpcService {
     this.disconnectRpc(previousRpc);
 
     return this.getRpc();
+  }
+
+  private getConfiguredRpcUrls(): string[] {
+    return this.kaspaL1NetworkService.getCurrentNetwork().kaspaWrpcUrls ?? [];
   }
 
   clearStoredRpcUrl(): void {
@@ -65,12 +86,36 @@ export class RpcService {
     return this.usingStoredRpcUrl;
   }
 
+  isUsingConfiguredRpcUrl(): boolean {
+    return this.usingConfiguredRpcUrl;
+  }
+
+  isUsingResolver(): boolean {
+    return this.usingResolver;
+  }
+
+  useNextConfiguredRpcUrl(): boolean {
+    const urls = this.getConfiguredRpcUrls();
+    if (this.configuredRpcUrlIndex + 1 >= urls.length) {
+      return false;
+    }
+
+    this.configuredRpcUrlIndex++;
+    this.refreshRpc({ skipStoredRpcUrl: true });
+    return true;
+  }
+
+  useResolver(): void {
+    this.refreshRpc({ skipStoredRpcUrl: true, useResolver: true });
+  }
+
   setNetwork(network: string): boolean {
     if (!this.kaspaL1NetworkService.setCurrentNetwork(network)) {
       return false;
     }
 
     this.network = this.kaspaL1NetworkService.getNetworkId();
+    this.configuredRpcUrlIndex = 0;
 
     this.clearStoredRpcUrl();
 

--- a/src/app/services/kaspa-netwrok-services/rpc.service.ts
+++ b/src/app/services/kaspa-netwrok-services/rpc.service.ts
@@ -9,6 +9,7 @@ import { KaspaL1NetworkService } from './kaspa-l1-network.service';
 export class RpcService {
   private RPC?: RpcClient;
   private network: string;
+  private usingStoredRpcUrl = false;
 
   constructor(private readonly kaspaL1NetworkService: KaspaL1NetworkService) {
     this.network = this.kaspaL1NetworkService.getNetworkId();
@@ -29,9 +30,11 @@ export class RpcService {
       console.warn('Failed reading RPC URL from localStorage', err);
     }
 
-    if (storedRpcUrl) {
+    this.usingStoredRpcUrl = !!storedRpcUrl;
+
+    if (this.usingStoredRpcUrl) {
       this.RPC = new RpcClient({
-        url: storedRpcUrl,
+        url: storedRpcUrl!,
         encoding: Encoding.Borsh,
         networkId: this.network,
       });
@@ -48,6 +51,20 @@ export class RpcService {
     return this.getRpc();
   }
 
+  clearStoredRpcUrl(): void {
+    try {
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.RPC_URL);
+    } catch (err) {
+      console.warn('Failed clearing custom RPC URL from localStorage', err);
+    }
+
+    this.usingStoredRpcUrl = false;
+  }
+
+  isUsingStoredRpcUrl(): boolean {
+    return this.usingStoredRpcUrl;
+  }
+
   setNetwork(network: string): boolean {
     if (!this.kaspaL1NetworkService.setCurrentNetwork(network)) {
       return false;
@@ -55,11 +72,7 @@ export class RpcService {
 
     this.network = this.kaspaL1NetworkService.getNetworkId();
 
-    try {
-      localStorage.removeItem(LOCAL_STORAGE_KEYS.RPC_URL);
-    } catch (err) {
-      console.warn('Failed clearing custom RPC URL from localStorage', err);
-    }
+    this.clearStoredRpcUrl();
 
     this.refreshRpc();
     return true;

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -53,6 +53,7 @@ export interface L1NetworkConfigInterface {
   network: string;
   shortName: string;
   icon: string;
+  kaspaWrpcUrls?: string[];
   kaspaComApiBaseurl: string;
   kaspaComDefiApiBaseurl: string;
   kasplexApiBaseurl?: string;

--- a/src/environments/l1-network-configurations.ts
+++ b/src/environments/l1-network-configurations.ts
@@ -5,6 +5,9 @@ export const KASPA_MAINNET_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
   network: KASPA_NETWORKS.MAINNET,
   shortName: 'Kaspa Mainnet',
   icon: 'images/tokens-logos/KAS.png',
+  kaspaWrpcUrls: [
+    'wss://mainnet-node.kaspa.com/kaspa/mainnet/wrpc/borsh',
+  ],
   kaspaComApiBaseurl: 'https://api.kaspa.com',
   kaspaComDefiApiBaseurl: 'https://api-defi.kaspa.com',
   kasplexApiBaseurl: 'https://api.kasplex.org/v1',
@@ -20,6 +23,10 @@ export const KASPA_TN10_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
   network: KASPA_NETWORKS.TESTNET10,
   shortName: 'Kaspa TN10',
   icon: 'images/tokens-logos/KAS.png',
+  kaspaWrpcUrls: [
+    'wss://tn10-node.kaspa.com/kaspa/testnet-10/wrpc/borsh',
+    'wss://tn10-node.kaspa.com/testnet-10',
+  ],
   kaspaComApiBaseurl: 'https://dev-api.kaspa.com',
   kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
   kasplexApiBaseurl: 'https://tn10api.kasplex.org/v1',


### PR DESCRIPTION
## Summary\n- send wallet-info balance from live UTXO state when available\n- fall back to the wallet's loaded total balance before publishing null\n- notify iframe consumers when the loaded total balance changes, not only when the UTXO processor emits\n- prefer KaspaCom/Kaspiano configured L1 wRPC endpoints before public resolver\n- clear a stale stored custom L1 RPC URL and fall back to configured endpoints/resolver if that stored node fails\n\n## Configured L1 wRPC endpoints\n- mainnet: wss://mainnet-node.kaspa.com/kaspa/mainnet/wrpc/borsh\n- TN10: wss://tn10-node.kaspa.com/kaspa/testnet-10/wrpc/borsh\n- TN10 fallback: wss://tn10-node.kaspa.com/testnet-10\n\n## Verification\n- npm run build:dev\n- live endpoint probe: all configured mainnet/TN10 endpoints connected with isSynced=true and hasUtxoIndex=true\n- latest commit retriggered CI