### PR TITLE
fix: support KRC721 marketplace delist

### DIFF
--- a/src/app/services/kaspa-netwrok-services/kaspa-network-transactions-manager.service.ts
+++ b/src/app/services/kaspa-netwrok-services/kaspa-network-transactions-manager.service.ts
@@ -391,11 +391,8 @@ export class KaspaNetworkTransactionsManagerService {
     }
 
     if (!entry) {
-      // not support to happen
-      console.log(entry,)
       throw new Error(
-        `Commit UTXO not found, revealTransactionId: ${commitUtxoTransactionId}, scriptAddress: ${operationScript.scriptAddress
-        }, wallet address: ${wallet.getAddress()}`
+        `Reveal-only commit UTXO not found. The listing commit may already be spent or is not available at the derived script address. commitTransactionId: ${commitUtxoTransactionId || 'not provided'}, scriptAddress: ${operationScript.scriptAddress}, walletAddress: ${wallet.getAddress()}`
       );
     }
 

--- a/src/app/services/protocols/krc721/krc721-action-data.service.spec.ts
+++ b/src/app/services/protocols/krc721/krc721-action-data.service.spec.ts
@@ -1,0 +1,109 @@
+import { WalletActionResultType } from "@kaspacom/wallet-messages";
+import { AppWallet } from "../../../classes/AppWallet";
+import { CommitRevealAction } from "../../../types/wallet-action";
+import { Krc721CompletedActionDataService } from "./krc721-completed-action-data.service";
+import { Krc721ReviewActionDataService } from "./krc721-review-action-data.service";
+
+describe('KRC721 action display services', () => {
+    const walletAddress = 'kaspatest:qwalletaddress';
+    const wallet = { getAddress: () => walletAddress } as unknown as AppWallet;
+    const kaspaNetworkActionsService = {
+        sompiToNumber: (amount: bigint) => Number(amount) / 100_000_000,
+    };
+
+    function commitRevealAction(protocolAction: object, options?: CommitRevealAction['options']): CommitRevealAction {
+        return {
+            actionScript: {
+                type: 'kspr',
+                stringifyAction: JSON.stringify(protocolAction),
+            },
+            options,
+        } as CommitRevealAction;
+    }
+
+    describe('Krc721ReviewActionDataService', () => {
+        let service: Krc721ReviewActionDataService;
+
+        beforeEach(() => {
+            service = new Krc721ReviewActionDataService(kaspaNetworkActionsService as any);
+        });
+
+        it('displays KRC721 list actions with collection, token id, wallet, and PSKT price', () => {
+            const display = service.getActionDisplay(commitRevealAction({
+                p: 'krc-721',
+                op: 'list',
+                tick: 'nftx',
+                tokenId: '12',
+            }, {
+                revealPskt: {
+                    outputs: [
+                        { address: walletAddress, amount: 150_000_000n },
+                        { address: 'kaspatest:qcommission', amount: 10_000_000n },
+                    ],
+                    script: {} as any,
+                }
+            }), wallet);
+
+            expect(display?.title).toBe('List KRC721 NFT');
+            expect(display?.rows).toContain(jasmine.objectContaining({
+                fieldName: 'Collection',
+                fieldValue: 'NFTX',
+            }));
+            expect(display?.rows).toContain(jasmine.objectContaining({
+                fieldName: 'Token ID',
+                fieldValue: '12',
+            }));
+            expect(display?.rows).toContain(jasmine.objectContaining({
+                fieldName: 'Price',
+                fieldValue: '1.5 KAS',
+            }));
+        });
+
+        it('displays KRC721 send with commit transaction id as cancel listing', () => {
+            const display = service.getActionDisplay(commitRevealAction({
+                p: 'krc-721',
+                op: 'send',
+                tick: 'nftx',
+                tokenId: '12',
+            }, {
+                commitTransactionId: 'listing-commit-tx',
+            }), wallet);
+
+            expect(display?.title).toBe('Cancel KRC721 NFT Listing');
+            expect(display?.rows).toContain(jasmine.objectContaining({
+                fieldName: 'List Transaction Id',
+                fieldValue: 'listing-commit-tx',
+            }));
+        });
+    });
+
+    describe('Krc721CompletedActionDataService', () => {
+        let service: Krc721CompletedActionDataService;
+
+        beforeEach(() => {
+            service = new Krc721CompletedActionDataService();
+        });
+
+        it('displays completed KRC721 send as a cancel listing transaction', () => {
+            const display = service.getActionDisplay({
+                type: WalletActionResultType.CommitReveal,
+                performedByWallet: walletAddress,
+                commitTransactionId: 'listing-commit-tx',
+                revealTransactionId: 'reveal-tx',
+                protocol: 'kspr',
+                protocolAction: JSON.stringify({
+                    p: 'krc-721',
+                    op: 'send',
+                    tick: 'nftx',
+                    tokenId: '12',
+                }),
+            });
+
+            expect(display?.title).toBe('Cancel KRC721 NFT Listing Transaction');
+            expect(display?.rows).toContain(jasmine.objectContaining({
+                fieldName: 'Reveal Transaction Id',
+                fieldValue: 'reveal-tx',
+            }));
+        });
+    });
+});

--- a/src/app/services/protocols/krc721/krc721-actions-validator.service.spec.ts
+++ b/src/app/services/protocols/krc721/krc721-actions-validator.service.spec.ts
@@ -1,0 +1,116 @@
+import { ERROR_CODES } from "@kaspacom/wallet-messages";
+import { of } from "rxjs";
+import { AppWallet } from "../../../classes/AppWallet";
+import { CommitRevealAction } from "../../../types/wallet-action";
+import { Krc721ActionsValidatorService } from "./krc721-actions-validator.service";
+
+describe('Krc721ActionsValidatorService', () => {
+    let service: Krc721ActionsValidatorService;
+    const walletAddress = 'kaspatest:qwalletaddress';
+    const wallet = { getAddress: () => walletAddress } as unknown as AppWallet;
+    const utils = {
+        isNullOrEmptyString: (value: string | undefined | null) => !value || value.trim().length === 0,
+        isValidWalletAddress: () => true,
+        isNumberString: (value: string) => /^\d+(\.\d+)?$/.test(value),
+    };
+    const krc721Api = {
+        getTokenDetails: jasmine.createSpy('getTokenDetails'),
+    };
+
+    function commitRevealAction(protocolAction: object, options?: CommitRevealAction['options']): CommitRevealAction {
+        return {
+            actionScript: {
+                type: 'kspr',
+                stringifyAction: JSON.stringify(protocolAction),
+            },
+            options,
+        } as CommitRevealAction;
+    }
+
+    beforeEach(() => {
+        krc721Api.getTokenDetails.calls.reset();
+        krc721Api.getTokenDetails.and.returnValue(of({
+            result: {
+                owner: walletAddress,
+            },
+        }));
+        service = new Krc721ActionsValidatorService(utils as any, krc721Api as any);
+    });
+
+    it('validates KRC721 list actions with ticker and token id', async () => {
+        const action = commitRevealAction({
+            p: 'krc-721',
+            op: 'list',
+            tick: 'nftx',
+            tokenId: '12',
+        });
+
+        await expectAsync(service.validateCommitRevealAction(action, wallet)).toBeResolvedTo({
+            isValidated: true,
+        });
+        expect(krc721Api.getTokenDetails).toHaveBeenCalledWith('nftx', '12');
+    });
+
+    it('rejects KRC721 list actions when the wallet is not the NFT owner', async () => {
+        krc721Api.getTokenDetails.and.returnValue(of({
+            result: {
+                owner: 'kaspatest:qotherwallet',
+            },
+        }));
+        const action = commitRevealAction({
+            p: 'krc-721',
+            op: 'list',
+            tick: 'nftx',
+            tokenId: '12',
+        });
+
+        await expectAsync(service.validateCommitRevealAction(action, wallet)).toBeResolvedTo({
+            isValidated: false,
+            errorCode: ERROR_CODES.WALLET_ACTION.INSUFFICIENT_BALANCE,
+        });
+    });
+
+    it('validates KRC721 send delist actions when commit transaction id is provided', async () => {
+        const action = commitRevealAction({
+            p: 'krc-721',
+            op: 'send',
+            tick: 'nftx',
+            tokenId: '12',
+        }, {
+            commitTransactionId: 'listing-commit-tx',
+        });
+
+        await expectAsync(service.validateCommitRevealAction(action, wallet)).toBeResolvedTo({
+            isValidated: true,
+        });
+    });
+
+    it('rejects KRC721 send actions without a commit transaction id', async () => {
+        const action = commitRevealAction({
+            p: 'krc-721',
+            op: 'send',
+            tick: 'nftx',
+            tokenId: '12',
+        });
+
+        await expectAsync(service.validateCommitRevealAction(action, wallet)).toBeResolvedTo({
+            isValidated: false,
+            errorCode: ERROR_CODES.WALLET_ACTION.REVEAL_WITH_NO_COMMIT_ACTION,
+        });
+    });
+
+    it('rejects KRC721 send actions without a token id', async () => {
+        const action = commitRevealAction({
+            p: 'krc-721',
+            op: 'send',
+            tick: 'nftx',
+        }, {
+            commitTransactionId: 'listing-commit-tx',
+        });
+
+        await expectAsync(service.validateCommitRevealAction(action, wallet)).toBeResolvedTo({
+            isValidated: false,
+            errorCode: ERROR_CODES.WALLET_ACTION.INVALID_AMOUNT,
+        });
+    });
+});

--- a/src/app/services/protocols/krc721/krc721-actions-validator.service.ts
+++ b/src/app/services/protocols/krc721/krc721-actions-validator.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@angular/core";
 import { ProtocolActionsValidatorInterface } from "../interfaces/protocol-actions-validator.interface";
 import { AppWallet } from "../../../classes/AppWallet";
 import { CommitRevealAction } from "../../../types/wallet-action";
-import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer } from "../../../types/kaspa-network/krc721-operations-data.interface";
+import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer, Krc721List, Krc721Send } from "../../../types/kaspa-network/krc721-operations-data.interface";
 import { ERROR_CODES } from "@kaspacom/wallet-messages";
 import { UtilsHelper } from "../../utils.service";
 import { firstValueFrom } from "rxjs";
@@ -19,7 +19,7 @@ export class Krc721ActionsValidatorService implements ProtocolActionsValidatorIn
 
     async validateCommitRevealAction(action: CommitRevealAction, wallet: AppWallet): Promise<{ isValidated: boolean; errorCode?: number; }> {
         try {
-            const data = JSON.parse(action.actionScript.stringifyAction) as Krc721Deploy | Krc721Mint | Krc721Transfer;
+            const data = JSON.parse(action.actionScript.stringifyAction) as Krc721Deploy | Krc721Mint | Krc721Transfer | Krc721List | Krc721Send;
 
             switch (data.op) {
                 case Krc721OperationType.TRANSFER:
@@ -28,6 +28,10 @@ export class Krc721ActionsValidatorService implements ProtocolActionsValidatorIn
                     return await this.validateMintKrc721Action(data as Krc721Mint, wallet);
                 case Krc721OperationType.DEPLOY:
                     return await this.validateDeployKrc721Action(data as Krc721Deploy, wallet);
+                case Krc721OperationType.LIST:
+                    return await this.validateListKrc721Action(data as Krc721List, wallet);
+                case Krc721OperationType.SEND:
+                    return this.validateSendKrc721Action(data as Krc721Send, action);
             }
         } catch (error) {
             console.error(error);
@@ -156,6 +160,51 @@ export class Krc721ActionsValidatorService implements ProtocolActionsValidatorIn
                 errorCode: ERROR_CODES.WALLET_ACTION.KASPLEX_API_ERROR,
             };
         }
+    }
+
+    private async validateListKrc721Action(krc721Command: Krc721List, wallet: AppWallet): Promise<{ isValidated: boolean; errorCode?: number; }> {
+        const baseValidation = this.validateTickerAndTokenId(krc721Command);
+
+        if (!baseValidation.isValidated) {
+            return baseValidation;
+        }
+
+        return await this.checkNftOwnership(krc721Command.tick, krc721Command.tokenId, wallet);
+    }
+
+    private validateSendKrc721Action(krc721Command: Krc721Send, action: CommitRevealAction): { isValidated: boolean; errorCode?: number; } {
+        const baseValidation = this.validateTickerAndTokenId(krc721Command);
+
+        if (!baseValidation.isValidated) {
+            return baseValidation;
+        }
+
+        if (this.utils.isNullOrEmptyString(action.options?.commitTransactionId)) {
+            return {
+                isValidated: false,
+                errorCode: ERROR_CODES.WALLET_ACTION.REVEAL_WITH_NO_COMMIT_ACTION,
+            };
+        }
+
+        return { isValidated: true };
+    }
+
+    private validateTickerAndTokenId(krc721Command: Krc721List | Krc721Send): { isValidated: boolean; errorCode?: number; } {
+        if (this.utils.isNullOrEmptyString(krc721Command.tick)) {
+            return {
+                isValidated: false,
+                errorCode: ERROR_CODES.WALLET_ACTION.INVALID_TICKER,
+            };
+        }
+
+        if (this.utils.isNullOrEmptyString(krc721Command.tokenId)) {
+            return {
+                isValidated: false,
+                errorCode: ERROR_CODES.WALLET_ACTION.INVALID_AMOUNT, // Reusing this for invalid token ID
+            };
+        }
+
+        return { isValidated: true };
     }
 
     private async checkNftOwnership(ticker: string, tokenId: string, wallet: AppWallet): Promise<{ isValidated: boolean; errorCode?: number; }> {

--- a/src/app/services/protocols/krc721/krc721-completed-action-data.service.ts
+++ b/src/app/services/protocols/krc721/krc721-completed-action-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { ActionDisplay } from "../../../types/action-display.type";
-import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer } from "../../../types/kaspa-network/krc721-operations-data.interface";
+import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer, Krc721List, Krc721Send } from "../../../types/kaspa-network/krc721-operations-data.interface";
 import { ProtocolCompletedActionDataInterface } from "../interfaces/protocol-completed-action-data.interface";
 import { CompletedActionDisplay } from "../../../types/completed-action-display.type";
 import { CommitRevealActionResult } from "@kaspacom/wallet-messages";
@@ -15,7 +15,7 @@ export class Krc721CompletedActionDataService implements ProtocolCompletedAction
     getActionDisplay(action: CommitRevealActionResult): CompletedActionDisplay | undefined {
 
         try {
-            const operationData: Krc721Deploy | Krc721Mint | Krc721Transfer = JSON.parse(action.protocolAction);
+            const operationData: Krc721Deploy | Krc721Mint | Krc721Transfer | Krc721List | Krc721Send = JSON.parse(action.protocolAction);
 
             switch (operationData.op) {
                 case Krc721OperationType.TRANSFER:
@@ -24,6 +24,10 @@ export class Krc721CompletedActionDataService implements ProtocolCompletedAction
                     return this.getKrc721MintActionDisplay(action, operationData as Krc721Mint);
                 case Krc721OperationType.DEPLOY:
                     return this.getKrc721DeployActionDisplay(action, operationData as Krc721Deploy);
+                case Krc721OperationType.LIST:
+                    return this.getKrc721ListActionDisplay(action, operationData as Krc721List);
+                case Krc721OperationType.SEND:
+                    return this.getKrc721CancelListActionDisplay(action, operationData as Krc721Send);
             }
 
         } catch (error) {
@@ -130,6 +134,50 @@ export class Krc721CompletedActionDataService implements ProtocolCompletedAction
         return {
             title: "Deploy KRC721 Collection Transaction",
             rows: rows
+        }
+    }
+
+    private getKrc721ListActionDisplay(action: CommitRevealActionResult, operationData: Krc721List): ActionDisplay {
+        return {
+            title: "List KRC721 NFT Transaction",
+            rows: [
+                {
+                    fieldName: "Collection",
+                    fieldValue: operationData.tick.toUpperCase()
+                },
+                {
+                    fieldName: "Token ID",
+                    fieldValue: operationData.tokenId
+                },
+                {
+                    fieldName: "Listed By",
+                    fieldValue: action.performedByWallet
+                }
+            ]
+        }
+    }
+
+    private getKrc721CancelListActionDisplay(action: CommitRevealActionResult, operationData: Krc721Send): ActionDisplay {
+        return {
+            title: "Cancel KRC721 NFT Listing Transaction",
+            rows: [
+                {
+                    fieldName: "Collection",
+                    fieldValue: operationData.tick.toUpperCase()
+                },
+                {
+                    fieldName: "Token ID",
+                    fieldValue: operationData.tokenId
+                },
+                {
+                    fieldName: "Wallet",
+                    fieldValue: action.performedByWallet
+                },
+                {
+                    fieldName: "Reveal Transaction Id",
+                    fieldValue: action.revealTransactionId
+                }
+            ]
         }
     }
 }

--- a/src/app/services/protocols/krc721/krc721-review-action-data.service.ts
+++ b/src/app/services/protocols/krc721/krc721-review-action-data.service.ts
@@ -2,15 +2,16 @@ import { Injectable } from "@angular/core";
 import { AppWallet } from "../../../classes/AppWallet";
 import { CommitRevealAction } from "../../../types/wallet-action";
 import { ActionDisplay } from "../../../types/action-display.type";
-import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer } from "../../../types/kaspa-network/krc721-operations-data.interface";
+import { Krc721OperationType, Krc721Deploy, Krc721Mint, Krc721Transfer, Krc721List, Krc721Send } from "../../../types/kaspa-network/krc721-operations-data.interface";
 import { ProtocolReviewActionDataInterface } from "../interfaces/protocol-review-action-data.interface";
+import { KaspaNetworkActionsService } from "../../kaspa-netwrok-services/kaspa-network-actions.service";
 
 @Injectable({
     providedIn: 'root',
 })
 export class Krc721ReviewActionDataService implements ProtocolReviewActionDataInterface {
 
-    constructor() { }
+    constructor(private readonly kaspaNetworkActionsService: KaspaNetworkActionsService) { }
 
     getActionDisplay(action: CommitRevealAction | undefined, wallet: AppWallet): ActionDisplay | undefined {
 
@@ -19,7 +20,7 @@ export class Krc721ReviewActionDataService implements ProtocolReviewActionDataIn
         }
 
         try {
-            const operationData: Krc721Deploy | Krc721Mint | Krc721Transfer = JSON.parse(action.actionScript.stringifyAction);
+            const operationData: Krc721Deploy | Krc721Mint | Krc721Transfer | Krc721List | Krc721Send = JSON.parse(action.actionScript.stringifyAction);
 
             switch (operationData.op) {
                 case Krc721OperationType.TRANSFER:
@@ -28,6 +29,12 @@ export class Krc721ReviewActionDataService implements ProtocolReviewActionDataIn
                     return this.getKrc721MintActionDisplay(operationData as Krc721Mint, wallet);
                 case Krc721OperationType.DEPLOY:
                     return this.getKrc721DeployActionDisplay(operationData as Krc721Deploy, wallet);
+                case Krc721OperationType.LIST:
+                    return this.getKrc721ListActionDisplay(operationData as Krc721List, wallet, action);
+                case Krc721OperationType.SEND:
+                    if (action.options?.commitTransactionId) {
+                        return this.getKrc721CancelListActionDisplay(operationData as Krc721Send, wallet, action);
+                    }
             }
 
         } catch (error) {
@@ -134,6 +141,66 @@ export class Krc721ReviewActionDataService implements ProtocolReviewActionDataIn
         return {
             title: "Deploy KRC721 Collection",
             rows: rows
+        }
+    }
+
+    private getKrc721ListActionDisplay(operationData: Krc721List, wallet: AppWallet, action: CommitRevealAction): ActionDisplay {
+        let totalPrice = "Unknown";
+
+        if (action.options?.revealPskt) {
+            const totalAmount = action.options.revealPskt.outputs
+                ?.filter(output => output.address === wallet.getAddress())
+                .reduce((acc, output) => acc + output.amount, 0n);
+
+            totalPrice = totalAmount && totalAmount > 0n
+                ? this.kaspaNetworkActionsService.sompiToNumber(totalAmount).toString()
+                : totalPrice;
+        }
+
+        return {
+            title: "List KRC721 NFT",
+            rows: [
+                {
+                    fieldName: "Collection",
+                    fieldValue: operationData.tick.toUpperCase()
+                },
+                {
+                    fieldName: "Token ID",
+                    fieldValue: operationData.tokenId
+                },
+                {
+                    fieldName: "Wallet",
+                    fieldValue: wallet.getAddress()
+                },
+                {
+                    fieldName: "Price",
+                    fieldValue: totalPrice + ' KAS'
+                }
+            ]
+        }
+    }
+
+    private getKrc721CancelListActionDisplay(operationData: Krc721Send, wallet: AppWallet, action: CommitRevealAction): ActionDisplay {
+        return {
+            title: "Cancel KRC721 NFT Listing",
+            rows: [
+                {
+                    fieldName: "Collection",
+                    fieldValue: operationData.tick.toUpperCase()
+                },
+                {
+                    fieldName: "Token ID",
+                    fieldValue: operationData.tokenId
+                },
+                {
+                    fieldName: "Wallet",
+                    fieldValue: wallet.getAddress()
+                },
+                {
+                    fieldName: "List Transaction Id",
+                    fieldValue: action.options!.commitTransactionId!
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
## What changed
- Adds KRC721 `list` and reveal-only `send` support to the web wallet KRC721 validator.
- Requires `options.commitTransactionId` for KRC721 `send` delist/cancel-listing actions.
- Adds approval/completed display rows for KRC721 list and cancel NFT listing actions.
- Improves the missing P2SH commit UTXO error so delist failures surface a useful reason instead of only `unknown error`.
- Adds OpenSpec artifacts for the fix and focused Karma unit coverage.

## Why
Kaspiano already sends decentralized NFT delist requests as KRC721 `op: "send"` with the original listing `commitTransactionId`. Kasware succeeds because it supports that reveal-only path; the web wallet rejected/failed the KRC721 protocol layer before the existing reveal-only transaction path could work cleanly.

## OpenSpec
- Change: `fix-krc721-send-delist`
- Validation: `openspec validate fix-krc721-send-delist` passed
- Tasks: 6/6 complete

## Quality Gates — Tier 2 (Full)
**Reason:** Multi-file protocol/action handling change with validator, transaction error handling, display services, tests, and OpenSpec artifacts.

- [x] G1: Tests written — 2 new spec files covering KRC721 list/send validation and review/completed display behavior
- [x] G2: Build passes — `npm run build` exit 0
- [x] G3: Tests pass — `CHROME_BIN=/usr/bin/chromium-browser npm run test -- --watch=false --karma-config=/tmp/kaspacom-wallet-karma.conf.js`, 42/42 success
- [x] G4: Self-review — 5/5 checks confirmed
- [x] G5: Cross-model review — Claude review approved after blockers were fixed

### Self-Review
1. Fixes issue: ✅ KRC721 `send` delist is now recognized, requires the original commit tx id, and can reach the existing reveal-only P2SH path.
2. No regressions: ✅ Existing deploy/mint/transfer branches remain unchanged; list ownership validation mirrors transfer ownership safety.
3. Simplest approach: ✅ No wallet-messages schema change and no duplicate PSKT implementation.
4. Edge cases: ✅ Missing ticker/token id, missing commit tx id, non-owner list attempts, and missing reveal UTXO have explicit handling/tests.
5. Security: ✅ No secrets or new dependencies; list approval now checks NFT ownership.

### Cross-Model Review
- Reviewer: Claude Code / Opus
- Initial findings: 2 major blockers found and fixed
  - KRC721 list now checks NFT ownership before approval.
  - KRC721 send without commit id now returns `REVEAL_WITH_NO_COMMIT_ACTION` instead of `INVALID_ACTION_TYPE`.
- Final review: 0 critical/major blockers, recommendation APPROVE

## Notes
The first raw `ng test --browsers=ChromeHeadless` attempt failed because this VPS needs an explicit Chrome binary/no-sandbox Karma launcher. The rerun used a temporary `/tmp` Karma config only for CI-style local execution; no test config file was added to the repo.
