### PR TITLE
[codex] Add indexer-backed contract tracking

### DIFF
--- a/docs/contracts-indexer-product-plan.md
+++ b/docs/contracts-indexer-product-plan.md
@@ -31,7 +31,9 @@ Important implementation rule: prefer `/covenants?wallet=...` over `/addresses/{
 KCW-77, My Contracts dashboard:
 
 - Default full-screen view is My Contracts.
-- Fetch with `/covenants?wallet=...`; support filters by template, active state, and role via `walletArg`.
+- Fetch My Contracts with `/covenants?wallet=...&sort=recent&limit=...` and filter supported wallet templates client-side.
+- Do not require `classification=covenant` for My Contracts because fresh wallet-created templates can be indexed as `unknown/unrevealed` while still exposing `claimedTemplate` and `claimedArgs`.
+- Support optional filters by template, active state, classification state, and role via `walletArg`.
 - Cards show type, status, locked KAS, participants, deadline/unlock, latest tx/action, and next action.
 - Local registry entries remain visible only as fallback/cache.
 

--- a/docs/contracts-indexer-product-plan.md
+++ b/docs/contracts-indexer-product-plan.md
@@ -1,0 +1,107 @@
+# Contracts indexer product plan
+
+This is the handoff for refining KCW-77 through KCW-84 and briefing Claude Design. The product goal is not more covenant mechanics first; it is the data foundation and user flows that make existing v1 covenant templates usable in the wallet.
+
+## Source of truth
+
+Use the covenant indexer as the source of truth for contract lifecycle state. Local registry data is only a cache/fallback while the indexer catches up.
+
+Configured indexers:
+
+- Mainnet: `https://indexer.kaspa.com`
+- TN10: `https://tn10-indexer.kaspa.com`
+
+Primary endpoints:
+
+- `GET /covenants?wallet={addressOrPubkey}&active={bool}&sort=recent&limit={n}`
+- `GET /covenants?wallet={wallet}&walletArg={role}&template={template}`
+- `GET /covenants?q={query}` for broad import fallback, including covenant addresses
+- `GET /covenants/{idOrScriptHash}`
+- `GET /covenants/by-id/{covenant_id}`
+- `GET /covenants/{idOrScriptHash}/actions`
+- `GET /covenants/{idOrScriptHash}/utxos`
+- `GET /tx/{txid}`
+- `GET /tx/{txid}/settlement-status`
+- `GET /explorer/search?q={query}`
+
+Important implementation rule: prefer `/covenants?wallet=...` over `/addresses/{address}/covenants` for My Contracts, because wallet matching must include participant args and decoded constructor args, not only covenant P2SH addresses.
+
+## Jira refinements
+
+KCW-77, My Contracts dashboard:
+
+- Default full-screen view is My Contracts.
+- Fetch with `/covenants?wallet=...`; support filters by template, active state, and role via `walletArg`.
+- Cards show type, status, locked KAS, participants, deadline/unlock, latest tx/action, and next action.
+- Local registry entries remain visible only as fallback/cache.
+
+KCW-78, Guided deployment wizard:
+
+- V1 templates: Deadman Switch, Time Lock, MultiSig, Escrow.
+- Use friendly forms, address/account pickers, date-time inputs, validation, and final review.
+- After deploy, poll `/tx/{txid}/settlement-status`.
+- Once indexed, expose canonical `covenantIdHex` for share/import.
+
+KCW-79, Education/tooltips:
+
+- Explain template purpose, roles, parameters, possible actions, and risks.
+- Use `constructor`, `claimedArgs`, `decodedArgs`, `classificationStatus`, and `claimVerified` to explain state confidence.
+- Put raw IDs, outpoints, args, and JSON under Advanced.
+
+KCW-80, Share/import:
+
+- Share links carry only `network` and canonical covenant ID.
+- Import accepts covenant ID, script hash, txid, covenant address, or concrete search result.
+- Use direct covenant lookup first, tx lookup second, `/covenants?q=` for addresses, and `/explorer/search` for concrete ID discovery.
+- If already tracked, open the existing detail instead of duplicating local registry state.
+
+KCW-81, Contract detail:
+
+- Detail is the canonical tracking screen.
+- Load summary/timeline from `/covenants/{id}` or `/covenants/by-id/{id}`.
+- Load active spendable UTXOs from `/covenants/{id}/utxos`.
+- Load history from `/covenants/{id}/actions`.
+- Show current active continuation/deadline from latest indexed state, not only original deploy params.
+
+KCW-82, Role-based actions:
+
+- Normal mode uses contextual actions, not generic Interact.
+- Deadman: Keep Alive, Claim.
+- Time Lock: Withdraw, Recover.
+- MultiSig: Create Partial, Sign, Complete.
+- Escrow: Release, Refund, Arbitrate.
+- Enabled state comes from wallet role, active UTXO, deadline/unlock, and latest indexer state.
+- Manual JSON/ABI interaction remains Advanced/dev mode only.
+
+KCW-83, Indexer dependency:
+
+- Treat as foundational for wallet contract tracking.
+- Required fields: template, canonical covenant ID, script hash, active UTXO/outpoint, locked amount, roles/participants, latest tx/action, action timeline, latest continuation/current state, deadline/unlock, and confidence fields.
+- If latest continuation, current UTXO, role, or deadline cannot be determined, UI must show tracking incomplete and disable unsafe actions.
+
+KCW-84, E2E QA:
+
+- Deadman deploy -> indexed -> keep alive -> detail shows new deadline/latest continuation.
+- Import Deadman by covenant ID -> same latest state appears.
+- Time Lock shows locked/unlocked and withdraw/recover state correctly.
+- MultiSig signer A creates partial -> signer B imports/signs/completes.
+- Escrow release/refund/arbitrate buttons match role and status.
+- Approval modal shows human-readable summary, not raw JSON/outpoints.
+
+## Claude Design brief
+
+Design the full-screen `/app/contracts` workspace using the current wallet design system. The compact wallet UI is only an entry point into this workspace.
+
+Required product areas:
+
+- My Contracts dashboard
+- Create wizard
+- Import/share flow
+- Contract detail
+- Timeline/history
+- Role-based action panel
+- Approval-summary content
+- Advanced technical drawer
+- Empty/loading/error/indexer-unavailable/tracking-incomplete states
+
+Design around normal wallet users. They need to understand what they created, who is involved, what funds are locked, what can happen next, and what action they can safely take. Raw covenant IDs, outpoints, args, and JSON should be accessible but hidden by default.

--- a/docs/contracts-indexer-product-plan.md
+++ b/docs/contracts-indexer-product-plan.md
@@ -35,6 +35,7 @@ KCW-77, My Contracts dashboard:
 - Do not require `classification=covenant` for My Contracts because fresh wallet-created templates can be indexed as `unknown/unrevealed` while still exposing `claimedTemplate` and `claimedArgs`.
 - Support optional filters by template, active state, classification state, and role via `walletArg`.
 - Cards show type, status, locked KAS, participants, deadline/unlock, latest tx/action, and next action.
+- Enable spend/action buttons only when the current indexer state has exactly one active UTXO. If multiple active UTXOs are present, show the contract but mark action tracking incomplete until a UTXO picker exists.
 - Local registry entries remain visible only as fallback/cache.
 
 KCW-78, Guided deployment wizard:

--- a/docs/kcw-contracts-ticket-updates.md
+++ b/docs/kcw-contracts-ticket-updates.md
@@ -14,6 +14,7 @@ Acceptance criteria:
 - Role/template filters use `walletArg`, `template`, and `active` query params.
 - Supported v1 templates are Deadman Switch, Time Lock, MultiSig, and Escrow.
 - Each card shows contract type, status, locked amount, participants/roles, deadline or unlock time, latest tx/action, and next available action.
+- Spend/action buttons are enabled only when the indexer reports exactly one active UTXO. Multiple active UTXOs must remain visible in details but actions stay disabled until the wallet has explicit UTXO selection.
 - Local registry entries are merged only as fallback/cache while indexer data catches up.
 - If indexer is unavailable, show local cached entries with an indexer-unavailable message.
 - Raw IDs, args, outpoints, and JSON stay hidden under Advanced or detail views.

--- a/docs/kcw-contracts-ticket-updates.md
+++ b/docs/kcw-contracts-ticket-updates.md
@@ -8,7 +8,8 @@ Build the default full-screen `/app/contracts` view as an indexer-backed My Cont
 
 Acceptance criteria:
 
-- Dashboard loads contracts involving the current wallet from `GET /covenants?wallet={addressOrPubkey}&active={bool}&sort=recent&limit={n}`.
+- Dashboard loads contracts involving the current wallet from `GET /covenants?wallet={addressOrPubkey}&sort=recent&limit={n}`.
+- The default My Contracts query must not require `classification=covenant`; fresh wallet template contracts can still be `unknown/unrevealed` but discoverable by `claimedTemplate` and `claimedArgs`.
 - Wallet lookup checks both wallet address and x-only pubkey where available.
 - Role/template filters use `walletArg`, `template`, and `active` query params.
 - Supported v1 templates are Deadman Switch, Time Lock, MultiSig, and Escrow.
@@ -22,6 +23,7 @@ Indexer dependencies:
 - `GET /covenants?wallet={wallet}`
 - `GET /covenants?wallet={wallet}&walletArg={role}`
 - `GET /covenants?wallet={wallet}&template={template}&active={bool}`
+- `GET /covenants?wallet={wallet}&classificationStatus={status}` for explicit confidence/status filters only, not the default wallet dashboard query
 
 ## KCW-78 - Guided deployment wizard
 

--- a/docs/kcw-contracts-ticket-updates.md
+++ b/docs/kcw-contracts-ticket-updates.md
@@ -1,0 +1,169 @@
+# KCW contracts ticket updates
+
+Copy these into KCW-77 through KCW-84. They are written as ticket body updates or implementation comments.
+
+## KCW-77 - My Contracts dashboard
+
+Build the default full-screen `/app/contracts` view as an indexer-backed My Contracts dashboard for wallet covenant tracking.
+
+Acceptance criteria:
+
+- Dashboard loads contracts involving the current wallet from `GET /covenants?wallet={addressOrPubkey}&active={bool}&sort=recent&limit={n}`.
+- Wallet lookup checks both wallet address and x-only pubkey where available.
+- Role/template filters use `walletArg`, `template`, and `active` query params.
+- Supported v1 templates are Deadman Switch, Time Lock, MultiSig, and Escrow.
+- Each card shows contract type, status, locked amount, participants/roles, deadline or unlock time, latest tx/action, and next available action.
+- Local registry entries are merged only as fallback/cache while indexer data catches up.
+- If indexer is unavailable, show local cached entries with an indexer-unavailable message.
+- Raw IDs, args, outpoints, and JSON stay hidden under Advanced or detail views.
+
+Indexer dependencies:
+
+- `GET /covenants?wallet={wallet}`
+- `GET /covenants?wallet={wallet}&walletArg={role}`
+- `GET /covenants?wallet={wallet}&template={template}&active={bool}`
+
+## KCW-78 - Guided deployment wizard
+
+Build a guided create flow for the four v1 wallet covenant templates.
+
+Acceptance criteria:
+
+- User chooses one of: Deadman Switch, Time Lock, MultiSig, Escrow.
+- Forms use wallet-friendly field names, address/account picker where possible, date-time inputs instead of raw timestamps, and validation before deploy.
+- Review screen explains amount locked, parties, unlock/expiry/deadline, allowed actions, fees, and risk summary before wallet approval.
+- After wallet approval, show txid immediately.
+- After deploy, poll `GET /tx/{txid}/settlement-status`.
+- When indexed, show canonical `covenantIdHex` and enable share link.
+- If not indexed yet, show waiting/indexer-pending state and keep local registry fallback.
+
+Indexer dependencies:
+
+- `GET /tx/{txid}/settlement-status`
+- `GET /tx/{txid}`
+- `GET /covenants/by-id/{covenant_id}` after canonical ID is known
+
+## KCW-79 - User education, tooltips, validator explanations
+
+Make covenant templates understandable to normal wallet users without exposing raw covenant internals by default.
+
+Acceptance criteria:
+
+- Each template explains what it does, when to use it, involved roles, parameters, next actions, and risks.
+- Deadman explains owner, heir, check-in deadline, keep alive, claim, and continuation.
+- Time Lock explains signer, recovery wallet, unlock time, withdraw, and recover.
+- MultiSig explains signers, threshold behavior, partial signing, and completion.
+- Escrow explains buyer, seller, arbiter, release, refund, and arbitrate.
+- Confidence/state copy uses indexer fields where available: `constructor`, `claimedArgs`, `decodedArgs`, `classificationStatus`, `classificationKind`, and `claimVerified`.
+- If claim/template confidence is weak or missing, UI labels the contract as tracking incomplete or unverified.
+- Advanced drawer contains raw covenant ID, script hash, outpoint, args, and JSON.
+
+## KCW-80 - Share/import flow for created contracts
+
+Build a share/import flow that lets another wallet open and track a covenant using public indexer data only.
+
+Acceptance criteria:
+
+- Share link format: `/app/contracts?network={network}&contract={canonicalCovenantId}`.
+- Share link must not include private data, compiled JSON secrets, or local-only wallet state.
+- Receiving wallet reads `network` and `contract` query params.
+- If network is supported, wallet switches/loads that network and previews the contract.
+- If contract is already tracked, open existing detail instead of creating a duplicate local registry entry.
+- Import accepts covenant ID, script hash, txid, covenant address, or concrete search result.
+- Direct ID lookups prefer `GET /covenants/by-id/{covenant_id}` and fall back to `GET /covenants/{idOrScriptHash}`.
+- Tx import uses `GET /tx/{txid}`.
+- Address/fuzzy import uses `GET /covenants?q={query}` first and `GET /explorer/search?q={query}` for concrete covenant/tx results.
+- Template/category search results are not importable by themselves.
+
+Indexer dependencies:
+
+- `GET /covenants/by-id/{covenant_id}`
+- `GET /covenants/{idOrScriptHash}`
+- `GET /tx/{txid}`
+- `GET /covenants?q={query}`
+- `GET /explorer/search?q={query}`
+
+## KCW-81 - Contract detail page with current state and timeline
+
+Build the contract detail page as the canonical tracking screen for current covenant lifecycle state.
+
+Acceptance criteria:
+
+- Detail loads contract summary from `GET /covenants/{idOrScriptHash}` or `GET /covenants/by-id/{covenant_id}`.
+- Detail loads history from `GET /covenants/{idOrScriptHash}/actions`.
+- Detail loads current spendable UTXOs from `GET /covenants/{idOrScriptHash}/utxos`.
+- Header shows type, status, locked amount, and latest action.
+- Participants are displayed as role labels, not raw args.
+- State area shows active UTXO, current continuation, current address, deadline/unlock, and latest tx.
+- Timeline shows deploy/spend/continuation actions.
+- Current state must come from latest active UTXO/action, not only original deploy params.
+- If latest continuation or current UTXO cannot be determined, show tracking incomplete and disable unsafe actions.
+- Advanced drawer shows covenant ID, script hash, outpoint, raw args, and JSON.
+
+## KCW-82 - Replace generic Interact with role-based action buttons
+
+Normal users should see safe contextual contract actions, not the generic ABI/manual interact flow.
+
+Acceptance criteria:
+
+- Deadman actions: Keep Alive, Claim.
+- Time Lock actions: Withdraw, Recover.
+- MultiSig actions: Create Partial, Sign, Complete.
+- Escrow actions: Release, Refund, Arbitrate.
+- Enabled/disabled state is computed from current wallet role, active UTXO, deadline/unlock state, and latest indexer state.
+- If current state is missing or tracking incomplete, disable unsafe spend actions and explain why.
+- Action review/approval summary is human-readable and includes amount, recipient/role, condition, tx fee/risk where relevant.
+- Manual JSON/ABI interaction remains available only under Advanced/dev mode.
+
+Indexer dependencies:
+
+- `GET /covenants/{id}/utxos`
+- `GET /covenants/{id}/actions`
+- current role/participant fields from covenant summary
+
+## KCW-83 - Indexer data required for wallet contract tracking
+
+Treat indexer-backed covenant data as a foundational wallet dependency.
+
+Acceptance criteria:
+
+- Confirm wallet participant search works with wallet address and x-only pubkey.
+- Confirm role filters work with `walletArg` values: owner, heir, buyer, seller, arbiter, key1, key2, key3, signer/recovery where applicable.
+- Confirm canonical ID lookup and script hash lookup behavior.
+- Confirm tx settlement path after deploy.
+- Confirm latest active continuation/current UTXO/deadline can be derived cleanly for Deadman keep-alive.
+- UI must expose tracking incomplete state if latest continuation, deadline, active UTXO, or user role cannot be determined.
+- Unsafe action buttons must be disabled when tracking is incomplete.
+
+Required endpoints:
+
+- `GET /covenants?wallet={wallet}&walletArg={role}&template={template}&active={bool}`
+- `GET /covenants/{id}/actions`
+- `GET /covenants/{id}/utxos`
+- `GET /tx/{txid}/settlement-status`
+- `GET /tx/{txid}`
+- `GET /covenants?q={query}`
+- `GET /explorer/search?q={query}`
+
+## KCW-84 - End-to-end covenant UX QA scenarios
+
+Test the full user lifecycle across the four supported v1 templates.
+
+Acceptance criteria:
+
+- Deadman: deploy -> indexer appears -> keep alive -> detail shows new deadline/latest continuation.
+- Deadman: import by canonical covenant ID -> same latest state appears.
+- Time Lock: before unlock, withdraw is disabled and recover state is clear.
+- Time Lock: after unlock, correct withdraw/recover action is enabled for the correct role.
+- MultiSig: signer A creates partial -> signer B imports/signs/completes -> timeline updates.
+- Escrow: buyer/seller/arbiter see only the actions available to their role.
+- Share link opened in a fresh wallet/session previews or opens the correct contract without duplicate registry entries.
+- Wallet approval modal uses human-readable action summaries, not raw JSON/outpoints.
+- Indexer unavailable and tracking incomplete states are tested.
+
+Regression checks:
+
+- Local-only deployments still appear while waiting for indexer.
+- Unsupported templates fail import with clear copy.
+- Already-imported contracts do not duplicate.
+- Advanced/dev manual interact remains available for developers.

--- a/src/app/services/covenant/covenant-indexer.service.ts
+++ b/src/app/services/covenant/covenant-indexer.service.ts
@@ -99,10 +99,17 @@ export interface IndexerSearchResult {
 }
 
 export interface IndexerTxSettlementStatus {
+  actionCount?: number;
+  actions?: IndexerCovenantAction[];
+  blockTimeMs?: number;
+  continuationCount?: number;
+  decoded?: boolean;
   indexed: boolean;
   indexedAtMs?: string | null;
   indexerStatus?: string | null;
+  matchedCovenantCount?: number;
   scanner?: Record<string, any>;
+  spendCount?: number;
   txidHex: string;
 }
 

--- a/src/app/services/covenant/covenant-indexer.service.ts
+++ b/src/app/services/covenant/covenant-indexer.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { KaspaL1NetworkService } from '../kaspa-netwrok-services/kaspa-l1-network.service';
@@ -13,33 +13,97 @@ export interface IndexerCovenantAction {
   action?: string;
   address?: string;
   blockTimeMs?: number;
+  classificationKind?: string | null;
+  classificationStatus?: string | null;
   covenantIdHex?: string;
+  decodedArgs?: Record<string, any> | null;
+  entrypoint?: string | null;
+  inputs?: Record<string, any> | null;
   outputs?: {
     address?: string;
     amountSompi?: number | string;
     scriptPubKeyHex?: string;
+    state?: Record<string, any> | null;
     vout?: number;
   } | null;
+  scriptHashHex?: string;
   txidHex?: string;
 }
 
 export interface IndexerCovenantDetails {
   address?: string;
+  activeUtxos?: number;
+  canonicalCovenantIdKnown?: boolean;
   claimedArgs?: {
     args?: IndexerCovenantArg[];
     tmpl?: string;
   } | null;
   claimedTemplate?: string | null;
+  claimVerified?: boolean;
+  classificationKind?: string | null;
+  classificationStatus?: string | null;
+  constructor?: Record<string, any> | null;
   covenantIdHex?: string;
   createdAtMs?: number;
+  decodedArgs?: Record<string, any> | null;
   genesisTxidHex?: string;
+  identitySource?: string;
   totalAmountSompi?: number | string;
   scriptHashHex?: string;
+  template?: string | null;
 }
 
 export interface IndexerCovenantResponse {
   actions?: IndexerCovenantAction[];
   covenant?: IndexerCovenantDetails;
+  events?: IndexerCovenantAction[];
+}
+
+export interface IndexerCovenantUtxo {
+  address?: string;
+  amountSompi?: number | string;
+  covenantIdHex?: string;
+  scriptHashHex?: string;
+  spentByTxidHex?: string | null;
+  state?: Record<string, any> | null;
+  status?: string;
+  txidHex?: string;
+  vout?: number;
+}
+
+export interface IndexerCovenantListParams {
+  template?: string;
+  verified_only?: boolean;
+  classification?: string;
+  classificationStatus?: string;
+  claimArg?: string;
+  claimArgValue?: string;
+  wallet?: string;
+  walletArg?: string;
+  covenantId?: string;
+  q?: string;
+  active?: boolean;
+  sort?: 'recent' | 'active' | 'amount' | 'template' | string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface IndexerSearchResult {
+  description?: string | null;
+  id?: string | null;
+  kind: 'covenant' | 'transaction' | 'address' | 'kcc20' | string;
+  label: string;
+  path: string;
+  score: number;
+  status?: string | null;
+}
+
+export interface IndexerTxSettlementStatus {
+  indexed: boolean;
+  indexedAtMs?: string | null;
+  indexerStatus?: string | null;
+  scanner?: Record<string, any>;
+  txidHex: string;
 }
 
 @Injectable({
@@ -51,9 +115,43 @@ export class CovenantIndexerService {
     private readonly kaspaL1NetworkService: KaspaL1NetworkService,
   ) {}
 
+  async listCovenants(params: IndexerCovenantListParams = {}): Promise<IndexerCovenantDetails[]> {
+    return firstValueFrom(
+      this.http.get<IndexerCovenantDetails[]>(`${this.getBaseUrl()}/covenants`, {
+        params: this.toHttpParams(params),
+      }),
+    );
+  }
+
   async getCovenant(covenantId: string): Promise<IndexerCovenantResponse> {
     return firstValueFrom(
       this.http.get<IndexerCovenantResponse>(`${this.getBaseUrl()}/covenants/${covenantId}`),
+    );
+  }
+
+  async getCovenantByCanonicalId(covenantId: string): Promise<IndexerCovenantResponse> {
+    return firstValueFrom(
+      this.http.get<IndexerCovenantResponse>(`${this.getBaseUrl()}/covenants/by-id/${covenantId}`),
+    );
+  }
+
+  async getCovenantActions(covenantIdOrScriptHash: string): Promise<IndexerCovenantAction[]> {
+    return firstValueFrom(
+      this.http.get<IndexerCovenantAction[]>(`${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/actions`),
+    );
+  }
+
+  async getCovenantUtxos(covenantIdOrScriptHash: string): Promise<IndexerCovenantUtxo[]> {
+    return firstValueFrom(
+      this.http.get<IndexerCovenantUtxo[]>(`${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/utxos`),
+    );
+  }
+
+  async getAddressEvents(address: string, limit = 50): Promise<IndexerCovenantAction[]> {
+    return firstValueFrom(
+      this.http.get<IndexerCovenantAction[]>(`${this.getBaseUrl()}/addresses/${address}/events`, {
+        params: this.toHttpParams({ limit }),
+      }),
     );
   }
 
@@ -61,6 +159,29 @@ export class CovenantIndexerService {
     return firstValueFrom(
       this.http.get<IndexerCovenantAction[]>(`${this.getBaseUrl()}/tx/${txid}`),
     );
+  }
+
+  async getTransactionSettlementStatus(txid: string): Promise<IndexerTxSettlementStatus> {
+    return firstValueFrom(
+      this.http.get<IndexerTxSettlementStatus>(`${this.getBaseUrl()}/tx/${txid}/settlement-status`),
+    );
+  }
+
+  async search(query: string, limit = 10): Promise<IndexerSearchResult[]> {
+    return firstValueFrom(
+      this.http.get<IndexerSearchResult[]>(`${this.getBaseUrl()}/explorer/search`, {
+        params: this.toHttpParams({ q: query, limit }),
+      }),
+    );
+  }
+
+  private toHttpParams(params: object): HttpParams {
+    let httpParams = new HttpParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === '') continue;
+      httpParams = httpParams.set(key, String(value));
+    }
+    return httpParams;
   }
 
   private getBaseUrl(): string {

--- a/src/app/services/covenant/covenant-indexer.service.ts
+++ b/src/app/services/covenant/covenant-indexer.service.ts
@@ -122,43 +122,68 @@ export class CovenantIndexerService {
     private readonly kaspaL1NetworkService: KaspaL1NetworkService,
   ) {}
 
-  async listCovenants(params: IndexerCovenantListParams = {}): Promise<IndexerCovenantDetails[]> {
+  async listCovenants(
+    params: IndexerCovenantListParams = {},
+  ): Promise<IndexerCovenantDetails[]> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantDetails[]>(`${this.getBaseUrl()}/covenants`, {
-        params: this.toHttpParams(params),
-      }),
+      this.http.get<IndexerCovenantDetails[]>(
+        `${this.getBaseUrl()}/covenants`,
+        {
+          params: this.toHttpParams(params),
+        },
+      ),
     );
   }
 
   async getCovenant(covenantId: string): Promise<IndexerCovenantResponse> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantResponse>(`${this.getBaseUrl()}/covenants/${covenantId}`),
+      this.http.get<IndexerCovenantResponse>(
+        `${this.getBaseUrl()}/covenants/${covenantId}`,
+      ),
     );
   }
 
-  async getCovenantByCanonicalId(covenantId: string): Promise<IndexerCovenantResponse> {
+  async getCovenantByCanonicalId(
+    covenantId: string,
+  ): Promise<IndexerCovenantResponse> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantResponse>(`${this.getBaseUrl()}/covenants/by-id/${covenantId}`),
+      this.http.get<IndexerCovenantResponse>(
+        `${this.getBaseUrl()}/covenants/by-id/${covenantId}`,
+      ),
     );
   }
 
-  async getCovenantActions(covenantIdOrScriptHash: string): Promise<IndexerCovenantAction[]> {
+  async getCovenantActions(
+    covenantIdOrScriptHash: string,
+  ): Promise<IndexerCovenantAction[]> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantAction[]>(`${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/actions`),
+      this.http.get<IndexerCovenantAction[]>(
+        `${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/actions`,
+      ),
     );
   }
 
-  async getCovenantUtxos(covenantIdOrScriptHash: string): Promise<IndexerCovenantUtxo[]> {
+  async getCovenantUtxos(
+    covenantIdOrScriptHash: string,
+  ): Promise<IndexerCovenantUtxo[]> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantUtxo[]>(`${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/utxos`),
+      this.http.get<IndexerCovenantUtxo[]>(
+        `${this.getBaseUrl()}/covenants/${covenantIdOrScriptHash}/utxos`,
+      ),
     );
   }
 
-  async getAddressEvents(address: string, limit = 50): Promise<IndexerCovenantAction[]> {
+  async getAddressEvents(
+    address: string,
+    limit = 50,
+  ): Promise<IndexerCovenantAction[]> {
     return firstValueFrom(
-      this.http.get<IndexerCovenantAction[]>(`${this.getBaseUrl()}/addresses/${address}/events`, {
-        params: this.toHttpParams({ limit }),
-      }),
+      this.http.get<IndexerCovenantAction[]>(
+        `${this.getBaseUrl()}/addresses/${address}/events`,
+        {
+          params: this.toHttpParams({ limit }),
+        },
+      ),
     );
   }
 
@@ -168,17 +193,24 @@ export class CovenantIndexerService {
     );
   }
 
-  async getTransactionSettlementStatus(txid: string): Promise<IndexerTxSettlementStatus> {
+  async getTransactionSettlementStatus(
+    txid: string,
+  ): Promise<IndexerTxSettlementStatus> {
     return firstValueFrom(
-      this.http.get<IndexerTxSettlementStatus>(`${this.getBaseUrl()}/tx/${txid}/settlement-status`),
+      this.http.get<IndexerTxSettlementStatus>(
+        `${this.getBaseUrl()}/tx/${txid}/settlement-status`,
+      ),
     );
   }
 
   async search(query: string, limit = 10): Promise<IndexerSearchResult[]> {
     return firstValueFrom(
-      this.http.get<IndexerSearchResult[]>(`${this.getBaseUrl()}/explorer/search`, {
-        params: this.toHttpParams({ q: query, limit }),
-      }),
+      this.http.get<IndexerSearchResult[]>(
+        `${this.getBaseUrl()}/explorer/search`,
+        {
+          params: this.toHttpParams({ q: query, limit }),
+        },
+      ),
     );
   }
 
@@ -194,7 +226,9 @@ export class CovenantIndexerService {
   private getBaseUrl(): string {
     const baseUrl = this.kaspaL1NetworkService.getCovenantIndexerApiBaseurl();
     if (!baseUrl) {
-      throw new Error(`Covenant indexer import is not available for ${this.kaspaL1NetworkService.getNetworkId()}.`);
+      throw new Error(
+        `Covenant indexer import is not available for ${this.kaspaL1NetworkService.getNetworkId()}.`,
+      );
     }
 
     return baseUrl.replace(/\/+$/, '');

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -965,7 +965,7 @@
                 (buttonClick)="navigateToContractDetail(contract)"
               >
               </kc-button>
-              @if (contract.status !== "spent") {
+              @if (contract.status === "active") {
                 <kc-button
                   [text]="contract.nextActionLabel"
                   (buttonClick)="openDashboardAction(contract)"
@@ -1011,7 +1011,7 @@
             </button>
           </div>
 
-          @if (selectedDetail()!.entry.status !== "spent") {
+          @if (selectedDetail()!.entry.status === "active") {
             <div class="contract-detail-tabs flex gap-4 rounded">
               <button
                 class="detail-tab-button p-8 rounded typo-text-2"
@@ -1171,7 +1171,7 @@
     (activeTab() === "detail" &&
       detailPanelTab() === "action" &&
       selectedDetail() &&
-      selectedDetail()!.entry.status !== "spent" &&
+      selectedDetail()!.entry.status === "active" &&
       interactContractJson())
   ) {
     <div class="panel flex column gap-20 p-24 rounded-lg">

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -242,6 +242,22 @@
           <app-copy-button [value]="deployResult()!.txid" [size]="'sm'"></app-copy-button>
         </div>
       </div>
+      @if (deployIndexerState()) {
+      <div class="result-row flex column gap-4">
+        <span class="text-gray-60 typo-text-1">Indexer Status</span>
+        <span class="text-white typo-text-2">{{ deployIndexerState()!.message }}</span>
+        @if (deployIndexerState()!.covenantId) {
+        <div class="flex align-items-center gap-8">
+          <span class="text-gray-60 typo-text-2 text-mono">{{ truncate(deployIndexerState()!.covenantId || '', 28) }}</span>
+          <app-copy-button [value]="deployIndexerState()!.covenantId || ''" [size]="'sm'"></app-copy-button>
+          @if (deployIndexerState()!.status === 'indexed') {
+          <kc-button [text]="'Copy Share Link'" (buttonClick)="copyDeployedContractShareLink()">
+          </kc-button>
+          }
+        </div>
+        }
+      </div>
+      }
     </div>
     }
 
@@ -348,10 +364,10 @@
     <!-- Indexer Import -->
     <div class="panel flex column gap-16 p-20 rounded-lg">
       <h3 class="text-white typo-text-1 fw-bold">Import from Indexer</h3>
-      <p class="text-gray-60 typo-text-2">Enter a deploy transaction ID or covenant ID. Only wallet-supported templates can be imported.</p>
+      <p class="text-gray-60 typo-text-2">Enter a covenant ID, script hash, deploy transaction, contract address, or shared contract link value. Only wallet-supported templates can be imported.</p>
       <div class="flex gap-8 align-items-end">
         <div class="form-group flex column gap-8 flex-1">
-          <kc-input [label]="'Deploy TX or Covenant ID'" [placeholder]="'32c30c5f... or 5bff84f6...'"
+          <kc-input [label]="'Contract Lookup'" [placeholder]="'covenant ID, txid, or kaspatest:...'"
             [type]="'text'" [isFullWidth]="true" [isDisabled]="indexerImportLoading()"
             [ngModel]="indexerImportQuery" (valueChange)="indexerImportQuery = $event || ''">
           </kc-input>
@@ -553,7 +569,7 @@
         <kc-button [text]="contract.nextActionLabel" (buttonClick)="openDashboardAction(contract)">
         </kc-button>
         }
-        @if (contract.covenantId || contract.scriptHash) {
+        @if (contract.covenantId) {
         <kc-button [text]="'Copy Share Link'" (buttonClick)="copyContractShareLink(contract)">
         </kc-button>
         }

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -6,6 +6,7 @@
   </div>
 
   <!-- Tabs -->
+  @if (!detailRouteId() && activeTab() !== 'detail') {
   <div class="tabs flex gap-8">
     <button class="tab-button p-12 rounded-lg typo-text-2" [class.active]="activeTab() === 'deploy'"
       (click)="switchTab('deploy')">
@@ -20,6 +21,7 @@
       Lookup / Import
     </button>
   </div>
+  }
 
   <!-- Tab 1: Create / Deploy -->
   @if (activeTab() === 'deploy') {
@@ -65,7 +67,7 @@
         <p class="text-gray-60 typo-text-2">Paste deploy-ready compiled JSON and choose how much KAS to lock.</p>
         }
       </div>
-      <button class="back-button p-8 rounded typo-text-2" (click)="resetTemplateSelection(); createMode.set('template')">
+      <button class="back-button template-change-button p-8 rounded typo-text-2" (click)="resetTemplateSelection(); createMode.set('template')">
         Change
       </button>
     </div>
@@ -443,15 +445,28 @@
   @if (activeTab() === 'my-contracts') {
   <div class="contracts-list flex column gap-16">
 
+    @if (!detailRouteId()) {
     <div class="panel flex column gap-12 p-20 rounded-lg">
-      <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
+      <div class="flex column align-items-start gap-12">
+        <div class="flex align-items-center gap-8 flex-wrap">
+          <div class="contract-filter flex gap-4 rounded">
+            <button class="filter-button p-8 rounded typo-text-2" [class.active]="dashboardFilter() === 'active'"
+              (click)="setDashboardFilter('active')">
+              Active ({{ activeDashboardContracts().length }})
+            </button>
+            <button class="filter-button p-8 rounded typo-text-2" [class.active]="dashboardFilter() === 'history'"
+              (click)="setDashboardFilter('history')">
+              History ({{ historyDashboardContracts().length }})
+            </button>
+          </div>
+          <button class="refresh-button p-8 rounded typo-text-2" [disabled]="dashboardLoading()" (click)="loadContracts()">
+            {{ dashboardLoading() ? 'Refreshing...' : 'Refresh' }}
+          </button>
+        </div>
         <div class="flex column gap-4">
           <h3 class="text-white typo-text-1 fw-bold">My Contracts</h3>
           <p class="text-gray-60 typo-text-2">Tracked by wallet address, role args, active UTXOs, and covenant timeline from the indexer.</p>
         </div>
-        <kc-button [text]="dashboardLoading() ? 'Refreshing...' : 'Refresh'" [isDisabled]="dashboardLoading()"
-          (buttonClick)="loadContracts()">
-        </kc-button>
       </div>
 
       @if (dashboardError()) {
@@ -466,21 +481,52 @@
       </div>
       }
     </div>
+    } @else {
+    <div class="detail-route-header flex justify-content-between align-items-center gap-12 flex-wrap">
+      <button class="back-button p-8 rounded typo-text-2" (click)="backToContractsList()">
+        Back to Contracts
+      </button>
+      @if (selectedDetail() && selectedDetail()!.entry.status !== 'spent') {
+      <span class="text-gray-60 typo-text-2">Actions are available below</span>
+      }
+    </div>
 
-    @if (!dashboardLoading() && dashboardContracts().length === 0) {
+    @if (detailRouteNotFound()) {
     <div class="empty-state p-32 rounded-lg text-center">
-      <p class="text-gray-60 typo-text-1">No contracts found for this wallet on {{ network() }}</p>
+      <p class="text-gray-60 typo-text-1">Contract not found for this wallet on {{ network() }}</p>
     </div>
     }
 
-    @for (contract of dashboardContracts(); track contract.id) {
+    @if (dashboardError()) {
+    <div class="error-message p-12 rounded-lg text-red typo-text-2">
+      {{ dashboardError() }}
+    </div>
+    }
+    }
+
+    @if (!detailRouteId()) {
+    @if (!dashboardLoading() && filteredDashboardContracts().length === 0) {
+    <div class="empty-state p-32 rounded-lg text-center">
+      <p class="text-gray-60 typo-text-1">
+        @if (dashboardFilter() === 'history') {
+        No spent contracts found for this wallet on {{ network() }}
+        } @else {
+        No active contracts found for this wallet on {{ network() }}
+        }
+      </p>
+    </div>
+    }
+
+    @for (contract of filteredDashboardContracts(); track contract.id) {
     <div class="contract-card p-20 rounded-lg flex column gap-16"
       [style.opacity]="contract.status === 'spent' ? '0.5' : '1'">
       <div class="flex justify-content-between align-items-start">
         <div class="flex column gap-4">
           <div class="flex align-items-center gap-8 flex-wrap">
             <h3 class="text-white typo-title-3">{{ contract.displayName }}</h3>
-            <span class="source-badge p-6 rounded typo-text-2">{{ getSourceLabel(contract) }}</span>
+            @for (sourceLabel of getSourceLabels(contract); track sourceLabel) {
+            <span class="source-badge p-6 rounded typo-text-2">{{ sourceLabel }}</span>
+            }
           </div>
           <span class="text-gray-60 typo-text-2">
             {{ formatSompiToKas(contract.amountSompi) }} KAS
@@ -523,11 +569,13 @@
       <div class="flex column gap-4">
         <span class="text-gray-60 typo-text-2">Current Address</span>
         <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerAddressLink(contract.currentAddress || '')" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.currentAddress || 'Unknown', 30) }}
-          </a>
           @if (contract.currentAddress) {
+          <a [href]="getExplorerAddressLink(contract.currentAddress || '')" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(contract.currentAddress, 30) }}
+          </a>
           <app-copy-button [value]="contract.currentAddress" [size]="'sm'"></app-copy-button>
+          } @else {
+          <span class="text-white typo-text-2">Unknown</span>
           }
         </div>
       </div>
@@ -563,7 +611,7 @@
       </div>
 
       <div class="flex gap-8 flex-wrap">
-        <kc-button [text]="'View Details'" (buttonClick)="openContractDetail(contract)">
+        <kc-button [text]="'View Details'" (buttonClick)="navigateToContractDetail(contract)">
         </kc-button>
         @if (contract.status !== 'spent') {
         <kc-button [text]="contract.nextActionLabel" (buttonClick)="openDashboardAction(contract)">
@@ -576,18 +624,36 @@
       </div>
     </div>
     }
+    }
+  </div>
+  }
 
+  @if (activeTab() === 'detail') {
+  <div class="contracts-list flex column gap-16">
     @if (selectedDetail()) {
-    <div class="panel flex column gap-16 p-20 rounded-lg">
+    <div id="contract-detail-panel" class="panel flex column gap-16 p-20 rounded-lg">
       <div class="flex justify-content-between align-items-start gap-12">
         <div class="flex column gap-4">
           <h3 class="text-white typo-title-3">{{ selectedDetail()!.entry.displayName }}</h3>
           <p class="text-gray-60 typo-text-2">Current state from covenant detail, active UTXOs, and action timeline.</p>
         </div>
-        <button class="back-button p-8 rounded typo-text-2" (click)="selectedDetail.set(null)">
+        <button class="back-button detail-close-button p-8 rounded typo-text-2" (click)="backToContractsList()">
           Close
         </button>
       </div>
+
+      @if (selectedDetail()!.entry.status !== 'spent') {
+      <div class="contract-detail-tabs flex gap-4 rounded">
+        <button class="detail-tab-button p-8 rounded typo-text-2" [class.active]="detailPanelTab() === 'details'"
+          (click)="setContractDetailTab('details')">
+          Details
+        </button>
+        <button class="detail-tab-button p-8 rounded typo-text-2" [class.active]="detailPanelTab() === 'action'"
+          (click)="setContractDetailTab('action')">
+          Action
+        </button>
+      </div>
+      }
 
       @if (selectedDetailLoading()) {
       <div class="p-12 rounded text-gray-60 typo-text-2">Loading current indexer state...</div>
@@ -599,6 +665,7 @@
       </div>
       }
 
+      @if (detailPanelTab() === 'details' || selectedDetail()!.entry.status === 'spent') {
       <div class="detail-grid">
         <div class="detail-item p-12 rounded">
           <span class="text-gray-60 typo-text-2">Status</span>
@@ -666,15 +733,28 @@
           }
         </div>
       </details>
+      }
     </div>
     }
   </div>
   }
 
   <!-- Tab 3: Interact -->
-  @if (activeTab() === 'interact') {
+  @if (activeTab() === 'interact' || (activeTab() === 'detail' && detailPanelTab() === 'action' && selectedDetail() && selectedDetail()!.entry.status !== 'spent' && interactContractJson())) {
   <div class="panel flex column gap-20 p-24 rounded-lg">
     <!-- Contract selector from registry -->
+    @if (selectedContract()) {
+    <div class="contract-summary p-16 rounded-lg flex column gap-8">
+      <span class="text-gray-60 typo-text-2">Current Contract</span>
+      <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
+        <div class="flex column gap-4">
+          <span class="text-white typo-text-1 fw-bold">{{ selectedContract()!.contractName }}</span>
+          <span class="text-gray-60 typo-text-2">{{ truncate(selectedContract()!.contractAddress, 30) }}</span>
+        </div>
+        <span class="text-gray-60 typo-text-2">{{ formatSompiToKas(selectedContract()!.amountSompi) }} KAS</span>
+      </div>
+    </div>
+    } @else if (activeTab() !== 'detail' && !detailRouteId() && !interactContractJson()) {
     <div class="form-group flex column gap-8">
       <label class="text-gray-60 typo-text-1">Select Contract</label>
       <kc-dropdown-select [options]="registryContractOptions()" [placeholder]="'Select a deployed contract'"
@@ -682,6 +762,7 @@
         (valueChange)="selectedContractId.set($event); selectContractFromRegistry()">
       </kc-dropdown-select>
     </div>
+    }
 
     <!-- Advanced: Manual contract JSON (collapsed by default) -->
     <details class="advanced-section">

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -619,9 +619,13 @@
         <span class="text-gray-60 typo-text-1">Current UTXO</span>
         @for (utxo of selectedDetail()!.utxos; track (utxo.txidHex || '') + ':' + utxo.vout) {
         <div class="utxo-row p-12 rounded-lg flex justify-content-between align-items-center gap-12">
-          <a [href]="getExplorerLink(utxo.txidHex || '')" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(utxo.txidHex || 'Unknown', 24) }}:{{ utxo.vout || 0 }}
+          @if (utxo.txidHex) {
+          <a [href]="getExplorerLink(utxo.txidHex)" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(utxo.txidHex, 24) }}:{{ utxo.vout ?? 0 }}
           </a>
+          } @else {
+          <span class="text-gray-60 typo-text-2">Unknown</span>
+          }
           <span class="text-white typo-text-2 fw-bold">{{ formatSompiToKas(utxo.amountSompi?.toString() || '0') }} KAS</span>
         </div>
         }

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -324,9 +324,9 @@
         <div class="form-group flex column gap-8">
           <kc-input
             [label]="'Amount to lock (KAS)'"
-            [placeholder]="'0'"
+            [placeholder]="'0.5'"
             [type]="'number'"
-            [min]="0"
+            [min]="MIN_DEPLOY_AMOUNT_KAS"
             [max]="deployAvailableBalance()"
             [isFullWidth]="true"
             [isValid]="!deployAmountError()"

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -427,48 +427,92 @@
   @if (activeTab() === 'my-contracts') {
   <div class="contracts-list flex column gap-16">
 
-    <!-- Deployed Contracts Registry -->
-    @if (registryContracts().length === 0) {
+    <div class="panel flex column gap-12 p-20 rounded-lg">
+      <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
+        <div class="flex column gap-4">
+          <h3 class="text-white typo-text-1 fw-bold">My Contracts</h3>
+          <p class="text-gray-60 typo-text-2">Tracked by wallet address, role args, active UTXOs, and covenant timeline from the indexer.</p>
+        </div>
+        <kc-button [text]="dashboardLoading() ? 'Refreshing...' : 'Refresh'" [isDisabled]="dashboardLoading()"
+          (buttonClick)="loadContracts()">
+        </kc-button>
+      </div>
+
+      @if (dashboardError()) {
+      <div class="error-message p-12 rounded-lg text-red typo-text-2">
+        {{ dashboardError() }}
+      </div>
+      }
+
+      @if (dashboardLoading()) {
+      <div class="p-12 rounded text-gray-60 typo-text-2">
+        Loading indexer-backed contract tracking...
+      </div>
+      }
+    </div>
+
+    @if (!dashboardLoading() && dashboardContracts().length === 0) {
     <div class="empty-state p-32 rounded-lg text-center">
-      <p class="text-gray-60 typo-text-1">No contracts deployed yet on {{ network() }}</p>
+      <p class="text-gray-60 typo-text-1">No contracts found for this wallet on {{ network() }}</p>
     </div>
     }
 
-    @for (contract of registryContracts(); track contract.id) {
+    @for (contract of dashboardContracts(); track contract.id) {
     <div class="contract-card p-20 rounded-lg flex column gap-16"
       [style.opacity]="contract.status === 'spent' ? '0.5' : '1'">
-      <!-- Contract header -->
       <div class="flex justify-content-between align-items-start">
         <div class="flex column gap-4">
-          <h3 class="text-white typo-title-3">{{ contract.contractName }}</h3>
+          <div class="flex align-items-center gap-8 flex-wrap">
+            <h3 class="text-white typo-title-3">{{ contract.displayName }}</h3>
+            <span class="source-badge p-6 rounded typo-text-2">{{ getSourceLabel(contract) }}</span>
+          </div>
           <span class="text-gray-60 typo-text-2">
             {{ formatSompiToKas(contract.amountSompi) }} KAS
           </span>
         </div>
         <div class="flex align-items-center gap-8">
           @if (contract.status === 'spent') {
-          <div class="status-badge inactive p-8 rounded" kcTooltip="This contract has been spent — funds withdrawn"
+          <div class="status-badge inactive p-8 rounded" kcTooltip="No active covenant UTXO is currently indexed"
             tooltipPosition="left">
             <span class="typo-text-2">Spent</span>
+          </div>
+          } @else if (contract.status === 'unknown' || contract.status === 'tracking-incomplete') {
+          <div class="status-badge unknown p-8 rounded" kcTooltip="The wallet has a local entry, but indexer tracking is incomplete"
+            tooltipPosition="left">
+            <span class="typo-text-2">Tracking</span>
           </div>
           } @else {
           <div class="status-badge active p-8 rounded">
             <span class="typo-text-2">Active</span>
           </div>
           }
-          <span class="text-gray-60 typo-text-2 cursor-pointer" (click)="deleteContract(contract.id)"
-            kcTooltip="Remove from list" tooltipPosition="left">✕</span>
+          @if (contract.registryEntry) {
+          <span class="text-gray-60 typo-text-2 cursor-pointer" (click)="deleteContract(contract.registryEntry.id)"
+            kcTooltip="Remove local copy from list" tooltipPosition="left">✕</span>
+          }
         </div>
       </div>
 
-      <!-- Contract address -->
+      @if (contract.participants.length > 0) {
+      <div class="participant-grid">
+        @for (participant of contract.participants.slice(0, 4); track participant.label + participant.value) {
+        <div class="participant-item p-8 rounded">
+          <span class="text-gray-60 typo-text-2">{{ participant.label }}</span>
+          <span class="text-white typo-text-2 text-mono">{{ truncate(participant.value, 22) }}</span>
+        </div>
+        }
+      </div>
+      }
+
       <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Contract Address</span>
+        <span class="text-gray-60 typo-text-2">Current Address</span>
         <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerAddressLink(contract.contractAddress)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.contractAddress, 30) }}
+          <a [href]="getExplorerAddressLink(contract.currentAddress || '')" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(contract.currentAddress || 'Unknown', 30) }}
           </a>
-          <app-copy-button [value]="contract.contractAddress" [size]="'sm'"></app-copy-button>
+          @if (contract.currentAddress) {
+          <app-copy-button [value]="contract.currentAddress" [size]="'sm'"></app-copy-button>
+          }
         </div>
       </div>
 
@@ -482,37 +526,126 @@
       </div>
       }
 
-      <!-- Deploy TX -->
+      @if (contract.deadlineMs) {
       <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Deploy TX</span>
-        <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerLink(contract.deployTxid)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.deployTxid, 20) }}
-          </a>
-          <app-copy-button [value]="contract.deployTxid" [size]="'sm'"></app-copy-button>
-        </div>
-      </div>
-
-      @if (contract.spendTxid) {
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Spend TX</span>
-        <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerLink(contract.spendTxid)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.spendTxid, 20) }}
-          </a>
-          <app-copy-button [value]="contract.spendTxid" [size]="'sm'"></app-copy-button>
-        </div>
+        <span class="text-gray-60 typo-text-2">Deadline</span>
+        <span class="text-white typo-text-2">{{ formatTimestamp(contract.deadlineMs) }}</span>
       </div>
       }
 
-      <!-- Action buttons -->
-      <div class="flex gap-8">
+      <div class="flex column gap-4">
+        <span class="text-gray-60 typo-text-2">Latest Action</span>
+        <div class="flex align-items-center gap-8">
+          <span class="text-white typo-text-2">{{ formatActionName(contract.latestAction || 'deploy') }}</span>
+          @if (contract.latestTxid) {
+          <a [href]="getExplorerLink(contract.latestTxid)" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(contract.latestTxid, 20) }}
+          </a>
+          <app-copy-button [value]="contract.latestTxid" [size]="'sm'"></app-copy-button>
+          }
+        </div>
+      </div>
+
+      <div class="flex gap-8 flex-wrap">
+        <kc-button [text]="'View Details'" (buttonClick)="openContractDetail(contract)">
+        </kc-button>
         @if (contract.status !== 'spent') {
-        <kc-button [text]="'💰 Withdraw'" [isFullWidth]="true"
-          (buttonClick)="selectedContractId.set(contract.id); selectContractFromRegistry(); switchTab('interact')">
+        <kc-button [text]="contract.nextActionLabel" (buttonClick)="openDashboardAction(contract)">
+        </kc-button>
+        }
+        @if (contract.covenantId || contract.scriptHash) {
+        <kc-button [text]="'Copy Share Link'" (buttonClick)="copyContractShareLink(contract)">
         </kc-button>
         }
       </div>
+    </div>
+    }
+
+    @if (selectedDetail()) {
+    <div class="panel flex column gap-16 p-20 rounded-lg">
+      <div class="flex justify-content-between align-items-start gap-12">
+        <div class="flex column gap-4">
+          <h3 class="text-white typo-title-3">{{ selectedDetail()!.entry.displayName }}</h3>
+          <p class="text-gray-60 typo-text-2">Current state from covenant detail, active UTXOs, and action timeline.</p>
+        </div>
+        <button class="back-button p-8 rounded typo-text-2" (click)="selectedDetail.set(null)">
+          Close
+        </button>
+      </div>
+
+      @if (selectedDetailLoading()) {
+      <div class="p-12 rounded text-gray-60 typo-text-2">Loading current indexer state...</div>
+      }
+
+      @if (selectedDetailError()) {
+      <div class="error-message p-12 rounded-lg text-red typo-text-2">
+        {{ selectedDetailError() }}
+      </div>
+      }
+
+      <div class="detail-grid">
+        <div class="detail-item p-12 rounded">
+          <span class="text-gray-60 typo-text-2">Status</span>
+          <span class="text-white typo-text-1 fw-bold">{{ getStatusLabel(selectedDetail()!.entry) }}</span>
+        </div>
+        <div class="detail-item p-12 rounded">
+          <span class="text-gray-60 typo-text-2">Locked</span>
+          <span class="text-white typo-text-1 fw-bold">{{ formatSompiToKas(selectedDetail()!.entry.amountSompi) }} KAS</span>
+        </div>
+        <div class="detail-item p-12 rounded">
+          <span class="text-gray-60 typo-text-2">Active UTXOs</span>
+          <span class="text-white typo-text-1 fw-bold">{{ selectedDetail()!.utxos.length }}</span>
+        </div>
+      </div>
+
+      @if (selectedDetail()!.utxos.length > 0) {
+      <div class="flex column gap-8">
+        <span class="text-gray-60 typo-text-1">Current UTXO</span>
+        @for (utxo of selectedDetail()!.utxos; track (utxo.txidHex || '') + ':' + utxo.vout) {
+        <div class="utxo-row p-12 rounded-lg flex justify-content-between align-items-center gap-12">
+          <a [href]="getExplorerLink(utxo.txidHex || '')" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(utxo.txidHex || 'Unknown', 24) }}:{{ utxo.vout || 0 }}
+          </a>
+          <span class="text-white typo-text-2 fw-bold">{{ formatSompiToKas(utxo.amountSompi?.toString() || '0') }} KAS</span>
+        </div>
+        }
+      </div>
+      }
+
+      <div class="flex column gap-8">
+        <span class="text-gray-60 typo-text-1">Timeline</span>
+        @for (action of selectedDetail()!.actions.slice(0, 8); track (action.txidHex || '') + (action.action || '') + (action.entrypoint || '')) {
+        <div class="timeline-row p-12 rounded-lg flex justify-content-between align-items-start gap-12">
+          <div class="flex column gap-4">
+            <span class="text-white typo-text-2">{{ formatActionName(action.entrypoint || action.action || 'action') }}</span>
+            <span class="text-gray-60 typo-text-2">{{ formatTimestamp(action.blockTimeMs) }}</span>
+          </div>
+          @if (action.txidHex) {
+          <a [href]="getExplorerLink(action.txidHex)" target="_blank" class="text-blue typo-text-2">
+            {{ truncate(action.txidHex, 20) }}
+          </a>
+          }
+        </div>
+        }
+      </div>
+
+      <details class="advanced-section">
+        <summary class="text-gray-60 typo-text-2 cursor-pointer">Advanced technical data</summary>
+        <div class="flex column gap-8 mt-8">
+          @if (selectedDetail()!.entry.covenantId) {
+          <div class="flex column gap-4">
+            <span class="text-gray-60 typo-text-2">Covenant ID</span>
+            <span class="text-white typo-text-2 text-mono">{{ selectedDetail()!.entry.covenantId }}</span>
+          </div>
+          }
+          @if (selectedDetail()!.entry.scriptHash) {
+          <div class="flex column gap-4">
+            <span class="text-gray-60 typo-text-2">Script Hash</span>
+            <span class="text-white typo-text-2 text-mono">{{ selectedDetail()!.entry.scriptHash }}</span>
+          </div>
+          }
+        </div>
+      </details>
     </div>
     }
   </div>

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2,1177 +2,1901 @@
   <!-- Header -->
   <div class="contracts-header flex column gap-8">
     <h1 class="text-white typo-title-1">Contracts</h1>
-    <p class="text-gray-75 typo-text-1">Deploy and interact with SilverScript covenants</p>
+    <p class="text-gray-75 typo-text-1">
+      Deploy and interact with SilverScript covenants
+    </p>
   </div>
 
   <!-- Tabs -->
-  @if (!detailRouteId() && activeTab() !== 'detail') {
-  <div class="tabs flex gap-8">
-    <button class="tab-button p-12 rounded-lg typo-text-2" [class.active]="activeTab() === 'deploy'"
-      (click)="switchTab('deploy')">
-      Create
-    </button>
-    <button class="tab-button p-12 rounded-lg typo-text-2" [class.active]="activeTab() === 'my-contracts'"
-      (click)="switchTab('my-contracts')">
-      My Contracts
-    </button>
-    <button class="tab-button p-12 rounded-lg typo-text-2" [class.active]="activeTab() === 'lookup-import'"
-      (click)="switchTab('lookup-import')">
-      Lookup / Import
-    </button>
-  </div>
+  @if (!detailRouteId() && activeTab() !== "detail") {
+    <div class="tabs flex gap-8">
+      <button
+        class="tab-button p-12 rounded-lg typo-text-2"
+        [class.active]="activeTab() === 'deploy'"
+        (click)="switchTab('deploy')"
+      >
+        Create
+      </button>
+      <button
+        class="tab-button p-12 rounded-lg typo-text-2"
+        [class.active]="activeTab() === 'my-contracts'"
+        (click)="switchTab('my-contracts')"
+      >
+        My Contracts
+      </button>
+      <button
+        class="tab-button p-12 rounded-lg typo-text-2"
+        [class.active]="activeTab() === 'lookup-import'"
+        (click)="switchTab('lookup-import')"
+      >
+        Lookup / Import
+      </button>
+    </div>
   }
 
   <!-- Tab 1: Create / Deploy -->
-  @if (activeTab() === 'deploy') {
-  <div class="panel flex column gap-20 p-24 rounded-lg">
-    <div class="wizard-header flex column gap-8">
-      <span class="text-gray-60 typo-text-2">Step {{ getTemplateStepNumber() }} of 3</span>
-      <h3 class="text-white typo-title-3">Create a covenant</h3>
-      <p class="text-gray-60 typo-text-2">Start with a guided template or use custom compiled JSON when you already have one.</p>
-    </div>
+  @if (activeTab() === "deploy") {
+    <div class="panel flex column gap-20 p-24 rounded-lg">
+      <div class="wizard-header flex column gap-8">
+        <span class="text-gray-60 typo-text-2"
+          >Step {{ getTemplateStepNumber() }} of 3</span
+        >
+        <h3 class="text-white typo-title-3">Create a covenant</h3>
+        <p class="text-gray-60 typo-text-2">
+          Start with a guided template or use custom compiled JSON when you
+          already have one.
+        </p>
+      </div>
 
-    @if (!activeTemplate() && createMode() !== 'custom') {
-    <div class="template-list flex column gap-12">
-      @for (template of contractTemplates; track template.id) {
-      <button type="button" class="template-card-compact p-16 rounded-lg flex align-items-center gap-12"
-        (click)="selectTemplate(template)">
-        <div class="template-icon-compact">{{ template.icon }}</div>
-        <div class="flex column gap-4 flex-1 text-left">
-          <h4 class="text-white typo-text-1 fw-bold">{{ template.name }}</h4>
-          <p class="text-gray-60 typo-text-2 template-description">{{ template.description }}</p>
-        </div>
-        <span class="template-chevron">Next</span>
-      </button>
-      }
+      @if (!activeTemplate() && createMode() !== "custom") {
+        <div class="template-list flex column gap-12">
+          @for (template of contractTemplates; track template.id) {
+            <button
+              type="button"
+              class="template-card-compact p-16 rounded-lg flex align-items-center gap-12"
+              (click)="selectTemplate(template)"
+            >
+              <div class="template-icon-compact">{{ template.icon }}</div>
+              <div class="flex column gap-4 flex-1 text-left">
+                <h4 class="text-white typo-text-1 fw-bold">
+                  {{ template.name }}
+                </h4>
+                <p class="text-gray-60 typo-text-2 template-description">
+                  {{ template.description }}
+                </p>
+              </div>
+              <span class="template-chevron">Next</span>
+            </button>
+          }
 
-      <button type="button" class="custom-contract-card p-16 rounded-lg flex align-items-center gap-12"
-        (click)="selectCustomContract()">
-        <div class="template-icon-compact">JSON</div>
-        <div class="flex column gap-4 flex-1 text-left">
-          <h4 class="text-white typo-text-1 fw-bold">Custom covenant</h4>
-          <p class="text-gray-60 typo-text-2 template-description">Paste compiled SilverScript JSON manually.</p>
+          <button
+            type="button"
+            class="custom-contract-card p-16 rounded-lg flex align-items-center gap-12"
+            (click)="selectCustomContract()"
+          >
+            <div class="template-icon-compact">JSON</div>
+            <div class="flex column gap-4 flex-1 text-left">
+              <h4 class="text-white typo-text-1 fw-bold">Custom covenant</h4>
+              <p class="text-gray-60 typo-text-2 template-description">
+                Paste compiled SilverScript JSON manually.
+              </p>
+            </div>
+            <span class="template-chevron">Use custom</span>
+          </button>
         </div>
-        <span class="template-chevron">Use custom</span>
-      </button>
-    </div>
-    } @else {
-    <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
-      <div class="flex column gap-4">
+      } @else {
+        <div
+          class="flex justify-content-between align-items-center gap-12 flex-wrap"
+        >
+          <div class="flex column gap-4">
+            @if (activeTemplate()) {
+              <h3 class="text-white typo-title-3">
+                {{ activeTemplate()!.icon }} {{ activeTemplate()!.name }}
+              </h3>
+              <p class="text-gray-60 typo-text-2">
+                {{ activeTemplate()!.description }}
+              </p>
+            } @else {
+              <h3 class="text-white typo-title-3">Custom covenant</h3>
+              <p class="text-gray-60 typo-text-2">
+                Paste deploy-ready compiled JSON and choose how much KAS to
+                lock.
+              </p>
+            }
+          </div>
+          <button
+            class="back-button template-change-button p-8 rounded typo-text-2"
+            (click)="resetTemplateSelection(); createMode.set('template')"
+          >
+            Change
+          </button>
+        </div>
+
+        <!-- Show selected pubkey -->
+        @if (selectedPubkey()) {
+          <div class="pubkey-display p-12 rounded-lg flex column gap-4">
+            <span class="text-gray-60 typo-text-1"
+              >Account Public Key (x-only)</span
+            >
+            <div class="flex align-items-center gap-8">
+              <span class="text-white typo-text-2 text-mono">{{
+                truncate(selectedPubkey(), 24)
+              }}</span>
+              <app-copy-button
+                [value]="selectedPubkey()"
+                [size]="'sm'"
+              ></app-copy-button>
+            </div>
+          </div>
+        }
+
         @if (activeTemplate()) {
-        <h3 class="text-white typo-title-3">{{ activeTemplate()!.icon }} {{ activeTemplate()!.name }}</h3>
-        <p class="text-gray-60 typo-text-2">{{ activeTemplate()!.description }}</p>
-        } @else {
-        <h3 class="text-white typo-title-3">Custom covenant</h3>
-        <p class="text-gray-60 typo-text-2">Paste deploy-ready compiled JSON and choose how much KAS to lock.</p>
+          <div class="wizard-section flex column gap-16">
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-2">Step 2 of 3</span>
+              <h4 class="text-white typo-text-1 fw-bold">
+                Set covenant parameters
+              </h4>
+            </div>
+
+            @for (field of activeTemplate()!.fields; track field.paramName) {
+              <div class="form-group flex column gap-8">
+                @if (field.type === "address") {
+                  <app-address-smart-input
+                    [label]="field.label"
+                    [placeholder]="field.placeholder"
+                    [isFullWidth]="true"
+                    [isValid]="isTemplateFieldValid(field)"
+                    [invalidReason]="getTemplateFieldError(field)"
+                    [isDisabled]="isDeploying() || isWalletOwnedField(field)"
+                    [showQrButton]="!isWalletOwnedField(field)"
+                    [value]="templateFormValues[field.paramName] || ''"
+                    (valueChange)="onTemplateFieldChange(field, $event)"
+                    (resolved)="onTemplateAddressResolved(field, $event)"
+                    (qrClick)="onTemplateAddressQrClick(field)"
+                  >
+                  </app-address-smart-input>
+                }
+
+                @if (field.type === "hash32") {
+                  <div class="flex column gap-4">
+                    <kc-input
+                      [label]="field.label"
+                      [placeholder]="'Paste address, public key, or 32-byte hash'"
+                      [type]="'text'"
+                      [isFullWidth]="true"
+                      [isValid]="isTemplateFieldValid(field)"
+                      [invalidReason]="getTemplateFieldError(field)"
+                      [isDisabled]="isDeploying()"
+                      [ngModel]="templateFormValues[field.paramName] || ''"
+                      (valueChange)="onTemplateFieldChange(field, $event)"
+                    >
+                    </kc-input>
+                    @if (
+                      templateFormValues[field.paramName + "_isAutoHashed"]
+                    ) {
+                      <span class="text-green typo-text-2"
+                        >Hash computed automatically.</span
+                      >
+                    }
+                    @if (
+                      !templateFormValues[field.paramName + "_isAutoHashed"] &&
+                      (templateFormValues[field.paramName] || "").length === 64
+                    ) {
+                      <div class="flex gap-8 align-items-center">
+                        <span class="text-gray-60 typo-text-2"
+                          >If this is a public key,</span
+                        >
+                        <span
+                          class="text-blue typo-text-2 cursor-pointer"
+                          (click)="computeBlake2bHash(field.paramName)"
+                        >
+                          compute its hash
+                        </span>
+                      </div>
+                    }
+                  </div>
+                }
+
+                @if (field.type === "int_days" || field.type === "int_count") {
+                  <kc-input
+                    [label]="field.label"
+                    [placeholder]="field.placeholder"
+                    [type]="'number'"
+                    [min]="0"
+                    [isFullWidth]="true"
+                    [isValid]="isTemplateFieldValid(field)"
+                    [invalidReason]="getTemplateFieldError(field)"
+                    [isDisabled]="isDeploying()"
+                    [ngModel]="templateFormValues[field.paramName] || ''"
+                    (valueChange)="onTemplateFieldChange(field, $event)"
+                  >
+                  </kc-input>
+                }
+
+                @if (field.type === "int_timestamp") {
+                  <app-covenant-date-time-input
+                    [label]="field.label"
+                    [value]="templateFormValues[field.paramName] || ''"
+                    [isDisabled]="isDeploying()"
+                    [isValid]="isTemplateFieldValid(field)"
+                    [invalidReason]="getTemplateFieldError(field)"
+                    (valueChange)="onTemplateFieldChange(field, $event)"
+                  >
+                  </app-covenant-date-time-input>
+                }
+
+                <span class="text-gray-60 typo-text-2">{{
+                  getFieldHelp(field)
+                }}</span>
+              </div>
+            }
+          </div>
         }
-      </div>
-      <button class="back-button template-change-button p-8 rounded typo-text-2" (click)="resetTemplateSelection(); createMode.set('template')">
-        Change
-      </button>
-    </div>
 
-    <!-- Show selected pubkey -->
-    @if (selectedPubkey()) {
-    <div class="pubkey-display p-12 rounded-lg flex column gap-4">
-      <span class="text-gray-60 typo-text-1">Account Public Key (x-only)</span>
-      <div class="flex align-items-center gap-8">
-        <span class="text-white typo-text-2 text-mono">{{ truncate(selectedPubkey(), 24) }}</span>
-        <app-copy-button [value]="selectedPubkey()" [size]="'sm'"></app-copy-button>
-      </div>
-    </div>
-    }
+        @if (createMode() === "custom") {
+          <div class="form-group flex column gap-8">
+            <label class="text-gray-60 typo-text-1"
+              >Compiled Contract JSON</label
+            >
+            <textarea
+              class="contract-input p-12 rounded-lg text-white typo-text-2"
+              [class.invalid]="!!deployContractError()"
+              rows="8"
+              placeholder="Paste compiled contract JSON from kascov"
+              [ngModel]="deployContractJson()"
+              (ngModelChange)="onDeployContractJsonChange($event)"
+              [disabled]="isDeploying()"
+            >
+            </textarea>
+            @if (deployContractError()) {
+              <span class="field-error typo-text-2">{{
+                deployContractError()
+              }}</span>
+            }
+            <span class="text-gray-60 typo-text-2"
+              >Templates are safer for common flows because the wallet explains
+              and validates each parameter.</span
+            >
+          </div>
 
-    @if (activeTemplate()) {
-    <div class="wizard-section flex column gap-16">
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Step 2 of 3</span>
-        <h4 class="text-white typo-text-1 fw-bold">Set covenant parameters</h4>
-      </div>
+          <!-- Contract summary -->
+          @if (parsedDeployContract()) {
+            <div class="contract-summary p-16 rounded-lg flex column gap-12">
+              <h3 class="text-white typo-text-1 fw-bold">Contract Summary</h3>
+              <div class="flex column gap-8">
+                <div class="flex column gap-4">
+                  <span class="text-gray-60 typo-text-1">Name</span>
+                  <span class="text-white typo-text-2">{{
+                    parsedDeployContract()!.contract_name || "Unnamed"
+                  }}</span>
+                </div>
 
-      @for (field of activeTemplate()!.fields; track field.paramName) {
-      <div class="form-group flex column gap-8">
-        @if (field.type === 'address') {
-        <app-address-smart-input [label]="field.label" [placeholder]="field.placeholder" [isFullWidth]="true"
-          [isValid]="isTemplateFieldValid(field)" [invalidReason]="getTemplateFieldError(field)"
-          [isDisabled]="isDeploying() || isWalletOwnedField(field)"
-          [showQrButton]="!isWalletOwnedField(field)" [value]="templateFormValues[field.paramName] || ''"
-          (valueChange)="onTemplateFieldChange(field, $event)" (resolved)="onTemplateAddressResolved(field, $event)"
-          (qrClick)="onTemplateAddressQrClick(field)">
-        </app-address-smart-input>
+                @if (deployConstructorParams().length > 0) {
+                  <div class="flex column gap-4">
+                    <span class="text-gray-60 typo-text-1"
+                      >Constructor Parameters</span
+                    >
+                    @for (
+                      param of deployConstructorParams();
+                      track param.name
+                    ) {
+                      <div class="param-item p-8 rounded">
+                        <span class="text-white typo-text-2">{{
+                          param.name
+                        }}</span>
+                        <span class="text-gray-60 typo-text-2 ml-8"
+                          >({{ param.type_ref.base }})</span
+                        >
+                        @if (param.type_ref.base === "pubkey") {
+                          <span class="text-green ml-8 typo-text-2">🔑</span>
+                        }
+                      </div>
+                    }
+                  </div>
+                }
+
+                @if (deployEntrypointFunctions().length > 0) {
+                  <div class="flex column gap-4">
+                    <span class="text-gray-60 typo-text-1"
+                      >Entrypoint Functions</span
+                    >
+                    @for (fn of deployEntrypointFunctions(); track fn.name) {
+                      <div class="param-item p-8 rounded">
+                        <span class="text-white typo-text-2"
+                          >{{ fn.name }}()</span
+                        >
+                        @if (fn.params.length > 0) {
+                          <span class="text-gray-60 typo-text-2 ml-8">
+                            params: {{ getParamTypes(fn.params) }}
+                          </span>
+                        }
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            </div>
+          }
         }
 
-        @if (field.type === 'hash32') {
-        <div class="flex column gap-4">
-          <kc-input [label]="field.label" [placeholder]="'Paste address, public key, or 32-byte hash'" [type]="'text'"
-            [isFullWidth]="true" [isValid]="isTemplateFieldValid(field)" [invalidReason]="getTemplateFieldError(field)"
-            [isDisabled]="isDeploying()" [ngModel]="templateFormValues[field.paramName] || ''"
-            (valueChange)="onTemplateFieldChange(field, $event)">
+        <!-- Amount input -->
+        <div class="form-group flex column gap-8">
+          <kc-input
+            [label]="'Amount to lock (KAS)'"
+            [placeholder]="'0'"
+            [type]="'number'"
+            [min]="0"
+            [max]="deployAvailableBalance()"
+            [isFullWidth]="true"
+            [isValid]="!deployAmountError()"
+            [invalidReason]="deployAmountError()"
+            [isDisabled]="isDeploying()"
+            [ngModel]="deployAmount"
+            (valueChange)="onDeployAmountChange($event)"
+          >
+            <div
+              (click)="!isDeploying() && onMaxDeployAmountClick()"
+              [class]="
+                isDeploying() ? 'max-text disabled' : 'max-text clickable'
+              "
+              rightSideSlot
+            >
+              <span>Max</span>
+            </div>
           </kc-input>
-          @if (templateFormValues[field.paramName + '_isAutoHashed']) {
-          <span class="text-green typo-text-2">Hash computed automatically.</span>
-          }
-          @if (!templateFormValues[field.paramName + '_isAutoHashed'] && (templateFormValues[field.paramName] || '').length ===
-          64) {
-          <div class="flex gap-8 align-items-center">
-            <span class="text-gray-60 typo-text-2">If this is a public key,</span>
-            <span class="text-blue typo-text-2 cursor-pointer" (click)="computeBlake2bHash(field.paramName)">
-              compute its hash
-            </span>
+          <span class="text-gray-60 typo-text-2"
+            >This amount is sent into the covenant. It can only move later by
+            following the covenant rules.</span
+          >
+        </div>
+
+        <!-- Error message -->
+        @if (deployError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ deployError() }}
           </div>
-          }
-        </div>
         }
 
-        @if (field.type === 'int_days' || field.type === 'int_count') {
-        <kc-input [label]="field.label" [placeholder]="field.placeholder" [type]="'number'" [min]="0"
-          [isFullWidth]="true" [isValid]="isTemplateFieldValid(field)" [invalidReason]="getTemplateFieldError(field)"
-          [isDisabled]="isDeploying()" [ngModel]="templateFormValues[field.paramName] || ''"
-          (valueChange)="onTemplateFieldChange(field, $event)">
-        </kc-input>
-        }
-
-        @if (field.type === 'int_timestamp') {
-        <app-covenant-date-time-input [label]="field.label" [value]="templateFormValues[field.paramName] || ''"
-          [isDisabled]="isDeploying()" [isValid]="isTemplateFieldValid(field)"
-          [invalidReason]="getTemplateFieldError(field)" (valueChange)="onTemplateFieldChange(field, $event)">
-        </app-covenant-date-time-input>
-        }
-
-        <span class="text-gray-60 typo-text-2">{{ getFieldHelp(field) }}</span>
-      </div>
-      }
-    </div>
-    }
-
-    @if (createMode() === 'custom') {
-    <div class="form-group flex column gap-8">
-      <label class="text-gray-60 typo-text-1">Compiled Contract JSON</label>
-      <textarea class="contract-input p-12 rounded-lg text-white typo-text-2" [class.invalid]="!!deployContractError()" rows="8"
-        placeholder="Paste compiled contract JSON from kascov" [ngModel]="deployContractJson()"
-        (ngModelChange)="onDeployContractJsonChange($event)" [disabled]="isDeploying()">
-        </textarea>
-      @if (deployContractError()) {
-      <span class="field-error typo-text-2">{{ deployContractError() }}</span>
-      }
-      <span class="text-gray-60 typo-text-2">Templates are safer for common flows because the wallet explains and validates each parameter.</span>
-    </div>
-
-    <!-- Contract summary -->
-    @if (parsedDeployContract()) {
-    <div class="contract-summary p-16 rounded-lg flex column gap-12">
-      <h3 class="text-white typo-text-1 fw-bold">Contract Summary</h3>
-      <div class="flex column gap-8">
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Name</span>
-          <span class="text-white typo-text-2">{{ parsedDeployContract()!.contract_name || 'Unnamed' }}</span>
-        </div>
-
-        @if (deployConstructorParams().length > 0) {
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Constructor Parameters</span>
-          @for (param of deployConstructorParams(); track param.name) {
-          <div class="param-item p-8 rounded">
-            <span class="text-white typo-text-2">{{ param.name }}</span>
-            <span class="text-gray-60 typo-text-2 ml-8">({{ param.type_ref.base }})</span>
-            @if (param.type_ref.base === 'pubkey') {
-            <span class="text-green ml-8 typo-text-2">🔑</span>
+        <!-- Success result -->
+        @if (deployResult()) {
+          <div class="result-panel flex column gap-12 p-16 rounded-lg">
+            <h3 class="text-white typo-text-1 fw-bold">
+              ✅ Contract Deployed!
+            </h3>
+            <div class="result-row flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Contract Address</span>
+              <div class="flex align-items-center gap-8">
+                <span class="text-white typo-text-2 text-truncate">{{
+                  deployResult()!.address
+                }}</span>
+                <app-copy-button
+                  [value]="deployResult()!.address"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+            <div class="result-row flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Transaction ID</span>
+              <div class="flex align-items-center gap-8">
+                <a
+                  [href]="getExplorerLink(deployResult()!.txid)"
+                  target="_blank"
+                  class="text-blue typo-text-2 text-truncate"
+                >
+                  {{ deployResult()!.txid }}
+                </a>
+                <app-copy-button
+                  [value]="deployResult()!.txid"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+            @if (deployIndexerState()) {
+              <div class="result-row flex column gap-4">
+                <span class="text-gray-60 typo-text-1">Indexer Status</span>
+                <span class="text-white typo-text-2">{{
+                  deployIndexerState()!.message
+                }}</span>
+                @if (deployIndexerState()!.covenantId) {
+                  <div class="flex align-items-center gap-8">
+                    <span class="text-gray-60 typo-text-2 text-mono">{{
+                      truncate(deployIndexerState()!.covenantId || "", 28)
+                    }}</span>
+                    <app-copy-button
+                      [value]="deployIndexerState()!.covenantId || ''"
+                      [size]="'sm'"
+                    ></app-copy-button>
+                    @if (deployIndexerState()!.status === "indexed") {
+                      <kc-button
+                        [text]="'Copy Share Link'"
+                        (buttonClick)="copyDeployedContractShareLink()"
+                      >
+                      </kc-button>
+                    }
+                  </div>
+                }
+              </div>
             }
           </div>
-          }
-        </div>
         }
 
-        @if (deployEntrypointFunctions().length > 0) {
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Entrypoint Functions</span>
-          @for (fn of deployEntrypointFunctions(); track fn.name) {
-          <div class="param-item p-8 rounded">
-            <span class="text-white typo-text-2">{{ fn.name }}()</span>
-            @if (fn.params.length > 0) {
-            <span class="text-gray-60 typo-text-2 ml-8">
-              params: {{ getParamTypes(fn.params) }}
-            </span>
-            }
-          </div>
-          }
-        </div>
-        }
-      </div>
-    </div>
-    }
-    }
-
-    <!-- Amount input -->
-    <div class="form-group flex column gap-8">
-      <kc-input [label]="'Amount to lock (KAS)'" [placeholder]="'0'" [type]="'number'" [min]="0"
-        [max]="deployAvailableBalance()" [isFullWidth]="true" [isValid]="!deployAmountError()"
-        [invalidReason]="deployAmountError()" [isDisabled]="isDeploying()" [ngModel]="deployAmount"
-        (valueChange)="onDeployAmountChange($event)">
-        <div (click)="!isDeploying() && onMaxDeployAmountClick()"
-          [class]="isDeploying() ? 'max-text disabled' : 'max-text clickable'" rightSideSlot>
-          <span>Max</span>
-        </div>
-      </kc-input>
-      <span class="text-gray-60 typo-text-2">This amount is sent into the covenant. It can only move later by following the covenant rules.</span>
-    </div>
-
-    <!-- Error message -->
-    @if (deployError()) {
-    <div class="error-message p-12 rounded-lg text-red typo-text-2">
-      {{ deployError() }}
-    </div>
-    }
-
-    <!-- Success result -->
-    @if (deployResult()) {
-    <div class="result-panel flex column gap-12 p-16 rounded-lg">
-      <h3 class="text-white typo-text-1 fw-bold">✅ Contract Deployed!</h3>
-      <div class="result-row flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Contract Address</span>
-        <div class="flex align-items-center gap-8">
-          <span class="text-white typo-text-2 text-truncate">{{ deployResult()!.address }}</span>
-          <app-copy-button [value]="deployResult()!.address" [size]="'sm'"></app-copy-button>
-        </div>
-      </div>
-      <div class="result-row flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Transaction ID</span>
-        <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerLink(deployResult()!.txid)" target="_blank" class="text-blue typo-text-2 text-truncate">
-            {{ deployResult()!.txid }}
-          </a>
-          <app-copy-button [value]="deployResult()!.txid" [size]="'sm'"></app-copy-button>
-        </div>
-      </div>
-      @if (deployIndexerState()) {
-      <div class="result-row flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Indexer Status</span>
-        <span class="text-white typo-text-2">{{ deployIndexerState()!.message }}</span>
-        @if (deployIndexerState()!.covenantId) {
-        <div class="flex align-items-center gap-8">
-          <span class="text-gray-60 typo-text-2 text-mono">{{ truncate(deployIndexerState()!.covenantId || '', 28) }}</span>
-          <app-copy-button [value]="deployIndexerState()!.covenantId || ''" [size]="'sm'"></app-copy-button>
-          @if (deployIndexerState()!.status === 'indexed') {
-          <kc-button [text]="'Copy Share Link'" (buttonClick)="copyDeployedContractShareLink()">
-          </kc-button>
-          }
-        </div>
-        }
-      </div>
+        <kc-button
+          [text]="isDeploying() ? 'Deploying...' : 'Review and deploy covenant'"
+          [isDisabled]="isCreateDeployDisabled()"
+          [isFullWidth]="true"
+          (buttonClick)="
+            createMode() === 'custom'
+              ? deployContract()
+              : deployTemplateContract()
+          "
+        >
+        </kc-button>
       }
     </div>
-    }
-
-    <kc-button [text]="isDeploying() ? 'Deploying...' : 'Review and deploy covenant'"
-      [isDisabled]="isCreateDeployDisabled()"
-      [isFullWidth]="true" (buttonClick)="createMode() === 'custom' ? deployContract() : deployTemplateContract()">
-    </kc-button>
-    }
-  </div>
   }
 
   <!-- Tab 2: Lookup / Import -->
-  @if (activeTab() === 'lookup-import') {
-  <div class="contracts-list flex column gap-16">
-    <!-- Address Lookup -->
-    <div class="panel flex column gap-16 p-20 rounded-lg">
-      <h3 class="text-white typo-text-1 fw-bold">🔍 Look Up Contract</h3>
-      <p class="text-gray-60 typo-text-2">Enter a contract address to check its on-chain state (balance, UTXOs).</p>
-      <div class="flex gap-8 align-items-end">
-        <div class="form-group flex column gap-8 flex-1">
-          <kc-input [label]="'Contract Address'" [placeholder]="'kaspatest:pr...'" [type]="'text'"
-            [isFullWidth]="true" [isDisabled]="lookupLoading()" [ngModel]="lookupAddress"
-            (valueChange)="lookupAddress = $event || ''">
-          </kc-input>
-        </div>
-        <kc-button [text]="lookupLoading() ? 'Querying...' : 'Look Up'"
-          [isDisabled]="lookupLoading() || !lookupAddress.trim()" (buttonClick)="lookupContract()">
-        </kc-button>
-      </div>
-
-      @if (lookupError()) {
-      <div class="error-message p-12 rounded-lg text-red typo-text-2">
-        {{ lookupError() }}
-      </div>
-      }
-
-      @if (lookupResult()) {
-      <div class="lookup-result flex column gap-12 p-16 rounded-lg">
-        <div class="flex justify-content-between align-items-center">
-          <h4 class="text-white typo-text-1 fw-bold">Contract State</h4>
-          <a [href]="getExplorerAddressLink(lookupResult()!.address)" target="_blank" class="text-blue typo-text-2">
-            View in Explorer ↗
-          </a>
-        </div>
-
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Address</span>
-          <div class="flex align-items-center gap-8">
-            <span class="text-white typo-text-2 text-mono">{{ truncate(lookupResult()!.address, 40) }}</span>
-            <app-copy-button [value]="lookupResult()!.address" [size]="'sm'"></app-copy-button>
+  @if (activeTab() === "lookup-import") {
+    <div class="contracts-list flex column gap-16">
+      <!-- Address Lookup -->
+      <div class="panel flex column gap-16 p-20 rounded-lg">
+        <h3 class="text-white typo-text-1 fw-bold">🔍 Look Up Contract</h3>
+        <p class="text-gray-60 typo-text-2">
+          Enter a contract address to check its on-chain state (balance, UTXOs).
+        </p>
+        <div class="flex gap-8 align-items-end">
+          <div class="form-group flex column gap-8 flex-1">
+            <kc-input
+              [label]="'Contract Address'"
+              [placeholder]="'kaspatest:pr...'"
+              [type]="'text'"
+              [isFullWidth]="true"
+              [isDisabled]="lookupLoading()"
+              [ngModel]="lookupAddress"
+              (valueChange)="lookupAddress = $event || ''"
+            >
+            </kc-input>
           </div>
+          <kc-button
+            [text]="lookupLoading() ? 'Querying...' : 'Look Up'"
+            [isDisabled]="lookupLoading() || !lookupAddress.trim()"
+            (buttonClick)="lookupContract()"
+          >
+          </kc-button>
         </div>
 
-        <div class="flex gap-24">
-          <div class="flex column gap-4">
-            <span class="text-gray-60 typo-text-1">Balance</span>
-            <span class="text-white typo-title-3 fw-bold">{{ formatSompiToKas(lookupResult()!.balanceSompi) }}
-              KAS</span>
+        @if (lookupError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ lookupError() }}
           </div>
-          <div class="flex column gap-4">
-            <span class="text-gray-60 typo-text-1">UTXOs</span>
-            <span class="text-white typo-title-3 fw-bold">{{ lookupResult()!.utxoCount }}</span>
-          </div>
-        </div>
-
-        @if (lookupResult()!.utxoCount === 0) {
-        <div class="p-12 rounded text-gray-60 typo-text-2">
-          No UTXOs found — contract may have been spent or address is empty.
-        </div>
         }
 
-        @if (lookupResult()!.utxos.length > 0) {
-        <div class="flex column gap-8">
-          <span class="text-gray-60 typo-text-1">UTXOs</span>
-          @for (utxo of lookupResult()!.utxos; track utxo.txid + ':' + utxo.vout) {
-          <div class="utxo-row p-12 rounded-lg flex column gap-4">
+        @if (lookupResult()) {
+          <div class="lookup-result flex column gap-12 p-16 rounded-lg">
             <div class="flex justify-content-between align-items-center">
-              <div class="flex align-items-center gap-8">
-                <a [href]="getExplorerLink(utxo.txid)" target="_blank" class="text-blue typo-text-2">
-                  {{ truncate(utxo.txid, 20) }}:{{ utxo.vout }}
-                </a>
-                <app-copy-button [value]="utxo.txid" [size]="'sm'"></app-copy-button>
-              </div>
-              <span class="text-white typo-text-2 fw-bold">{{ formatSompiToKas(utxo.amount) }} KAS</span>
+              <h4 class="text-white typo-text-1 fw-bold">Contract State</h4>
+              <a
+                [href]="getExplorerAddressLink(lookupResult()!.address)"
+                target="_blank"
+                class="text-blue typo-text-2"
+              >
+                View in Explorer ↗
+              </a>
             </div>
-          </div>
-          }
-        </div>
 
-        <div class="form-group flex column gap-8">
-          <label class="text-gray-60 typo-text-2">Paste the compiled contract JSON to interact:</label>
-          <textarea class="form-input p-12 rounded-lg text-white typo-text-2" [(ngModel)]="lookupContractJson" rows="3"
-            placeholder='Paste the contract JSON here (from the deployer)...'
-            style="resize: vertical; font-family: 'Courier New', monospace; font-size: 11px;"></textarea>
-        </div>
-        <kc-button [text]="'Interact with this Contract'" [isFullWidth]="true" [isDisabled]="!lookupContractJson"
-          (buttonClick)="importLookupContract()">
-        </kc-button>
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Address</span>
+              <div class="flex align-items-center gap-8">
+                <span class="text-white typo-text-2 text-mono">{{
+                  truncate(lookupResult()!.address, 40)
+                }}</span>
+                <app-copy-button
+                  [value]="lookupResult()!.address"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+
+            <div class="flex gap-24">
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-1">Balance</span>
+                <span class="text-white typo-title-3 fw-bold"
+                  >{{
+                    formatSompiToKas(lookupResult()!.balanceSompi)
+                  }}
+                  KAS</span
+                >
+              </div>
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-1">UTXOs</span>
+                <span class="text-white typo-title-3 fw-bold">{{
+                  lookupResult()!.utxoCount
+                }}</span>
+              </div>
+            </div>
+
+            @if (lookupResult()!.utxoCount === 0) {
+              <div class="p-12 rounded text-gray-60 typo-text-2">
+                No UTXOs found — contract may have been spent or address is
+                empty.
+              </div>
+            }
+
+            @if (lookupResult()!.utxos.length > 0) {
+              <div class="flex column gap-8">
+                <span class="text-gray-60 typo-text-1">UTXOs</span>
+                @for (
+                  utxo of lookupResult()!.utxos;
+                  track utxo.txid + ":" + utxo.vout
+                ) {
+                  <div class="utxo-row p-12 rounded-lg flex column gap-4">
+                    <div
+                      class="flex justify-content-between align-items-center"
+                    >
+                      <div class="flex align-items-center gap-8">
+                        <a
+                          [href]="getExplorerLink(utxo.txid)"
+                          target="_blank"
+                          class="text-blue typo-text-2"
+                        >
+                          {{ truncate(utxo.txid, 20) }}:{{ utxo.vout }}
+                        </a>
+                        <app-copy-button
+                          [value]="utxo.txid"
+                          [size]="'sm'"
+                        ></app-copy-button>
+                      </div>
+                      <span class="text-white typo-text-2 fw-bold"
+                        >{{ formatSompiToKas(utxo.amount) }} KAS</span
+                      >
+                    </div>
+                  </div>
+                }
+              </div>
+
+              <div class="form-group flex column gap-8">
+                <label class="text-gray-60 typo-text-2"
+                  >Paste the compiled contract JSON to interact:</label
+                >
+                <textarea
+                  class="form-input p-12 rounded-lg text-white typo-text-2"
+                  [(ngModel)]="lookupContractJson"
+                  rows="3"
+                  placeholder="Paste the contract JSON here (from the deployer)..."
+                  style="
+                    resize: vertical;
+                    font-family: &quot;Courier New&quot;, monospace;
+                    font-size: 11px;
+                  "
+                ></textarea>
+              </div>
+              <kc-button
+                [text]="'Interact with this Contract'"
+                [isFullWidth]="true"
+                [isDisabled]="!lookupContractJson"
+                (buttonClick)="importLookupContract()"
+              >
+              </kc-button>
+            }
+          </div>
         }
       </div>
-      }
+
+      <!-- Indexer Import -->
+      <div class="panel flex column gap-16 p-20 rounded-lg">
+        <h3 class="text-white typo-text-1 fw-bold">Import from Indexer</h3>
+        <p class="text-gray-60 typo-text-2">
+          Enter a covenant ID, script hash, deploy transaction, contract
+          address, or shared contract link value. Only wallet-supported
+          templates can be imported.
+        </p>
+        <div class="flex gap-8 align-items-end">
+          <div class="form-group flex column gap-8 flex-1">
+            <kc-input
+              [label]="'Contract Lookup'"
+              [placeholder]="'covenant ID, txid, or kaspatest:...'"
+              [type]="'text'"
+              [isFullWidth]="true"
+              [isDisabled]="indexerImportLoading()"
+              [ngModel]="indexerImportQuery"
+              (valueChange)="indexerImportQuery = $event || ''"
+            >
+            </kc-input>
+          </div>
+          <kc-button
+            [text]="indexerImportLoading() ? 'Loading...' : 'Find'"
+            [isDisabled]="indexerImportLoading() || !indexerImportQuery.trim()"
+            (buttonClick)="lookupIndexerImport()"
+          >
+          </kc-button>
+        </div>
+
+        @if (indexerImportError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ indexerImportError() }}
+          </div>
+        }
+
+        @if (indexerImportPreview()) {
+          <div class="lookup-result flex column gap-12 p-16 rounded-lg">
+            <div class="flex justify-content-between align-items-center">
+              <h4 class="text-white typo-text-1 fw-bold">
+                {{ indexerImportPreview()!.template.name }}
+              </h4>
+              <span class="text-gray-60 typo-text-2"
+                >{{
+                  formatSompiToKas(indexerImportPreview()!.amountSompi)
+                }}
+                KAS</span
+              >
+            </div>
+
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Covenant ID</span>
+              <div class="flex align-items-center gap-8">
+                <span class="text-white typo-text-2 text-mono">{{
+                  truncate(indexerImportPreview()!.covenantId, 28)
+                }}</span>
+                <app-copy-button
+                  [value]="indexerImportPreview()!.covenantId"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Contract Address</span>
+              <div class="flex align-items-center gap-8">
+                <a
+                  [href]="
+                    getExplorerAddressLink(
+                      indexerImportPreview()!.contractAddress
+                    )
+                  "
+                  target="_blank"
+                  class="text-blue typo-text-2"
+                >
+                  {{ truncate(indexerImportPreview()!.contractAddress, 34) }}
+                </a>
+                <app-copy-button
+                  [value]="indexerImportPreview()!.contractAddress"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Deploy TX</span>
+              <div class="flex align-items-center gap-8">
+                <a
+                  [href]="getExplorerLink(indexerImportPreview()!.deployTxid)"
+                  target="_blank"
+                  class="text-blue typo-text-2"
+                >
+                  {{ truncate(indexerImportPreview()!.deployTxid, 24) }}
+                </a>
+                <app-copy-button
+                  [value]="indexerImportPreview()!.deployTxid"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+
+            <div class="flex column gap-8">
+              <span class="text-gray-60 typo-text-1">Parameters</span>
+              @for (
+                field of indexerImportPreview()!.template.fields;
+                track field.paramName
+              ) {
+                <div class="param-item p-8 rounded flex column gap-4">
+                  <span class="text-white typo-text-2">{{ field.label }}</span>
+                  <span class="text-gray-60 typo-text-2 text-mono">
+                    {{ indexerImportPreview()!.fieldValues[field.paramName] }}
+                  </span>
+                </div>
+              }
+            </div>
+
+            <kc-button
+              [text]="'Import Covenant'"
+              [isFullWidth]="true"
+              (buttonClick)="importIndexerPreview()"
+            >
+            </kc-button>
+          </div>
+        }
+      </div>
     </div>
-
-    <!-- Indexer Import -->
-    <div class="panel flex column gap-16 p-20 rounded-lg">
-      <h3 class="text-white typo-text-1 fw-bold">Import from Indexer</h3>
-      <p class="text-gray-60 typo-text-2">Enter a covenant ID, script hash, deploy transaction, contract address, or shared contract link value. Only wallet-supported templates can be imported.</p>
-      <div class="flex gap-8 align-items-end">
-        <div class="form-group flex column gap-8 flex-1">
-          <kc-input [label]="'Contract Lookup'" [placeholder]="'covenant ID, txid, or kaspatest:...'"
-            [type]="'text'" [isFullWidth]="true" [isDisabled]="indexerImportLoading()"
-            [ngModel]="indexerImportQuery" (valueChange)="indexerImportQuery = $event || ''">
-          </kc-input>
-        </div>
-        <kc-button [text]="indexerImportLoading() ? 'Loading...' : 'Find'"
-          [isDisabled]="indexerImportLoading() || !indexerImportQuery.trim()" (buttonClick)="lookupIndexerImport()">
-        </kc-button>
-      </div>
-
-      @if (indexerImportError()) {
-      <div class="error-message p-12 rounded-lg text-red typo-text-2">
-        {{ indexerImportError() }}
-      </div>
-      }
-
-      @if (indexerImportPreview()) {
-      <div class="lookup-result flex column gap-12 p-16 rounded-lg">
-        <div class="flex justify-content-between align-items-center">
-          <h4 class="text-white typo-text-1 fw-bold">{{ indexerImportPreview()!.template.name }}</h4>
-          <span class="text-gray-60 typo-text-2">{{ formatSompiToKas(indexerImportPreview()!.amountSompi) }} KAS</span>
-        </div>
-
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Covenant ID</span>
-          <div class="flex align-items-center gap-8">
-            <span class="text-white typo-text-2 text-mono">{{ truncate(indexerImportPreview()!.covenantId, 28) }}</span>
-            <app-copy-button [value]="indexerImportPreview()!.covenantId" [size]="'sm'"></app-copy-button>
-          </div>
-        </div>
-
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Contract Address</span>
-          <div class="flex align-items-center gap-8">
-            <a [href]="getExplorerAddressLink(indexerImportPreview()!.contractAddress)" target="_blank"
-              class="text-blue typo-text-2">
-              {{ truncate(indexerImportPreview()!.contractAddress, 34) }}
-            </a>
-            <app-copy-button [value]="indexerImportPreview()!.contractAddress" [size]="'sm'"></app-copy-button>
-          </div>
-        </div>
-
-        <div class="flex column gap-4">
-          <span class="text-gray-60 typo-text-1">Deploy TX</span>
-          <div class="flex align-items-center gap-8">
-            <a [href]="getExplorerLink(indexerImportPreview()!.deployTxid)" target="_blank" class="text-blue typo-text-2">
-              {{ truncate(indexerImportPreview()!.deployTxid, 24) }}
-            </a>
-            <app-copy-button [value]="indexerImportPreview()!.deployTxid" [size]="'sm'"></app-copy-button>
-          </div>
-        </div>
-
-        <div class="flex column gap-8">
-          <span class="text-gray-60 typo-text-1">Parameters</span>
-          @for (field of indexerImportPreview()!.template.fields; track field.paramName) {
-          <div class="param-item p-8 rounded flex column gap-4">
-            <span class="text-white typo-text-2">{{ field.label }}</span>
-            <span class="text-gray-60 typo-text-2 text-mono">
-              {{ indexerImportPreview()!.fieldValues[field.paramName] }}
-            </span>
-          </div>
-          }
-        </div>
-
-        <kc-button [text]="'Import Covenant'" [isFullWidth]="true" (buttonClick)="importIndexerPreview()">
-        </kc-button>
-      </div>
-      }
-    </div>
-  </div>
   }
 
   <!-- Tab 3: My Contracts -->
-  @if (activeTab() === 'my-contracts') {
-  <div class="contracts-list flex column gap-16">
-
-    @if (!detailRouteId()) {
-    <div class="panel flex column gap-12 p-20 rounded-lg">
-      <div class="flex column align-items-start gap-12">
-        <div class="flex align-items-center gap-8 flex-wrap">
-          <div class="contract-filter flex gap-4 rounded">
-            <button class="filter-button p-8 rounded typo-text-2" [class.active]="dashboardFilter() === 'active'"
-              (click)="setDashboardFilter('active')">
-              Active ({{ activeDashboardContracts().length }})
-            </button>
-            <button class="filter-button p-8 rounded typo-text-2" [class.active]="dashboardFilter() === 'history'"
-              (click)="setDashboardFilter('history')">
-              History ({{ historyDashboardContracts().length }})
-            </button>
+  @if (activeTab() === "my-contracts") {
+    <div class="contracts-list flex column gap-16">
+      @if (!detailRouteId()) {
+        <div class="panel flex column gap-12 p-20 rounded-lg">
+          <div class="flex column align-items-start gap-12">
+            <div class="flex align-items-center gap-8 flex-wrap">
+              <div class="contract-filter flex gap-4 rounded">
+                <button
+                  class="filter-button p-8 rounded typo-text-2"
+                  [class.active]="dashboardFilter() === 'active'"
+                  (click)="setDashboardFilter('active')"
+                >
+                  Active ({{ activeDashboardContracts().length }})
+                </button>
+                <button
+                  class="filter-button p-8 rounded typo-text-2"
+                  [class.active]="dashboardFilter() === 'history'"
+                  (click)="setDashboardFilter('history')"
+                >
+                  History ({{ historyDashboardContracts().length }})
+                </button>
+              </div>
+              <button
+                class="refresh-button p-8 rounded typo-text-2"
+                [disabled]="dashboardLoading()"
+                (click)="loadContracts()"
+              >
+                {{ dashboardLoading() ? "Refreshing..." : "Refresh" }}
+              </button>
+            </div>
+            <div class="flex column gap-4">
+              <h3 class="text-white typo-text-1 fw-bold">My Contracts</h3>
+              <p class="text-gray-60 typo-text-2">
+                Tracked by wallet address, role args, active UTXOs, and covenant
+                timeline from the indexer.
+              </p>
+            </div>
           </div>
-          <button class="refresh-button p-8 rounded typo-text-2" [disabled]="dashboardLoading()" (click)="loadContracts()">
-            {{ dashboardLoading() ? 'Refreshing...' : 'Refresh' }}
+
+          @if (dashboardError()) {
+            <div class="error-message p-12 rounded-lg text-red typo-text-2">
+              {{ dashboardError() }}
+            </div>
+          }
+
+          @if (dashboardLoading()) {
+            <div class="p-12 rounded text-gray-60 typo-text-2">
+              Loading indexer-backed contract tracking...
+            </div>
+          }
+        </div>
+      } @else {
+        <div
+          class="detail-route-header flex justify-content-between align-items-center gap-12 flex-wrap"
+        >
+          <button
+            class="back-button p-8 rounded typo-text-2"
+            (click)="backToContractsList()"
+          >
+            Back to Contracts
           </button>
+          @if (selectedDetail() && selectedDetail()!.entry.status !== "spent") {
+            <span class="text-gray-60 typo-text-2"
+              >Actions are available below</span
+            >
+          }
         </div>
-        <div class="flex column gap-4">
-          <h3 class="text-white typo-text-1 fw-bold">My Contracts</h3>
-          <p class="text-gray-60 typo-text-2">Tracked by wallet address, role args, active UTXOs, and covenant timeline from the indexer.</p>
-        </div>
-      </div>
 
-      @if (dashboardError()) {
-      <div class="error-message p-12 rounded-lg text-red typo-text-2">
-        {{ dashboardError() }}
-      </div>
-      }
-
-      @if (dashboardLoading()) {
-      <div class="p-12 rounded text-gray-60 typo-text-2">
-        Loading indexer-backed contract tracking...
-      </div>
-      }
-    </div>
-    } @else {
-    <div class="detail-route-header flex justify-content-between align-items-center gap-12 flex-wrap">
-      <button class="back-button p-8 rounded typo-text-2" (click)="backToContractsList()">
-        Back to Contracts
-      </button>
-      @if (selectedDetail() && selectedDetail()!.entry.status !== 'spent') {
-      <span class="text-gray-60 typo-text-2">Actions are available below</span>
-      }
-    </div>
-
-    @if (detailRouteNotFound()) {
-    <div class="empty-state p-32 rounded-lg text-center">
-      <p class="text-gray-60 typo-text-1">Contract not found for this wallet on {{ network() }}</p>
-    </div>
-    }
-
-    @if (dashboardError()) {
-    <div class="error-message p-12 rounded-lg text-red typo-text-2">
-      {{ dashboardError() }}
-    </div>
-    }
-    }
-
-    @if (!detailRouteId()) {
-    @if (!dashboardLoading() && filteredDashboardContracts().length === 0) {
-    <div class="empty-state p-32 rounded-lg text-center">
-      <p class="text-gray-60 typo-text-1">
-        @if (dashboardFilter() === 'history') {
-        No spent contracts found for this wallet on {{ network() }}
-        } @else {
-        No active contracts found for this wallet on {{ network() }}
+        @if (detailRouteNotFound()) {
+          <div class="empty-state p-32 rounded-lg text-center">
+            <p class="text-gray-60 typo-text-1">
+              Contract not found for this wallet on {{ network() }}
+            </p>
+          </div>
         }
-      </p>
-    </div>
-    }
 
-    @for (contract of filteredDashboardContracts(); track contract.id) {
-    <div class="contract-card p-20 rounded-lg flex column gap-16"
-      [style.opacity]="contract.status === 'spent' ? '0.5' : '1'">
-      <div class="flex justify-content-between align-items-start">
-        <div class="flex column gap-4">
-          <div class="flex align-items-center gap-8 flex-wrap">
-            <h3 class="text-white typo-title-3">{{ contract.displayName }}</h3>
-            @for (sourceLabel of getSourceLabels(contract); track sourceLabel) {
-            <span class="source-badge p-6 rounded typo-text-2">{{ sourceLabel }}</span>
+        @if (selectedDetailError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ selectedDetailError() }}
+          </div>
+        }
+
+        @if (dashboardError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ dashboardError() }}
+          </div>
+        }
+      }
+
+      @if (!detailRouteId()) {
+        @if (!dashboardLoading() && filteredDashboardContracts().length === 0) {
+          <div class="empty-state p-32 rounded-lg text-center">
+            <p class="text-gray-60 typo-text-1">
+              @if (dashboardFilter() === "history") {
+                No spent contracts found for this wallet on {{ network() }}
+              } @else {
+                No active contracts found for this wallet on {{ network() }}
+              }
+            </p>
+          </div>
+        }
+
+        @for (contract of filteredDashboardContracts(); track contract.id) {
+          <div
+            class="contract-card p-20 rounded-lg flex column gap-16"
+            [style.opacity]="contract.status === 'spent' ? '0.5' : '1'"
+          >
+            <div class="flex justify-content-between align-items-start">
+              <div class="flex column gap-4">
+                <div class="flex align-items-center gap-8 flex-wrap">
+                  <h3 class="text-white typo-title-3">
+                    {{ contract.displayName }}
+                  </h3>
+                  @for (
+                    sourceLabel of getSourceLabels(contract);
+                    track sourceLabel
+                  ) {
+                    <span class="source-badge p-6 rounded typo-text-2">{{
+                      sourceLabel
+                    }}</span>
+                  }
+                </div>
+                <span class="text-gray-60 typo-text-2">
+                  {{ formatSompiToKas(contract.amountSompi) }} KAS
+                </span>
+              </div>
+              <div class="flex align-items-center gap-8">
+                @if (contract.status === "spent") {
+                  <div
+                    class="status-badge inactive p-8 rounded"
+                    kcTooltip="No active covenant UTXO is currently indexed"
+                    tooltipPosition="left"
+                  >
+                    <span class="typo-text-2">Spent</span>
+                  </div>
+                } @else if (
+                  contract.status === "unknown" ||
+                  contract.status === "tracking-incomplete"
+                ) {
+                  <div
+                    class="status-badge unknown p-8 rounded"
+                    kcTooltip="The wallet has a local entry, but indexer tracking is incomplete"
+                    tooltipPosition="left"
+                  >
+                    <span class="typo-text-2">Tracking</span>
+                  </div>
+                } @else {
+                  <div class="status-badge active p-8 rounded">
+                    <span class="typo-text-2">Active</span>
+                  </div>
+                }
+                @if (contract.registryEntry) {
+                  <span
+                    class="text-gray-60 typo-text-2 cursor-pointer"
+                    (click)="deleteContract(contract.registryEntry.id)"
+                    kcTooltip="Remove local copy from list"
+                    tooltipPosition="left"
+                    >✕</span
+                  >
+                }
+              </div>
+            </div>
+
+            @if (contract.participants.length > 0) {
+              <div class="participant-grid">
+                @for (
+                  participant of contract.participants.slice(0, 4);
+                  track participant.label + participant.value
+                ) {
+                  <div class="participant-item p-8 rounded">
+                    <span class="text-gray-60 typo-text-2">{{
+                      participant.label
+                    }}</span>
+                    <span class="text-white typo-text-2 text-mono">{{
+                      truncate(participant.value, 22)
+                    }}</span>
+                  </div>
+                }
+              </div>
             }
-          </div>
-          <span class="text-gray-60 typo-text-2">
-            {{ formatSompiToKas(contract.amountSompi) }} KAS
-          </span>
-        </div>
-        <div class="flex align-items-center gap-8">
-          @if (contract.status === 'spent') {
-          <div class="status-badge inactive p-8 rounded" kcTooltip="No active covenant UTXO is currently indexed"
-            tooltipPosition="left">
-            <span class="typo-text-2">Spent</span>
-          </div>
-          } @else if (contract.status === 'unknown' || contract.status === 'tracking-incomplete') {
-          <div class="status-badge unknown p-8 rounded" kcTooltip="The wallet has a local entry, but indexer tracking is incomplete"
-            tooltipPosition="left">
-            <span class="typo-text-2">Tracking</span>
-          </div>
-          } @else {
-          <div class="status-badge active p-8 rounded">
-            <span class="typo-text-2">Active</span>
-          </div>
-          }
-          @if (contract.registryEntry) {
-          <span class="text-gray-60 typo-text-2 cursor-pointer" (click)="deleteContract(contract.registryEntry.id)"
-            kcTooltip="Remove local copy from list" tooltipPosition="left">✕</span>
-          }
-        </div>
-      </div>
 
-      @if (contract.participants.length > 0) {
-      <div class="participant-grid">
-        @for (participant of contract.participants.slice(0, 4); track participant.label + participant.value) {
-        <div class="participant-item p-8 rounded">
-          <span class="text-gray-60 typo-text-2">{{ participant.label }}</span>
-          <span class="text-white typo-text-2 text-mono">{{ truncate(participant.value, 22) }}</span>
-        </div>
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-2">Current Address</span>
+              <div class="flex align-items-center gap-8">
+                @if (contract.currentAddress) {
+                  <a
+                    [href]="getExplorerAddressLink(contract.currentAddress)"
+                    target="_blank"
+                    class="text-blue typo-text-2"
+                  >
+                    {{ truncate(contract.currentAddress, 30) }}
+                  </a>
+                  <app-copy-button
+                    [value]="contract.currentAddress"
+                    [size]="'sm'"
+                  ></app-copy-button>
+                } @else {
+                  <span class="text-white typo-text-2">Unknown</span>
+                }
+              </div>
+            </div>
+
+            @if (contract.covenantId) {
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-2">Covenant ID</span>
+                <div class="flex align-items-center gap-8">
+                  <span class="text-white typo-text-2 text-mono">{{
+                    truncate(contract.covenantId, 24)
+                  }}</span>
+                  <app-copy-button
+                    [value]="contract.covenantId"
+                    [size]="'sm'"
+                  ></app-copy-button>
+                </div>
+              </div>
+            }
+
+            @if (contract.deadlineMs) {
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-2">Deadline</span>
+                <span class="text-white typo-text-2">{{
+                  formatTimestamp(contract.deadlineMs)
+                }}</span>
+              </div>
+            }
+
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-2">Latest Action</span>
+              <div class="flex align-items-center gap-8">
+                <span class="text-white typo-text-2">{{
+                  formatActionName(contract.latestAction || "deploy")
+                }}</span>
+                @if (contract.latestTxid) {
+                  <a
+                    [href]="getExplorerLink(contract.latestTxid)"
+                    target="_blank"
+                    class="text-blue typo-text-2"
+                  >
+                    {{ truncate(contract.latestTxid, 20) }}
+                  </a>
+                  <app-copy-button
+                    [value]="contract.latestTxid"
+                    [size]="'sm'"
+                  ></app-copy-button>
+                }
+              </div>
+            </div>
+
+            <div class="flex gap-8 flex-wrap">
+              <kc-button
+                [text]="'View Details'"
+                (buttonClick)="navigateToContractDetail(contract)"
+              >
+              </kc-button>
+              @if (contract.status !== "spent") {
+                <kc-button
+                  [text]="contract.nextActionLabel"
+                  (buttonClick)="openDashboardAction(contract)"
+                >
+                </kc-button>
+              }
+              @if (contract.covenantId) {
+                <kc-button
+                  [text]="'Copy Share Link'"
+                  (buttonClick)="copyContractShareLink(contract)"
+                >
+                </kc-button>
+              }
+            </div>
+          </div>
         }
-      </div>
       }
-
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Current Address</span>
-        <div class="flex align-items-center gap-8">
-          @if (contract.currentAddress) {
-          <a [href]="getExplorerAddressLink(contract.currentAddress || '')" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.currentAddress, 30) }}
-          </a>
-          <app-copy-button [value]="contract.currentAddress" [size]="'sm'"></app-copy-button>
-          } @else {
-          <span class="text-white typo-text-2">Unknown</span>
-          }
-        </div>
-      </div>
-
-      @if (contract.covenantId) {
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Covenant ID</span>
-        <div class="flex align-items-center gap-8">
-          <span class="text-white typo-text-2 text-mono">{{ truncate(contract.covenantId, 24) }}</span>
-          <app-copy-button [value]="contract.covenantId" [size]="'sm'"></app-copy-button>
-        </div>
-      </div>
-      }
-
-      @if (contract.deadlineMs) {
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Deadline</span>
-        <span class="text-white typo-text-2">{{ formatTimestamp(contract.deadlineMs) }}</span>
-      </div>
-      }
-
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Latest Action</span>
-        <div class="flex align-items-center gap-8">
-          <span class="text-white typo-text-2">{{ formatActionName(contract.latestAction || 'deploy') }}</span>
-          @if (contract.latestTxid) {
-          <a [href]="getExplorerLink(contract.latestTxid)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(contract.latestTxid, 20) }}
-          </a>
-          <app-copy-button [value]="contract.latestTxid" [size]="'sm'"></app-copy-button>
-          }
-        </div>
-      </div>
-
-      <div class="flex gap-8 flex-wrap">
-        <kc-button [text]="'View Details'" (buttonClick)="navigateToContractDetail(contract)">
-        </kc-button>
-        @if (contract.status !== 'spent') {
-        <kc-button [text]="contract.nextActionLabel" (buttonClick)="openDashboardAction(contract)">
-        </kc-button>
-        }
-        @if (contract.covenantId) {
-        <kc-button [text]="'Copy Share Link'" (buttonClick)="copyContractShareLink(contract)">
-        </kc-button>
-        }
-      </div>
     </div>
-    }
-    }
-  </div>
   }
 
-  @if (activeTab() === 'detail') {
-  <div class="contracts-list flex column gap-16">
-    @if (selectedDetail()) {
-    <div id="contract-detail-panel" class="panel flex column gap-16 p-20 rounded-lg">
-      <div class="flex justify-content-between align-items-start gap-12">
-        <div class="flex column gap-4">
-          <h3 class="text-white typo-title-3">{{ selectedDetail()!.entry.displayName }}</h3>
-          <p class="text-gray-60 typo-text-2">Current state from covenant detail, active UTXOs, and action timeline.</p>
-        </div>
-        <button class="back-button detail-close-button p-8 rounded typo-text-2" (click)="backToContractsList()">
-          Close
-        </button>
-      </div>
-
-      @if (selectedDetail()!.entry.status !== 'spent') {
-      <div class="contract-detail-tabs flex gap-4 rounded">
-        <button class="detail-tab-button p-8 rounded typo-text-2" [class.active]="detailPanelTab() === 'details'"
-          (click)="setContractDetailTab('details')">
-          Details
-        </button>
-        <button class="detail-tab-button p-8 rounded typo-text-2" [class.active]="detailPanelTab() === 'action'"
-          (click)="setContractDetailTab('action')">
-          Action
-        </button>
-      </div>
-      }
-
-      @if (selectedDetailLoading()) {
-      <div class="p-12 rounded text-gray-60 typo-text-2">Loading current indexer state...</div>
-      }
-
-      @if (selectedDetailError()) {
-      <div class="error-message p-12 rounded-lg text-red typo-text-2">
-        {{ selectedDetailError() }}
-      </div>
-      }
-
-      @if (detailPanelTab() === 'details' || selectedDetail()!.entry.status === 'spent') {
-      <div class="detail-grid">
-        <div class="detail-item p-12 rounded">
-          <span class="text-gray-60 typo-text-2">Status</span>
-          <span class="text-white typo-text-1 fw-bold">{{ getStatusLabel(selectedDetail()!.entry) }}</span>
-        </div>
-        <div class="detail-item p-12 rounded">
-          <span class="text-gray-60 typo-text-2">Locked</span>
-          <span class="text-white typo-text-1 fw-bold">{{ formatSompiToKas(selectedDetail()!.entry.amountSompi) }} KAS</span>
-        </div>
-        <div class="detail-item p-12 rounded">
-          <span class="text-gray-60 typo-text-2">Active UTXOs</span>
-          <span class="text-white typo-text-1 fw-bold">{{ selectedDetail()!.utxos.length }}</span>
-        </div>
-      </div>
-
-      @if (selectedDetail()!.utxos.length > 0) {
-      <div class="flex column gap-8">
-        <span class="text-gray-60 typo-text-1">Current UTXO</span>
-        @for (utxo of selectedDetail()!.utxos; track (utxo.txidHex || '') + ':' + utxo.vout) {
-        <div class="utxo-row p-12 rounded-lg flex justify-content-between align-items-center gap-12">
-          @if (utxo.txidHex) {
-          <a [href]="getExplorerLink(utxo.txidHex)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(utxo.txidHex, 24) }}:{{ utxo.vout ?? 0 }}
-          </a>
-          } @else {
-          <span class="text-gray-60 typo-text-2">Unknown</span>
-          }
-          <span class="text-white typo-text-2 fw-bold">{{ formatSompiToKas(utxo.amountSompi?.toString() || '0') }} KAS</span>
-        </div>
-        }
-      </div>
-      }
-
-      <div class="flex column gap-8">
-        <span class="text-gray-60 typo-text-1">Timeline</span>
-        @for (action of selectedDetail()!.actions.slice(0, 8); track (action.txidHex || '') + (action.action || '') + (action.entrypoint || '')) {
-        <div class="timeline-row p-12 rounded-lg flex justify-content-between align-items-start gap-12">
-          <div class="flex column gap-4">
-            <span class="text-white typo-text-2">{{ formatActionName(action.entrypoint || action.action || 'action') }}</span>
-            <span class="text-gray-60 typo-text-2">{{ formatTimestamp(action.blockTimeMs) }}</span>
+  @if (activeTab() === "detail") {
+    <div class="contracts-list flex column gap-16">
+      @if (selectedDetail()) {
+        <div
+          id="contract-detail-panel"
+          class="panel flex column gap-16 p-20 rounded-lg"
+        >
+          <div class="flex justify-content-between align-items-start gap-12">
+            <div class="flex column gap-4">
+              <h3 class="text-white typo-title-3">
+                {{ selectedDetail()!.entry.displayName }}
+              </h3>
+              <p class="text-gray-60 typo-text-2">
+                Current state from covenant detail, active UTXOs, and action
+                timeline.
+              </p>
+            </div>
+            <button
+              class="back-button detail-close-button p-8 rounded typo-text-2"
+              (click)="backToContractsList()"
+            >
+              Close
+            </button>
           </div>
-          @if (action.txidHex) {
-          <a [href]="getExplorerLink(action.txidHex)" target="_blank" class="text-blue typo-text-2">
-            {{ truncate(action.txidHex, 20) }}
-          </a>
-          }
-        </div>
-        }
-      </div>
 
-      <details class="advanced-section">
-        <summary class="text-gray-60 typo-text-2 cursor-pointer">Advanced technical data</summary>
-        <div class="flex column gap-8 mt-8">
-          @if (selectedDetail()!.entry.covenantId) {
-          <div class="flex column gap-4">
-            <span class="text-gray-60 typo-text-2">Covenant ID</span>
-            <span class="text-white typo-text-2 text-mono">{{ selectedDetail()!.entry.covenantId }}</span>
-          </div>
+          @if (selectedDetail()!.entry.status !== "spent") {
+            <div class="contract-detail-tabs flex gap-4 rounded">
+              <button
+                class="detail-tab-button p-8 rounded typo-text-2"
+                [class.active]="detailPanelTab() === 'details'"
+                (click)="setContractDetailTab('details')"
+              >
+                Details
+              </button>
+              <button
+                class="detail-tab-button p-8 rounded typo-text-2"
+                [class.active]="detailPanelTab() === 'action'"
+                (click)="setContractDetailTab('action')"
+              >
+                Action
+              </button>
+            </div>
           }
-          @if (selectedDetail()!.entry.scriptHash) {
-          <div class="flex column gap-4">
-            <span class="text-gray-60 typo-text-2">Script Hash</span>
-            <span class="text-white typo-text-2 text-mono">{{ selectedDetail()!.entry.scriptHash }}</span>
-          </div>
+
+          @if (selectedDetailLoading()) {
+            <div class="p-12 rounded text-gray-60 typo-text-2">
+              Loading current indexer state...
+            </div>
+          }
+
+          @if (selectedDetailError()) {
+            <div class="error-message p-12 rounded-lg text-red typo-text-2">
+              {{ selectedDetailError() }}
+            </div>
+          }
+
+          @if (
+            detailPanelTab() === "details" ||
+            selectedDetail()!.entry.status === "spent"
+          ) {
+            <div class="detail-grid">
+              <div class="detail-item p-12 rounded">
+                <span class="text-gray-60 typo-text-2">Status</span>
+                <span class="text-white typo-text-1 fw-bold">{{
+                  getStatusLabel(selectedDetail()!.entry)
+                }}</span>
+              </div>
+              <div class="detail-item p-12 rounded">
+                <span class="text-gray-60 typo-text-2">Locked</span>
+                <span class="text-white typo-text-1 fw-bold"
+                  >{{
+                    formatSompiToKas(selectedDetail()!.entry.amountSompi)
+                  }}
+                  KAS</span
+                >
+              </div>
+              <div class="detail-item p-12 rounded">
+                <span class="text-gray-60 typo-text-2">Active UTXOs</span>
+                <span class="text-white typo-text-1 fw-bold">{{
+                  selectedDetail()!.utxos.length
+                }}</span>
+              </div>
+            </div>
+
+            @if (selectedDetail()!.utxos.length > 0) {
+              <div class="flex column gap-8">
+                <span class="text-gray-60 typo-text-1">Current UTXO</span>
+                @for (
+                  utxo of selectedDetail()!.utxos;
+                  track (utxo.txidHex || "") + ":" + utxo.vout
+                ) {
+                  <div
+                    class="utxo-row p-12 rounded-lg flex justify-content-between align-items-center gap-12"
+                  >
+                    @if (utxo.txidHex) {
+                      <a
+                        [href]="getExplorerLink(utxo.txidHex)"
+                        target="_blank"
+                        class="text-blue typo-text-2"
+                      >
+                        {{ truncate(utxo.txidHex, 24) }}:{{ utxo.vout ?? 0 }}
+                      </a>
+                    } @else {
+                      <span class="text-gray-60 typo-text-2">Unknown</span>
+                    }
+                    <span class="text-white typo-text-2 fw-bold"
+                      >{{
+                        formatSompiToKas(utxo.amountSompi?.toString() || "0")
+                      }}
+                      KAS</span
+                    >
+                  </div>
+                }
+              </div>
+            }
+
+            <div class="flex column gap-8">
+              <span class="text-gray-60 typo-text-1">Timeline</span>
+              @for (
+                action of selectedDetail()!.actions.slice(0, 8);
+                track (action.txidHex || "") +
+                  (action.action || "") +
+                  (action.entrypoint || "")
+              ) {
+                <div
+                  class="timeline-row p-12 rounded-lg flex justify-content-between align-items-start gap-12"
+                >
+                  <div class="flex column gap-4">
+                    <span class="text-white typo-text-2">{{
+                      formatActionName(
+                        action.entrypoint || action.action || "action"
+                      )
+                    }}</span>
+                    <span class="text-gray-60 typo-text-2">{{
+                      formatTimestamp(action.blockTimeMs)
+                    }}</span>
+                  </div>
+                  @if (action.txidHex) {
+                    <a
+                      [href]="getExplorerLink(action.txidHex)"
+                      target="_blank"
+                      class="text-blue typo-text-2"
+                    >
+                      {{ truncate(action.txidHex, 20) }}
+                    </a>
+                  }
+                </div>
+              }
+            </div>
+
+            <details class="advanced-section">
+              <summary class="text-gray-60 typo-text-2 cursor-pointer">
+                Advanced technical data
+              </summary>
+              <div class="flex column gap-8 mt-8">
+                @if (selectedDetail()!.entry.covenantId) {
+                  <div class="flex column gap-4">
+                    <span class="text-gray-60 typo-text-2">Covenant ID</span>
+                    <span class="text-white typo-text-2 text-mono">{{
+                      selectedDetail()!.entry.covenantId
+                    }}</span>
+                  </div>
+                }
+                @if (selectedDetail()!.entry.scriptHash) {
+                  <div class="flex column gap-4">
+                    <span class="text-gray-60 typo-text-2">Script Hash</span>
+                    <span class="text-white typo-text-2 text-mono">{{
+                      selectedDetail()!.entry.scriptHash
+                    }}</span>
+                  </div>
+                }
+              </div>
+            </details>
           }
         </div>
-      </details>
       }
     </div>
-    }
-  </div>
   }
 
   <!-- Tab 3: Interact -->
-  @if (activeTab() === 'interact' || (activeTab() === 'detail' && detailPanelTab() === 'action' && selectedDetail() && selectedDetail()!.entry.status !== 'spent' && interactContractJson())) {
-  <div class="panel flex column gap-20 p-24 rounded-lg">
-    <!-- Contract selector from registry -->
-    @if (selectedContract()) {
-    <div class="contract-summary p-16 rounded-lg flex column gap-8">
-      <span class="text-gray-60 typo-text-2">Current Contract</span>
-      <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
-        <div class="flex column gap-4">
-          <span class="text-white typo-text-1 fw-bold">{{ selectedContract()!.contractName }}</span>
-          <span class="text-gray-60 typo-text-2">{{ truncate(selectedContract()!.contractAddress, 30) }}</span>
+  @if (
+    activeTab() === "interact" ||
+    (activeTab() === "detail" &&
+      detailPanelTab() === "action" &&
+      selectedDetail() &&
+      selectedDetail()!.entry.status !== "spent" &&
+      interactContractJson())
+  ) {
+    <div class="panel flex column gap-20 p-24 rounded-lg">
+      <!-- Contract selector from registry -->
+      @if (selectedContract()) {
+        <div class="contract-summary p-16 rounded-lg flex column gap-8">
+          <span class="text-gray-60 typo-text-2">Current Contract</span>
+          <div
+            class="flex justify-content-between align-items-center gap-12 flex-wrap"
+          >
+            <div class="flex column gap-4">
+              <span class="text-white typo-text-1 fw-bold">{{
+                selectedContract()!.contractName
+              }}</span>
+              <span class="text-gray-60 typo-text-2">{{
+                truncate(selectedContract()!.contractAddress, 30)
+              }}</span>
+            </div>
+            <span class="text-gray-60 typo-text-2"
+              >{{ formatSompiToKas(selectedContract()!.amountSompi) }} KAS</span
+            >
+          </div>
         </div>
-        <span class="text-gray-60 typo-text-2">{{ formatSompiToKas(selectedContract()!.amountSompi) }} KAS</span>
-      </div>
-    </div>
-    } @else if (activeTab() !== 'detail' && !detailRouteId() && !interactContractJson()) {
-    <div class="form-group flex column gap-8">
-      <label class="text-gray-60 typo-text-1">Select Contract</label>
-      <kc-dropdown-select [options]="registryContractOptions()" [placeholder]="'Select a deployed contract'"
-        [isFullWidth]="true" [isDisabled]="isInteracting()" [value]="selectedContractId()"
-        (valueChange)="selectedContractId.set($event); selectContractFromRegistry()">
-      </kc-dropdown-select>
-    </div>
-    }
+      } @else if (
+        activeTab() !== "detail" && !detailRouteId() && !interactContractJson()
+      ) {
+        <div class="form-group flex column gap-8">
+          <label class="text-gray-60 typo-text-1">Select Contract</label>
+          <kc-dropdown-select
+            [options]="registryContractOptions()"
+            [placeholder]="'Select a deployed contract'"
+            [isFullWidth]="true"
+            [isDisabled]="isInteracting()"
+            [value]="selectedContractId()"
+            (valueChange)="
+              selectedContractId.set($event); selectContractFromRegistry()
+            "
+          >
+          </kc-dropdown-select>
+        </div>
+      }
 
-    <!-- Advanced: Manual contract JSON (collapsed by default) -->
-    <details class="advanced-section">
-      <summary class="text-gray-60 typo-text-2 cursor-pointer"
-        kcTooltip="Paste raw compiled JSON to interact with unregistered contracts" tooltipPosition="top">
-        ⚙️ Advanced: Paste Contract JSON
-      </summary>
-      <div class="form-group flex column gap-8 mt-8">
-        <textarea class="contract-input p-12 rounded-lg text-white typo-text-2" rows="4"
-          placeholder="Paste compiled contract JSON here" [ngModel]="interactContractJson()" (ngModelChange)="interactContractJson.set($event)"
-          [disabled]="isInteracting()">
+      <!-- Advanced: Manual contract JSON (collapsed by default) -->
+      <details class="advanced-section">
+        <summary
+          class="text-gray-60 typo-text-2 cursor-pointer"
+          kcTooltip="Paste raw compiled JSON to interact with unregistered contracts"
+          tooltipPosition="top"
+        >
+          ⚙️ Advanced: Paste Contract JSON
+        </summary>
+        <div class="form-group flex column gap-8 mt-8">
+          <textarea
+            class="contract-input p-12 rounded-lg text-white typo-text-2"
+            rows="4"
+            placeholder="Paste compiled contract JSON here"
+            [ngModel]="interactContractJson()"
+            (ngModelChange)="interactContractJson.set($event)"
+            [disabled]="isInteracting()"
+          >
           </textarea>
-      </div>
-    </details>
-
-    <!-- Contract info card -->
-    @if (parsedInteractContract()) {
-    <div class="contract-summary p-16 rounded-lg flex column gap-12">
-      <h3 class="text-white typo-text-1 fw-bold">{{ parsedInteractContract()!.contract_name || 'Contract' }}</h3>
-
-      <!-- UTXO Details (read-only) -->
-      <div class="flex column gap-8">
-        <div class="flex align-items-center gap-4">
-          <span class="text-gray-60 typo-text-2">Locked Amount</span>
-          <kc-icon [iconClass]="'icon-info'" [size]="'xs'" kcTooltip="Total KAS locked in this covenant UTXO"
-            tooltipPosition="top"></kc-icon>
         </div>
-        <span class="text-white typo-text-1 fw-bold">{{ interactInputAmountKas() }} KAS</span>
-      </div>
+      </details>
 
-      @if (interactOutpointTxid) {
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Transaction</span>
-        <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerLink(interactOutpointTxid)" target="_blank" class="text-blue typo-text-2 text-truncate">
-            {{ truncate(interactOutpointTxid, 24) }}
-          </a>
-          <app-copy-button [value]="interactOutpointTxid" [size]="'sm'"></app-copy-button>
+      <!-- Contract info card -->
+      @if (parsedInteractContract()) {
+        <div class="contract-summary p-16 rounded-lg flex column gap-12">
+          <h3 class="text-white typo-text-1 fw-bold">
+            {{ parsedInteractContract()!.contract_name || "Contract" }}
+          </h3>
+
+          <!-- UTXO Details (read-only) -->
+          <div class="flex column gap-8">
+            <div class="flex align-items-center gap-4">
+              <span class="text-gray-60 typo-text-2">Locked Amount</span>
+              <kc-icon
+                [iconClass]="'icon-info'"
+                [size]="'xs'"
+                kcTooltip="Total KAS locked in this covenant UTXO"
+                tooltipPosition="top"
+              ></kc-icon>
+            </div>
+            <span class="text-white typo-text-1 fw-bold"
+              >{{ interactInputAmountKas() }} KAS</span
+            >
+          </div>
+
+          @if (interactOutpointTxid) {
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-2">Transaction</span>
+              <div class="flex align-items-center gap-8">
+                <a
+                  [href]="getExplorerLink(interactOutpointTxid)"
+                  target="_blank"
+                  class="text-blue typo-text-2 text-truncate"
+                >
+                  {{ truncate(interactOutpointTxid, 24) }}
+                </a>
+                <app-copy-button
+                  [value]="interactOutpointTxid"
+                  [size]="'sm'"
+                ></app-copy-button>
+              </div>
+            </div>
+          }
+
+          @if (currentWallet()) {
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-2">Your Account</span>
+              <span class="text-white typo-text-2">{{
+                currentWallet()!.getDisplayName()
+              }}</span>
+            </div>
+          }
         </div>
-      </div>
-      }
 
-      @if (currentWallet()) {
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-2">Your Account</span>
-        <span class="text-white typo-text-2">{{ currentWallet()!.getDisplayName() }}</span>
-      </div>
-      }
-    </div>
+        <!-- Action Selection -->
+        <div class="form-group flex column gap-8">
+          <div class="flex align-items-center gap-4">
+            <label class="text-gray-60 typo-text-1">Action</label>
+            <kc-icon
+              [iconClass]="'icon-info'"
+              [size]="'xs'"
+              kcTooltip="Choose how to interact with this contract. Each action has different requirements (e.g. owner key, timelock expiry)."
+              tooltipPosition="top"
+            ></kc-icon>
+          </div>
 
-    <!-- Action Selection -->
-    <div class="form-group flex column gap-8">
-      <div class="flex align-items-center gap-4">
-        <label class="text-gray-60 typo-text-1">Action</label>
-        <kc-icon [iconClass]="'icon-info'" [size]="'xs'"
-          kcTooltip="Choose how to interact with this contract. Each action has different requirements (e.g. owner key, timelock expiry)."
-          tooltipPosition="top"></kc-icon>
-      </div>
+          <!-- Function buttons instead of dropdown -->
+          <div class="flex gap-8 flex-wrap">
+            @for (fn of availableFunctions(); track fn.name) {
+              <kc-button
+                [text]="getFunctionLabel(fn.name)"
+                [isDisabled]="isInteracting()"
+                [class.active-function]="selectedFunction === fn.name"
+                [style]="
+                  selectedFunction === fn.name ? 'opacity: 1' : 'opacity: 0.6'
+                "
+                (buttonClick)="selectFunction(fn.name)"
+              >
+              </kc-button>
+            }
+          </div>
 
-      <!-- Function buttons instead of dropdown -->
-      <div class="flex gap-8 flex-wrap">
-        @for (fn of availableFunctions(); track fn.name) {
-        <kc-button [text]="getFunctionLabel(fn.name)" [isDisabled]="isInteracting()"
-          [class.active-function]="selectedFunction === fn.name"
-          [style]="selectedFunction === fn.name ? 'opacity: 1' : 'opacity: 0.6'"
-          (buttonClick)="selectFunction(fn.name)">
-        </kc-button>
-        }
-      </div>
+          @if (selectedFunction) {
+            <div
+              class="p-12 rounded-lg"
+              style="
+                background: rgba(111, 199, 186, 0.08);
+                border: 1px solid rgba(111, 199, 186, 0.2);
+              "
+            >
+              <span class="text-gray-75 typo-text-2">{{
+                getFunctionDescription(selectedFunction)
+              }}</span>
+            </div>
+          }
 
-      @if (selectedFunction) {
-      <div class="p-12 rounded-lg"
-        style="background: rgba(111, 199, 186, 0.08); border: 1px solid rgba(111, 199, 186, 0.2);">
-        <span class="text-gray-75 typo-text-2">{{ getFunctionDescription(selectedFunction) }}</span>
-      </div>
-      }
+          @if (availableFunctions().length === 0 && interactContractJson()) {
+            <span class="text-gray-60 typo-text-2"
+              >No callable functions found in this contract</span
+            >
+          }
 
-      @if (availableFunctions().length === 0 && interactContractJson()) {
-      <span class="text-gray-60 typo-text-2">No callable functions found in this contract</span>
-      }
+          @if (selectedFunction && isMultiSigFunction(selectedFunction)) {
+            <div
+              class="p-12 rounded-lg"
+              style="
+                background: rgba(255, 193, 7, 0.1);
+                border: 1px solid rgba(255, 193, 7, 0.3);
+              "
+            >
+              <span class="text-yellow typo-text-2">
+                Two-phase signing: clicking the button will sign your part and
+                generate a partial spend JSON. Send it to the co-signer to
+                complete.
+              </span>
+            </div>
+          }
+        </div>
 
-      @if (selectedFunction && isMultiSigFunction(selectedFunction)) {
-      <div class="p-12 rounded-lg"
-        style="background: rgba(255, 193, 7, 0.1); border: 1px solid rgba(255, 193, 7, 0.3);">
-        <span class="text-yellow typo-text-2">
-          Two-phase signing: clicking the button will sign your part and generate a partial spend JSON. Send it to the
-          co-signer to complete.
-        </span>
-      </div>
-      }
-    </div>
-
-    <!-- DMS keepAlive: new expiry input -->
-    @if (isDmsKeepAlive()) {
-    <div class="form-group flex column gap-8">
-      <app-covenant-date-time-input [label]="'New check-in deadline'" [value]="dmsNewExpiry"
-        [isDisabled]="isInteracting()" [isValid]="true" (valueChange)="dmsNewExpiry = $event">
-      </app-covenant-date-time-input>
-      <!--
+        <!-- DMS keepAlive: new expiry input -->
+        @if (isDmsKeepAlive()) {
+          <div class="form-group flex column gap-8">
+            <app-covenant-date-time-input
+              [label]="'New check-in deadline'"
+              [value]="dmsNewExpiry"
+              [isDisabled]="isInteracting()"
+              [isValid]="true"
+              (valueChange)="dmsNewExpiry = $event"
+            >
+            </app-covenant-date-time-input>
+            <!--
         🔗 Convert date to timestamp →
       -->
-      <span class="text-gray-60 typo-text-2">Pick when the heir should become able to claim if you do not refresh again.</span>
-    </div>
+            <span class="text-gray-60 typo-text-2"
+              >Pick when the heir should become able to claim if you do not
+              refresh again.</span
+            >
+          </div>
 
-    <div class="p-12 rounded-lg"
-      style="background: rgba(111, 199, 186, 0.08); border: 1px solid rgba(111, 199, 186, 0.2);">
-      <span class="text-gray-75 typo-text-2">
-        A new Dead Man's Switch contract will be generated with the same owner and heir but the updated expiry.
-        Funds will move to the new contract in the same transaction. The covenant lineage is preserved.
-      </span>
-    </div>
-    }
-
-    <!-- Output address + amount (only for withdrawal functions, NOT DMS keepAlive) -->
-    @if (selectedFunction && functionRequiresOutput(selectedFunction) && !isDmsKeepAlive()) {
-    <div class="form-group flex column gap-8">
-      <app-address-smart-input [label]="'Send To'" [placeholder]="'Enter recipient wallet address or KNS domain'"
-        [isFullWidth]="true" [isValid]="true" [invalidReason]="''" [isDisabled]="isInteracting()"
-        [value]="interactOutputAddress" (valueChange)="onInteractOutputAddressChange($event)"
-        (resolved)="onInteractOutputAddressResolved($event)" (qrClick)="onInteractOutputQrClick()">
-      </app-address-smart-input>
-    </div>
-
-    <div class="form-group flex column gap-8">
-      <kc-input [label]="'Withdraw Amount (KAS)'" [placeholder]="'0'" [type]="'number'" [min]="0"
-        [isFullWidth]="true" [isDisabled]="isInteracting()" [ngModel]="interactOutputAmount"
-        (valueChange)="onInteractOutputAmountChange($event)">
-        <div (click)="!isInteracting() && fillMaxOutputAmount()"
-          [class]="isInteracting() ? 'max-text disabled' : 'max-text clickable'" rightSideSlot>
-          <span>Max</span>
-        </div>
-      </kc-input>
-    </div>
-    }
-
-    <!-- Info banner for redeploy functions (keepAlive on non-DMS contracts, increment) -->
-    @if (selectedFunction && !functionRequiresOutput(selectedFunction) && !isDmsKeepAlive()) {
-    <div class="p-12 rounded-lg"
-      style="background: rgba(111, 199, 186, 0.08); border: 1px solid rgba(111, 199, 186, 0.2);">
-      <span class="text-gray-75 typo-text-2">
-        Funds will be re-locked into the same contract (minus ~0.00001 KAS fee). No external withdrawal.
-      </span>
-    </div>
-    }
-
-    <!-- Extra args (int/bool params, e.g. escrow arbitrate amountToSeller) -->
-    @for (arg of extraArgsForFunction(); track arg.name) {
-    <div class="form-group flex column gap-8">
-      <kc-input [label]="arg.name + ' (' + arg.type_name + ')'" [placeholder]="'Enter ' + arg.name + ' value'"
-        [type]="'number'" [isFullWidth]="true" [isDisabled]="isInteracting()"
-        [ngModel]="extraArgValues[arg.name] || ''" (valueChange)="extraArgValues[arg.name] = $event || ''">
-      </kc-input>
-    </div>
-    }
-
-    <!-- Multi-sig: partial spend output -->
-    @if (partialSpendJson()) {
-    <div class="flex column gap-8 p-12 rounded-lg"
-      style="background: rgba(255, 193, 7, 0.08); border: 1px solid rgba(255, 193, 7, 0.2);">
-      <span class="text-yellow typo-text-1 fw-bold">Partial Spend Created</span>
-      <span class="text-gray-75 typo-text-2">
-        Your signature has been added. Copy the JSON below and send it to the co-signer to complete the transaction.
-      </span>
-      <textarea class="contract-input p-12 rounded-lg text-white typo-text-2" rows="4" readonly
-        [value]="partialSpendJson()!">
-            </textarea>
-      <kc-button [text]="'Copy Partial Spend JSON'" [isFullWidth]="true" (buttonClick)="copyPartialSpend()">
-      </kc-button>
-    </div>
-    }
-    }
-
-    <!-- Two-Phase Signing: Complete a partial spend from co-signer -->
-    @if (parsedInteractContract()) {
-    <details class="advanced-section">
-      <summary class="text-gray-60 typo-text-2 cursor-pointer"
-        kcTooltip="Complete a multi-sig transaction started by a co-signer" tooltipPosition="top">
-        Complete Co-Signer Transaction
-      </summary>
-      <div class="flex column gap-12 mt-8">
-        <span class="text-gray-75 typo-text-2">
-          Paste the partial spend JSON received from the co-signer. Your signature will be added and the transaction
-          broadcast.
-        </span>
-        <textarea class="contract-input p-12 rounded-lg text-white typo-text-2" rows="4"
-          placeholder="Paste partial spend JSON from co-signer" [(ngModel)]="importPartialJson"
-          [disabled]="isCompletingPartial()">
-            </textarea>
-        <kc-button [text]="isCompletingPartial() ? 'Completing...' : 'Sign & Broadcast'"
-          [isDisabled]="isCompletingPartial() || !importPartialJson" [isFullWidth]="true"
-          (buttonClick)="completePartialSpend()">
-        </kc-button>
-
-        @if (partialCompleteError()) {
-        <div class="error-message p-12 rounded-lg text-red typo-text-2">
-          {{ partialCompleteError() }}
-        </div>
+          <div
+            class="p-12 rounded-lg"
+            style="
+              background: rgba(111, 199, 186, 0.08);
+              border: 1px solid rgba(111, 199, 186, 0.2);
+            "
+          >
+            <span class="text-gray-75 typo-text-2">
+              A new Dead Man's Switch contract will be generated with the same
+              owner and heir but the updated expiry. Funds will move to the new
+              contract in the same transaction. The covenant lineage is
+              preserved.
+            </span>
+          </div>
         }
 
-        @if (partialCompleteResult()) {
+        <!-- Output address + amount (only for withdrawal functions, NOT DMS keepAlive) -->
+        @if (
+          selectedFunction &&
+          functionRequiresOutput(selectedFunction) &&
+          !isDmsKeepAlive()
+        ) {
+          <div class="form-group flex column gap-8">
+            <app-address-smart-input
+              [label]="'Send To'"
+              [placeholder]="'Enter recipient wallet address or KNS domain'"
+              [isFullWidth]="true"
+              [isValid]="true"
+              [invalidReason]="''"
+              [isDisabled]="isInteracting()"
+              [value]="interactOutputAddress"
+              (valueChange)="onInteractOutputAddressChange($event)"
+              (resolved)="onInteractOutputAddressResolved($event)"
+              (qrClick)="onInteractOutputQrClick()"
+            >
+            </app-address-smart-input>
+          </div>
+
+          <div class="form-group flex column gap-8">
+            <kc-input
+              [label]="'Withdraw Amount (KAS)'"
+              [placeholder]="'0'"
+              [type]="'number'"
+              [min]="0"
+              [isFullWidth]="true"
+              [isDisabled]="isInteracting()"
+              [ngModel]="interactOutputAmount"
+              (valueChange)="onInteractOutputAmountChange($event)"
+            >
+              <div
+                (click)="!isInteracting() && fillMaxOutputAmount()"
+                [class]="
+                  isInteracting() ? 'max-text disabled' : 'max-text clickable'
+                "
+                rightSideSlot
+              >
+                <span>Max</span>
+              </div>
+            </kc-input>
+          </div>
+        }
+
+        <!-- Info banner for redeploy functions (keepAlive on non-DMS contracts, increment) -->
+        @if (
+          selectedFunction &&
+          !functionRequiresOutput(selectedFunction) &&
+          !isDmsKeepAlive()
+        ) {
+          <div
+            class="p-12 rounded-lg"
+            style="
+              background: rgba(111, 199, 186, 0.08);
+              border: 1px solid rgba(111, 199, 186, 0.2);
+            "
+          >
+            <span class="text-gray-75 typo-text-2">
+              Funds will be re-locked into the same contract (minus ~0.00001 KAS
+              fee). No external withdrawal.
+            </span>
+          </div>
+        }
+
+        <!-- Extra args (int/bool params, e.g. escrow arbitrate amountToSeller) -->
+        @for (arg of extraArgsForFunction(); track arg.name) {
+          <div class="form-group flex column gap-8">
+            <kc-input
+              [label]="arg.name + ' (' + arg.type_name + ')'"
+              [placeholder]="'Enter ' + arg.name + ' value'"
+              [type]="'number'"
+              [isFullWidth]="true"
+              [isDisabled]="isInteracting()"
+              [ngModel]="extraArgValues[arg.name] || ''"
+              (valueChange)="extraArgValues[arg.name] = $event || ''"
+            >
+            </kc-input>
+          </div>
+        }
+
+        <!-- Multi-sig: partial spend output -->
+        @if (partialSpendJson()) {
+          <div
+            class="flex column gap-8 p-12 rounded-lg"
+            style="
+              background: rgba(255, 193, 7, 0.08);
+              border: 1px solid rgba(255, 193, 7, 0.2);
+            "
+          >
+            <span class="text-yellow typo-text-1 fw-bold"
+              >Partial Spend Created</span
+            >
+            <span class="text-gray-75 typo-text-2">
+              Your signature has been added. Copy the JSON below and send it to
+              the co-signer to complete the transaction.
+            </span>
+            <textarea
+              class="contract-input p-12 rounded-lg text-white typo-text-2"
+              rows="4"
+              readonly
+              [value]="partialSpendJson()!"
+            >
+            </textarea>
+            <kc-button
+              [text]="'Copy Partial Spend JSON'"
+              [isFullWidth]="true"
+              (buttonClick)="copyPartialSpend()"
+            >
+            </kc-button>
+          </div>
+        }
+      }
+
+      <!-- Two-Phase Signing: Complete a partial spend from co-signer -->
+      @if (parsedInteractContract()) {
+        <details class="advanced-section">
+          <summary
+            class="text-gray-60 typo-text-2 cursor-pointer"
+            kcTooltip="Complete a multi-sig transaction started by a co-signer"
+            tooltipPosition="top"
+          >
+            Complete Co-Signer Transaction
+          </summary>
+          <div class="flex column gap-12 mt-8">
+            <span class="text-gray-75 typo-text-2">
+              Paste the partial spend JSON received from the co-signer. Your
+              signature will be added and the transaction broadcast.
+            </span>
+            <textarea
+              class="contract-input p-12 rounded-lg text-white typo-text-2"
+              rows="4"
+              placeholder="Paste partial spend JSON from co-signer"
+              [(ngModel)]="importPartialJson"
+              [disabled]="isCompletingPartial()"
+            >
+            </textarea>
+            <kc-button
+              [text]="
+                isCompletingPartial() ? 'Completing...' : 'Sign & Broadcast'
+              "
+              [isDisabled]="isCompletingPartial() || !importPartialJson"
+              [isFullWidth]="true"
+              (buttonClick)="completePartialSpend()"
+            >
+            </kc-button>
+
+            @if (partialCompleteError()) {
+              <div class="error-message p-12 rounded-lg text-red typo-text-2">
+                {{ partialCompleteError() }}
+              </div>
+            }
+
+            @if (partialCompleteResult()) {
+              <div class="result-panel flex column gap-12 p-16 rounded-lg">
+                <h3 class="text-white typo-text-1 fw-bold">
+                  Transaction Sent!
+                </h3>
+                <div class="result-row flex column gap-4">
+                  <span class="text-gray-60 typo-text-1">Transaction</span>
+                  <div class="flex align-items-center gap-8">
+                    <a
+                      [href]="getExplorerLink(partialCompleteResult()!.txid)"
+                      target="_blank"
+                      class="text-blue typo-text-2 text-truncate"
+                    >
+                      {{ partialCompleteResult()!.txid }}
+                    </a>
+                    <app-copy-button
+                      [value]="partialCompleteResult()!.txid"
+                      [size]="'sm'"
+                    ></app-copy-button>
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        </details>
+      }
+
+      <!-- Error message -->
+      @if (interactError()) {
+        <div class="error-message p-12 rounded-lg text-red typo-text-2">
+          {{ interactError() }}
+        </div>
+      }
+
+      <!-- Success result -->
+      @if (interactResult()) {
         <div class="result-panel flex column gap-12 p-16 rounded-lg">
-          <h3 class="text-white typo-text-1 fw-bold">Transaction Sent!</h3>
+          <h3 class="text-white typo-text-1 fw-bold">✅ Transaction Sent!</h3>
+          <div class="result-row flex column gap-4">
+            <span class="text-gray-60 typo-text-1">Action</span>
+            <span class="text-white typo-text-2">{{
+              getFunctionLabel(interactResult()!.functionName)
+            }}</span>
+          </div>
           <div class="result-row flex column gap-4">
             <span class="text-gray-60 typo-text-1">Transaction</span>
             <div class="flex align-items-center gap-8">
-              <a [href]="getExplorerLink(partialCompleteResult()!.txid)" target="_blank"
-                class="text-blue typo-text-2 text-truncate">
-                {{ partialCompleteResult()!.txid }}
+              <a
+                [href]="getExplorerLink(interactResult()!.txid)"
+                target="_blank"
+                class="text-blue typo-text-2 text-truncate"
+              >
+                {{ interactResult()!.txid }}
               </a>
-              <app-copy-button [value]="partialCompleteResult()!.txid" [size]="'sm'"></app-copy-button>
+              <app-copy-button
+                [value]="interactResult()!.txid"
+                [size]="'sm'"
+              ></app-copy-button>
             </div>
           </div>
         </div>
-        }
-      </div>
-    </details>
-    }
+      }
 
-    <!-- Error message -->
-    @if (interactError()) {
-    <div class="error-message p-12 rounded-lg text-red typo-text-2">
-      {{ interactError() }}
-    </div>
-    }
-
-    <!-- Success result -->
-    @if (interactResult()) {
-    <div class="result-panel flex column gap-12 p-16 rounded-lg">
-      <h3 class="text-white typo-text-1 fw-bold">✅ Transaction Sent!</h3>
-      <div class="result-row flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Action</span>
-        <span class="text-white typo-text-2">{{ getFunctionLabel(interactResult()!.functionName) }}</span>
-      </div>
-      <div class="result-row flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Transaction</span>
-        <div class="flex align-items-center gap-8">
-          <a [href]="getExplorerLink(interactResult()!.txid)" target="_blank"
-            class="text-blue typo-text-2 text-truncate">
-            {{ interactResult()!.txid }}
-          </a>
-          <app-copy-button [value]="interactResult()!.txid" [size]="'sm'"></app-copy-button>
+      <!-- Sender Fee Toggle -->
+      @if (parsedInteractContract()) {
+        <div class="form-group flex align-items-center gap-8">
+          <label class="flex align-items-center gap-8 cursor-pointer m-0">
+            <input
+              type="checkbox"
+              class="cursor-pointer"
+              [(ngModel)]="useSenderFee"
+              [disabled]="
+                isInteracting() ||
+                (selectedFunction && isMultiSigFunction(selectedFunction))
+              "
+            />
+            <span class="text-white typo-text-2"
+              >Use wallet to pay for fees</span
+            >
+          </label>
+          <kc-icon
+            [iconClass]="'icon-info'"
+            [size]="'xs'"
+            [kcTooltip]="
+              selectedFunction && isMultiSigFunction(selectedFunction)
+                ? 'Disabled for multi-sig signing. The contract must pay fees because wallet fee inputs would change the transaction after signatures are created.'
+                : 'If enabled, transaction fees will be paid from your wallet balance instead of the contract funds.'
+            "
+            tooltipPosition="top"
+          ></kc-icon>
         </div>
-      </div>
-    </div>
-    }
+        @if (selectedFunction && isMultiSigFunction(selectedFunction)) {
+          <div
+            class="p-12 rounded-lg"
+            style="
+              background: rgba(255, 193, 7, 0.08);
+              border: 1px solid rgba(255, 193, 7, 0.2);
+            "
+          >
+            <span class="text-yellow typo-text-2">
+              Multi-sig transactions must pay fees from the contract funds.
+              Wallet-paid fees add inputs and would invalidate the partial
+              signatures.
+            </span>
+          </div>
+        }
+      }
 
-    <!-- Sender Fee Toggle -->
-    @if (parsedInteractContract()) {
-    <div class="form-group flex align-items-center gap-8">
-      <label class="flex align-items-center gap-8 cursor-pointer m-0">
-        <input type="checkbox" class="cursor-pointer" [(ngModel)]="useSenderFee"
-          [disabled]="isInteracting() || (selectedFunction && isMultiSigFunction(selectedFunction))" />
-        <span class="text-white typo-text-2">Use wallet to pay for fees</span>
-      </label>
-      <kc-icon [iconClass]="'icon-info'" [size]="'xs'"
-        [kcTooltip]="selectedFunction && isMultiSigFunction(selectedFunction)
-          ? 'Disabled for multi-sig signing. The contract must pay fees because wallet fee inputs would change the transaction after signatures are created.'
-          : 'If enabled, transaction fees will be paid from your wallet balance instead of the contract funds.'"
-        tooltipPosition="top"></kc-icon>
+      <!-- Execute button -->
+      @if (parsedInteractContract()) {
+        <kc-button
+          [text]="
+            isInteracting()
+              ? 'Processing...'
+              : selectedFunction
+                ? getFunctionLabel(selectedFunction)
+                : 'Select an action'
+          "
+          [isDisabled]="
+            isInteracting() ||
+            !interactContractJson() ||
+            !interactOutpointTxid ||
+            !selectedFunction
+          "
+          [isFullWidth]="true"
+          (buttonClick)="interactContract()"
+        >
+        </kc-button>
+      }
     </div>
-    @if (selectedFunction && isMultiSigFunction(selectedFunction)) {
-    <div class="p-12 rounded-lg"
-      style="background: rgba(255, 193, 7, 0.08); border: 1px solid rgba(255, 193, 7, 0.2);">
-      <span class="text-yellow typo-text-2">
-        Multi-sig transactions must pay fees from the contract funds. Wallet-paid fees add inputs and would invalidate
-        the partial signatures.
-      </span>
-    </div>
-    }
-    }
-
-    <!-- Execute button -->
-    @if (parsedInteractContract()) {
-    <kc-button
-      [text]="isInteracting() ? 'Processing...' : (selectedFunction ? getFunctionLabel(selectedFunction) : 'Select an action')"
-      [isDisabled]="isInteracting() || !interactContractJson() || !interactOutpointTxid || !selectedFunction"
-      [isFullWidth]="true" (buttonClick)="interactContract()">
-    </kc-button>
-    }
-  </div>
   }
 
   <!-- Tab 4: Templates -->
-  @if (activeTab() === 'templates') {
-  <div class="panel flex column gap-20 p-24 rounded-lg">
-    @if (!activeTemplate()) {
-    <div class="flex column gap-8">
-      <h3 class="text-white typo-text-1 fw-bold">Contract Templates</h3>
-      <p class="text-gray-60 typo-text-2">
-        Pick a pre-built covenant, fill in a human-friendly form, and generate deploy-ready compiled JSON.
-      </p>
-    </div>
-
-    <div class="template-list flex column gap-12">
-      @for (template of contractTemplates; track template.id) {
-      <div class="template-card-compact p-16 rounded-lg flex align-items-center gap-12"
-        (click)="selectTemplate(template)">
-        <div class="template-icon-compact">{{ template.icon }}</div>
-        <div class="flex column gap-4 flex-1">
-          <h4 class="text-white typo-text-1 fw-bold">{{ template.name }}</h4>
-          <p class="text-gray-60 typo-text-2 template-description">{{ template.description }}</p>
+  @if (activeTab() === "templates") {
+    <div class="panel flex column gap-20 p-24 rounded-lg">
+      @if (!activeTemplate()) {
+        <div class="flex column gap-8">
+          <h3 class="text-white typo-text-1 fw-bold">Contract Templates</h3>
+          <p class="text-gray-60 typo-text-2">
+            Pick a pre-built covenant, fill in a human-friendly form, and
+            generate deploy-ready compiled JSON.
+          </p>
         </div>
-        <svg class="template-chevron" width="20" height="20" viewBox="0 0 20 20" fill="none"
-          xmlns="http://www.w3.org/2000/svg">
-          <path d="M7.5 15L12.5 10L7.5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" />
-        </svg>
-      </div>
-      }
-    </div>
-    } @else {
-    <div class="flex justify-content-between align-items-center gap-12 flex-wrap">
-      <div class="flex align-items-center gap-12">
-        <button class="back-button p-8 rounded typo-text-2"
-          (click)="activeTemplate.set(null); generatedContractJson.set(null); templateError.set(null)">
-          ← Back
-        </button>
-        <div class="flex column gap-4">
-          <h3 class="text-white typo-title-3">{{ activeTemplate()!.icon }} {{ activeTemplate()!.name }}</h3>
-          <p class="text-gray-60 typo-text-2">{{ activeTemplate()!.description }}</p>
-        </div>
-      </div>
-    </div>
 
-    <div class="flex column gap-16">
-      @for (field of activeTemplate()!.fields; track field.paramName) {
-      <div class="form-group flex column gap-8">
-        <label class="text-gray-60 typo-text-1" [title]="field.description">{{ field.label }}</label>
-
-        @if (field.type === 'address') {
-        <input type="text" class="form-input p-12 rounded-lg text-white typo-text-2" [name]="field.paramName"
-          [placeholder]="field.placeholder" [title]="field.description"
-          [(ngModel)]="templateFormValues[field.paramName]" />
-        }
-
-        @if (field.type === 'hash32') {
-        <div class="flex column gap-4">
-          <input type="text" class="form-input p-12 rounded-lg text-white typo-text-2" [name]="field.paramName"
-            placeholder="Paste Kaspa address or pubkey hex — auto-hashes, or paste hash directly"
-            [title]="field.description" [(ngModel)]="templateFormValues[field.paramName]"
-            (ngModelChange)="onHash32Input(field.paramName, $event)" />
-          @if (templateFormValues[field.paramName + '_isAutoHashed']) {
-          <span class="text-green typo-text-2">✓ blake2b-256 hash computed automatically</span>
+        <div class="template-list flex column gap-12">
+          @for (template of contractTemplates; track template.id) {
+            <div
+              class="template-card-compact p-16 rounded-lg flex align-items-center gap-12"
+              (click)="selectTemplate(template)"
+            >
+              <div class="template-icon-compact">{{ template.icon }}</div>
+              <div class="flex column gap-4 flex-1">
+                <h4 class="text-white typo-text-1 fw-bold">
+                  {{ template.name }}
+                </h4>
+                <p class="text-gray-60 typo-text-2 template-description">
+                  {{ template.description }}
+                </p>
+              </div>
+              <svg
+                class="template-chevron"
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.5 15L12.5 10L7.5 5"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
           }
-          @if (!templateFormValues[field.paramName + '_isAutoHashed'] && (templateFormValues[field.paramName] || '').length ===
-          64) {
-          <div class="flex gap-8 align-items-center">
-            <span class="text-gray-60 typo-text-2">Is this a pubkey?</span>
-            <span class="text-blue typo-text-2 cursor-pointer" (click)="computeBlake2bHash(field.paramName)">
-              Click to compute blake2b hash →
-            </span>
+        </div>
+      } @else {
+        <div
+          class="flex justify-content-between align-items-center gap-12 flex-wrap"
+        >
+          <div class="flex align-items-center gap-12">
+            <button
+              class="back-button p-8 rounded typo-text-2"
+              (click)="
+                activeTemplate.set(null);
+                generatedContractJson.set(null);
+                templateError.set(null)
+              "
+            >
+              ← Back
+            </button>
+            <div class="flex column gap-4">
+              <h3 class="text-white typo-title-3">
+                {{ activeTemplate()!.icon }} {{ activeTemplate()!.name }}
+              </h3>
+              <p class="text-gray-60 typo-text-2">
+                {{ activeTemplate()!.description }}
+              </p>
+            </div>
           </div>
+        </div>
+
+        <div class="flex column gap-16">
+          @for (field of activeTemplate()!.fields; track field.paramName) {
+            <div class="form-group flex column gap-8">
+              <label
+                class="text-gray-60 typo-text-1"
+                [title]="field.description"
+                >{{ field.label }}</label
+              >
+
+              @if (field.type === "address") {
+                <input
+                  type="text"
+                  class="form-input p-12 rounded-lg text-white typo-text-2"
+                  [name]="field.paramName"
+                  [placeholder]="field.placeholder"
+                  [title]="field.description"
+                  [(ngModel)]="templateFormValues[field.paramName]"
+                />
+              }
+
+              @if (field.type === "hash32") {
+                <div class="flex column gap-4">
+                  <input
+                    type="text"
+                    class="form-input p-12 rounded-lg text-white typo-text-2"
+                    [name]="field.paramName"
+                    placeholder="Paste Kaspa address or pubkey hex — auto-hashes, or paste hash directly"
+                    [title]="field.description"
+                    [(ngModel)]="templateFormValues[field.paramName]"
+                    (ngModelChange)="onHash32Input(field.paramName, $event)"
+                  />
+                  @if (templateFormValues[field.paramName + "_isAutoHashed"]) {
+                    <span class="text-green typo-text-2"
+                      >✓ blake2b-256 hash computed automatically</span
+                    >
+                  }
+                  @if (
+                    !templateFormValues[field.paramName + "_isAutoHashed"] &&
+                    (templateFormValues[field.paramName] || "").length === 64
+                  ) {
+                    <div class="flex gap-8 align-items-center">
+                      <span class="text-gray-60 typo-text-2"
+                        >Is this a pubkey?</span
+                      >
+                      <span
+                        class="text-blue typo-text-2 cursor-pointer"
+                        (click)="computeBlake2bHash(field.paramName)"
+                      >
+                        Click to compute blake2b hash →
+                      </span>
+                    </div>
+                  }
+                </div>
+              }
+
+              @if (field.type === "int_days" || field.type === "int_count") {
+                <input
+                  type="number"
+                  class="form-input p-12 rounded-lg text-white typo-text-2"
+                  [name]="field.paramName"
+                  [placeholder]="field.placeholder"
+                  [title]="field.description"
+                  min="0"
+                  step="1"
+                  [(ngModel)]="templateFormValues[field.paramName]"
+                />
+              }
+
+              @if (field.type === "int_timestamp") {
+                <input
+                  type="number"
+                  class="form-input p-12 rounded-lg text-white typo-text-2"
+                  [name]="field.paramName"
+                  [placeholder]="field.placeholder"
+                  [title]="field.description"
+                  min="0"
+                  step="1"
+                  [(ngModel)]="templateFormValues[field.paramName]"
+                />
+              }
+
+              <span class="text-gray-60 typo-text-2">{{
+                field.description
+              }}</span>
+              @if (field.helpUrl) {
+                <a
+                  [href]="field.helpUrl"
+                  target="_blank"
+                  class="text-blue typo-text-2"
+                  style="font-size: 12px"
+                >
+                  🔗 Convert date to timestamp →
+                </a>
+              }
+            </div>
           }
         </div>
+
+        @if (templateError()) {
+          <div class="error-message p-12 rounded-lg text-red typo-text-2">
+            {{ templateError() }}
+          </div>
         }
 
-        @if (field.type === 'int_days' || field.type === 'int_count') {
-        <input type="number" class="form-input p-12 rounded-lg text-white typo-text-2" [name]="field.paramName"
-          [placeholder]="field.placeholder" [title]="field.description" min="0" step="1"
-          [(ngModel)]="templateFormValues[field.paramName]" />
-        }
+        <kc-button
+          [text]="'Generate Contract'"
+          [isFullWidth]="true"
+          (buttonClick)="generateContract()"
+        >
+        </kc-button>
 
-        @if (field.type === 'int_timestamp') {
-        <input type="number" class="form-input p-12 rounded-lg text-white typo-text-2" [name]="field.paramName"
-          [placeholder]="field.placeholder" [title]="field.description" min="0" step="1"
-          [(ngModel)]="templateFormValues[field.paramName]" />
+        @if (generatedContractJson()) {
+          <div class="result-panel flex column gap-12 p-16 rounded-lg">
+            <h3 class="text-white typo-text-1 fw-bold">
+              ✅ Contract JSON Ready
+            </h3>
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Template</span>
+              <span class="text-white typo-text-2">{{
+                activeTemplate()!.name
+              }}</span>
+            </div>
+            <div class="flex column gap-4">
+              <span class="text-gray-60 typo-text-1">Details</span>
+              <span class="text-white typo-text-2"
+                >Compiled JSON has been patched and is ready for the existing
+                deploy flow.</span
+              >
+            </div>
+            <div class="form-group flex column gap-8">
+              <label class="text-gray-60 typo-text-1"
+                >Generated JSON Preview</label
+              >
+              <textarea
+                class="contract-input p-12 rounded-lg text-white typo-text-2"
+                rows="8"
+                [ngModel]="generatedContractJson()"
+                readonly
+              >
+              </textarea>
+            </div>
+            <kc-button
+              [text]="'Deploy This Contract'"
+              [isFullWidth]="true"
+              (buttonClick)="useGeneratedContract()"
+            >
+            </kc-button>
+          </div>
         }
-
-        <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
-        @if (field.helpUrl) {
-        <a [href]="field.helpUrl" target="_blank" class="text-blue typo-text-2" style="font-size: 12px;">
-          🔗 Convert date to timestamp →
-        </a>
-        }
-      </div>
       }
     </div>
-
-    @if (templateError()) {
-    <div class="error-message p-12 rounded-lg text-red typo-text-2">
-      {{ templateError() }}
-    </div>
-    }
-
-    <kc-button [text]="'Generate Contract'" [isFullWidth]="true" (buttonClick)="generateContract()">
-    </kc-button>
-
-    @if (generatedContractJson()) {
-    <div class="result-panel flex column gap-12 p-16 rounded-lg">
-      <h3 class="text-white typo-text-1 fw-bold">✅ Contract JSON Ready</h3>
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Template</span>
-        <span class="text-white typo-text-2">{{ activeTemplate()!.name }}</span>
-      </div>
-      <div class="flex column gap-4">
-        <span class="text-gray-60 typo-text-1">Details</span>
-        <span class="text-white typo-text-2">Compiled JSON has been patched and is ready for the existing deploy
-          flow.</span>
-      </div>
-      <div class="form-group flex column gap-8">
-        <label class="text-gray-60 typo-text-1">Generated JSON Preview</label>
-        <textarea class="contract-input p-12 rounded-lg text-white typo-text-2" rows="8"
-          [ngModel]="generatedContractJson()" readonly>
-              </textarea>
-      </div>
-      <kc-button [text]="'Deploy This Contract'" [isFullWidth]="true" (buttonClick)="useGeneratedContract()">
-      </kc-button>
-    </div>
-    }
-    }
-  </div>
   }
 </div>

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
@@ -156,6 +156,90 @@ select.form-input {
   color: var(--gray-60);
 }
 
+.contract-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 40px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-secondary);
+  box-sizing: border-box;
+}
+
+.filter-button,
+.refresh-button {
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  color: var(--gray-60);
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1;
+  transition: all 0.2s;
+}
+
+.filter-button {
+  background: transparent;
+
+  &.active {
+    background: rgba(111, 199, 186, 0.15);
+    border-color: rgba(111, 199, 186, 0.3);
+    color: #fff;
+  }
+}
+
+.refresh-button {
+  background: var(--gray-10);
+  border-color: var(--border-secondary);
+  color: #fff;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: var(--kaspa-20);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+}
+
+.contract-detail-tabs {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 4px;
+  min-height: 40px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-secondary);
+  box-sizing: border-box;
+}
+
+.detail-tab-button {
+  min-height: 32px;
+  min-width: 88px;
+  padding: 0 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--gray-60);
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1;
+  transition: all 0.2s;
+
+  &.active {
+    background: rgba(111, 199, 186, 0.15);
+    border-color: rgba(111, 199, 186, 0.3);
+    color: #fff;
+  }
+}
+
+.detail-route-header {
+  min-width: 0;
+}
+
 .participant-grid,
 .detail-grid {
   display: grid;
@@ -393,6 +477,14 @@ select.form-input {
     background: rgba(255, 255, 255, 0.08);
     border-color: var(--kaspa-20);
   }
+}
+
+.detail-close-button {
+  min-width: 72px;
+}
+
+.template-change-button {
+  min-width: 84px;
 }
 
 // Lookup result

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
@@ -72,13 +72,13 @@
   background: var(--gray-10);
   border: 1px solid var(--border-secondary);
   outline: none;
-  font-family: 'Courier New', monospace;
+  font-family: "Courier New", monospace;
   transition: border-color 0.2s;
-  
+
   &:focus {
     border-color: var(--kaspa-20);
   }
-  
+
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -289,7 +289,7 @@ select.form-input {
 
 // Utilities
 .text-mono {
-  font-family: 'Courier New', monospace;
+  font-family: "Courier New", monospace;
   font-size: 13px;
 }
 
@@ -445,7 +445,9 @@ select.form-input {
 .template-chevron {
   color: var(--gray-60);
   min-width: max-content;
-  transition: color 0.2s, transform 0.2s;
+  transition:
+    color 0.2s,
+    transform 0.2s;
 }
 
 .template-card-compact:hover .template-chevron {
@@ -510,12 +512,12 @@ select.form-input {
   summary {
     user-select: none;
     padding: 8px 0;
-    
+
     &:hover {
       color: var(--kaspa-20);
     }
   }
-  
+
   .mt-8 {
     margin-top: 8px;
   }
@@ -563,7 +565,7 @@ select.form-input {
   .contracts-container {
     padding: 0 24px;
   }
-  
+
   .contracts-list {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
@@ -117,6 +117,12 @@ select.form-input {
     border: 1px solid var(--border-secondary);
     color: var(--gray-60);
   }
+
+  &.unknown {
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.35);
+    color: var(--yellow-20);
+  }
 }
 
 // Messages
@@ -142,6 +148,34 @@ select.form-input {
 .param-item {
   background: rgba(0, 0, 0, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.source-badge {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-secondary);
+  color: var(--gray-60);
+}
+
+.participant-grid,
+.detail-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.participant-item,
+.detail-item,
+.timeline-row {
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  min-width: 0;
+}
+
+.participant-item,
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 // Access roles

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -12,7 +12,14 @@ import { UtilsHelper } from '../../../../../services/utils.service';
 import { CovenantService } from '../../../../../services/covenant/covenant.service';
 import { RpcService } from '../../../../../services/kaspa-netwrok-services/rpc.service';
 import { ContractRegistryService, ContractRegistryEntry, ContractStatus } from '../../../../../services/covenant/contract-registry.service';
-import { CovenantIndexerService, IndexerCovenantAction, IndexerCovenantArg, IndexerCovenantDetails } from '../../../../../services/covenant/covenant-indexer.service';
+import {
+  CovenantIndexerService,
+  IndexerCovenantAction,
+  IndexerCovenantArg,
+  IndexerCovenantDetails,
+  IndexerCovenantResponse,
+  IndexerCovenantUtxo,
+} from '../../../../../services/covenant/covenant-indexer.service';
 import { CompiledContract, CovenantOutpoint, PartiallySignedSpend, SpendOutput } from '../../../../../services/covenant/covenant-sdk/types';
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { CONTRACT_TEMPLATES, ContractTemplate, TemplateField } from '../../../../services/covenant/contract-templates';
@@ -57,6 +64,36 @@ type IndexerImportPreview = {
   amountSompi: string;
   deployedAt: number;
   isLatestContinuation: boolean;
+};
+
+type ContractDashboardSource = 'indexer' | 'local';
+
+type ContractDashboardEntry = {
+  id: string;
+  source: ContractDashboardSource;
+  contractName: string;
+  displayName: string;
+  status: 'active' | 'spent' | 'unknown' | 'tracking-incomplete';
+  amountSompi: string;
+  currentAddress?: string;
+  covenantId?: string;
+  scriptHash?: string;
+  deployTxid?: string;
+  latestTxid?: string;
+  latestAction?: string;
+  deadlineMs?: number;
+  participants: Array<{ label: string; value: string }>;
+  nextActionLabel: string;
+  actionHint: string;
+  registryEntry?: ContractRegistryEntry;
+  indexerSummary?: IndexerCovenantDetails;
+};
+
+type ContractDetailState = {
+  entry: ContractDashboardEntry;
+  response?: IndexerCovenantResponse;
+  actions: IndexerCovenantAction[];
+  utxos: IndexerCovenantUtxo[];
 };
 
 @Component({
@@ -154,6 +191,13 @@ export class ContractsPageComponent implements OnInit {
 
   // Contract registry (my contracts tab)
   registryContracts = signal<ContractRegistryEntry[]>([]);
+  dashboardContracts = signal<ContractDashboardEntry[]>([]);
+  dashboardLoading = signal(false);
+  dashboardError = signal<string | null>(null);
+  selectedDetail = signal<ContractDetailState | null>(null);
+  selectedDetailLoading = signal(false);
+  selectedDetailError = signal<string | null>(null);
+  private readonly supportedIndexerTemplates = ['DeadManSwitch', 'TimeLockVault', 'MultiSigVault', 'EscrowWithArbiter'];
 
   contractTemplates = CONTRACT_TEMPLATES;
   createMode = signal<CreateMode>('template');
@@ -714,6 +758,11 @@ export class ContractsPageComponent implements OnInit {
    * Load contracts from registry and check on-chain status
    */
   async loadContracts() {
+    this.dashboardLoading.set(true);
+    this.dashboardError.set(null);
+    this.selectedDetail.set(null);
+    this.selectedDetailError.set(null);
+
     const allContracts = this.registryService.getAllContracts();
     const currentNetwork = this.network();
     const filtered = allContracts.filter((c) => c.network === currentNetwork);
@@ -721,6 +770,23 @@ export class ContractsPageComponent implements OnInit {
 
     // Check on-chain status for each contract
     await this.refreshContractStatuses(filtered);
+
+    const updatedLocal = this.registryService.getAllContracts().filter((c) => c.network === this.network());
+    this.registryContracts.set(updatedLocal);
+
+    try {
+      // Indexer-backed tracking is the source of truth for contracts involving
+      // the wallet. Local registry entries are merged below so older local-only
+      // deployments still remain visible while the indexer catches up.
+      const indexerEntries = await this.loadIndexerDashboardEntries();
+      this.dashboardContracts.set(this.mergeDashboardEntries(indexerEntries, updatedLocal.map((entry) => this.localEntryToDashboard(entry))));
+    } catch (error: any) {
+      console.warn('[Contracts] Indexer dashboard load failed:', error);
+      this.dashboardError.set(error?.message || 'Indexer tracking is unavailable. Showing locally saved contracts only.');
+      this.dashboardContracts.set(updatedLocal.map((entry) => this.localEntryToDashboard(entry)));
+    } finally {
+      this.dashboardLoading.set(false);
+    }
   }
 
   /**
@@ -765,6 +831,333 @@ export class ContractsPageComponent implements OnInit {
     // Reload with updated statuses
     const updated = this.registryService.getAllContracts().filter((c) => c.network === this.network());
     this.registryContracts.set(updated);
+  }
+
+  private async loadIndexerDashboardEntries(): Promise<ContractDashboardEntry[]> {
+    const wallet = this.currentWallet();
+    const identifiers = [
+      wallet?.getAddress(),
+      wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString(),
+    ].filter((value): value is string => !!value);
+
+    if (identifiers.length === 0) return [];
+
+    const byKey = new Map<string, ContractDashboardEntry>();
+    for (const identifier of identifiers) {
+      // `/covenants?wallet=` matches the wallet against covenant address,
+      // common participant args, and decoded constructor args. This is broader
+      // than `/addresses/{address}/covenants`, which only matches P2SH covenant
+      // addresses and would miss participant-owned contracts.
+      const rows = await this.covenantIndexerService.listCovenants({
+        wallet: identifier,
+        classification: 'covenant',
+        sort: 'recent',
+        limit: 100,
+      });
+
+      const supportedRows = rows.filter((row) => this.supportedIndexerTemplates.includes(this.getIndexerTemplateName(row)));
+      const entries = await Promise.all(supportedRows.map((row) => this.indexerSummaryToDashboard(row)));
+      for (const entry of entries) {
+        byKey.set(entry.covenantId || entry.scriptHash || entry.id, entry);
+      }
+    }
+
+    return Array.from(byKey.values()).sort((a, b) => (this.getEntryTime(b) - this.getEntryTime(a)));
+  }
+
+  private mergeDashboardEntries(indexerEntries: ContractDashboardEntry[], localEntries: ContractDashboardEntry[]): ContractDashboardEntry[] {
+    const merged = new Map<string, ContractDashboardEntry>();
+    for (const entry of localEntries) {
+      merged.set(entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id, entry);
+    }
+    for (const entry of indexerEntries) {
+      const key = entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id;
+      const local = Array.from(merged.values()).find((candidate) =>
+        (!!entry.covenantId && candidate.covenantId === entry.covenantId) ||
+        (!!entry.scriptHash && candidate.scriptHash === entry.scriptHash) ||
+        (!!entry.currentAddress && candidate.currentAddress === entry.currentAddress),
+      );
+
+      merged.set(local?.id || key, {
+        ...entry,
+        registryEntry: local?.registryEntry,
+      });
+    }
+
+    return Array.from(merged.values()).sort((a, b) => this.getEntryTime(b) - this.getEntryTime(a));
+  }
+
+  private localEntryToDashboard(contract: ContractRegistryEntry): ContractDashboardEntry {
+    const contractName = this.normalizeContractName(contract.contractName);
+    const participants = this.localParticipants(contract);
+    return {
+      id: `local:${contract.id}`,
+      source: 'local',
+      contractName,
+      displayName: this.getTemplateDisplayName(contractName),
+      status: contract.status || 'unknown',
+      amountSompi: contract.amountSompi,
+      currentAddress: contract.contractAddress,
+      covenantId: contract.covenantId,
+      deployTxid: contract.deployTxid,
+      latestTxid: contract.spendTxid || contract.outpoint?.txid || contract.deployTxid,
+      latestAction: contract.spendTxid ? 'spend' : 'deploy',
+      participants,
+      nextActionLabel: this.getNextActionLabel(contractName, contract.status || 'unknown', participants),
+      actionHint: 'Open wallet action flow',
+      registryEntry: contract,
+    };
+  }
+
+  private async indexerSummaryToDashboard(summary: IndexerCovenantDetails): Promise<ContractDashboardEntry> {
+    const contractName = this.getIndexerTemplateName(summary);
+    const participants = this.indexerParticipants(summary);
+    const status = (summary.activeUtxos ?? 0) > 0 ? 'active' : 'spent';
+    const latestAction = await this.getLatestActionForSummary(summary);
+    return {
+      id: `indexer:${summary.covenantIdHex || summary.scriptHashHex}`,
+      source: 'indexer',
+      contractName,
+      displayName: this.getTemplateDisplayName(contractName),
+      status,
+      amountSompi: String(summary.totalAmountSompi ?? '0'),
+      currentAddress: summary.address,
+      covenantId: summary.covenantIdHex,
+      scriptHash: summary.scriptHashHex,
+      deployTxid: summary.genesisTxidHex,
+      latestTxid: latestAction?.txidHex || summary.genesisTxidHex,
+      latestAction: latestAction?.entrypoint || latestAction?.action || 'deploy',
+      deadlineMs: this.extractDeadlineMs(summary),
+      participants,
+      nextActionLabel: this.getNextActionLabel(contractName, status, participants),
+      actionHint: summary.claimVerified === false ? 'Template claim is not verified on-chain yet' : 'Open current covenant state',
+      indexerSummary: summary,
+    };
+  }
+
+  private async getLatestActionForSummary(summary: IndexerCovenantDetails): Promise<IndexerCovenantAction | undefined> {
+    const identifier = summary.covenantIdHex || summary.scriptHashHex;
+    if (!identifier) return undefined;
+
+    try {
+      const actions = await this.covenantIndexerService.getCovenantActions(identifier);
+      return this.latestAction(actions);
+    } catch {
+      // Card rendering should survive indexer action lookup failures; detail
+      // view will surface the precise error if the user opens this contract.
+      return undefined;
+    }
+  }
+
+  private latestAction(actions: IndexerCovenantAction[]): IndexerCovenantAction | undefined {
+    return [...actions].sort((a, b) => (b.blockTimeMs || 0) - (a.blockTimeMs || 0))[0];
+  }
+
+  private getIndexerTemplateName(summary: IndexerCovenantDetails): string {
+    return this.normalizeContractName(
+      summary.template ||
+      summary.claimedTemplate ||
+      summary.claimedArgs?.tmpl ||
+      'Covenant',
+    );
+  }
+
+  private normalizeContractName(name: string): string {
+    const normalized = String(name || '').replace(/\s+/g, '');
+    const aliases: Record<string, string> = {
+      DeadMansSwitch: 'DeadManSwitch',
+      "DeadMan'sSwitch": 'DeadManSwitch',
+      TimeLockVault: 'TimeLockVault',
+      MultiSigVault: 'MultiSigVault',
+      Escrow: 'EscrowWithArbiter',
+    };
+    return aliases[normalized] || normalized;
+  }
+
+  private getTemplateDisplayName(name: string): string {
+    const labels: Record<string, string> = {
+      DeadManSwitch: "Dead Man's Switch",
+      TimeLockVault: 'Time Lock',
+      MultiSigVault: 'MultiSig',
+      EscrowWithArbiter: 'Escrow',
+    };
+    return labels[this.normalizeContractName(name)] || name || 'Covenant';
+  }
+
+  private localParticipants(contract: ContractRegistryEntry): Array<{ label: string; value: string }> {
+    const participants = [{ label: 'Owner', value: contract.deployedBy.address || contract.deployedBy.pubkey }];
+    const predecessor = contract.predecessorId ? this.registryService.getContract(contract.predecessorId) : undefined;
+    if (predecessor?.deployedBy?.address && predecessor.deployedBy.address !== contract.deployedBy.address) {
+      participants.push({ label: 'Original owner', value: predecessor.deployedBy.address });
+    }
+    return participants;
+  }
+
+  private indexerParticipants(summary: IndexerCovenantDetails): Array<{ label: string; value: string }> {
+    const source = {
+      ...(summary.constructor || {}),
+      ...this.argsArrayToRecord(summary.claimedArgs?.args || []),
+    };
+    const roles = ['owner', 'heir', 'signer', 'recovery', 'key1', 'key2', 'key3', 'buyer', 'seller', 'arbiter', 'arbiterHash'];
+    return roles
+      .filter((role) => source[role] !== undefined && source[role] !== null && source[role] !== '')
+      .map((role) => ({ label: this.roleLabel(role), value: String(source[role]) }));
+  }
+
+  private argsArrayToRecord(args: IndexerCovenantArg[]): Record<string, string> {
+    return args.reduce<Record<string, string>>((record, arg) => {
+      record[arg.name] = String(arg.value);
+      return record;
+    }, {});
+  }
+
+  private roleLabel(role: string): string {
+    const labels: Record<string, string> = {
+      owner: 'Owner',
+      heir: 'Heir',
+      signer: 'Owner',
+      recovery: 'Recovery',
+      key1: 'Signer 1',
+      key2: 'Signer 2',
+      key3: 'Signer 3',
+      buyer: 'Buyer',
+      seller: 'Seller',
+      arbiter: 'Arbiter',
+      arbiterHash: 'Arbiter',
+    };
+    return labels[role] || role;
+  }
+
+  private getNextActionLabel(contractName: string, status: ContractDashboardEntry['status'], participants: Array<{ label: string; value: string }>): string {
+    if (status !== 'active') return 'View history';
+    const normalized = this.normalizeContractName(contractName);
+    const currentRole = this.currentWalletRole(participants);
+    if (normalized === 'DeadManSwitch') return currentRole === 'Owner' ? 'Keep Alive' : 'Claim';
+    if (normalized === 'TimeLockVault') return currentRole === 'Recovery' ? 'Recover' : 'Withdraw';
+    if (normalized === 'MultiSigVault') return currentRole.startsWith('Signer') ? 'Sign / Complete' : 'View details';
+    if (normalized === 'EscrowWithArbiter') {
+      if (currentRole === 'Arbiter') return 'Arbitrate';
+      if (currentRole === 'Buyer') return 'Release / Refund';
+      if (currentRole === 'Seller') return 'Release';
+    }
+    return 'View details';
+  }
+
+  private currentWalletRole(participants: Array<{ label: string; value: string }>): string {
+    const wallet = this.currentWallet();
+    const candidates = [
+      wallet?.getAddress(),
+      wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString(),
+    ].filter((value): value is string => !!value).map((value) => value.toLowerCase());
+
+    return participants.find((participant) => candidates.includes(String(participant.value).toLowerCase()))?.label || '';
+  }
+
+  private extractDeadlineMs(summary: IndexerCovenantDetails): number | undefined {
+    const source = {
+      ...(summary.constructor || {}),
+      ...this.argsArrayToRecord(summary.claimedArgs?.args || []),
+    };
+    const raw = source['checkInDeadline'] ?? source['expiry'] ?? source['timeout'] ?? source['timeoutBlueScore'] ?? source['unlockBlueScore'];
+    if (raw === undefined || raw === null || raw === '') return undefined;
+    const numeric = Number(raw);
+    if (!Number.isFinite(numeric) || numeric <= 0) return undefined;
+    if (numeric > 946684800000) return numeric;
+    if (numeric > 946684800) return numeric * 1000;
+    return undefined;
+  }
+
+  private getEntryTime(entry: ContractDashboardEntry): number {
+    return entry.indexerSummary?.createdAtMs || entry.registryEntry?.deployedAt || 0;
+  }
+
+  async openContractDetail(entry: ContractDashboardEntry) {
+    this.selectedDetailLoading.set(true);
+    this.selectedDetailError.set(null);
+    this.selectedDetail.set({ entry, actions: [], utxos: [] });
+
+    const identifier = entry.covenantId || entry.scriptHash;
+    if (!identifier) {
+      this.selectedDetailLoading.set(false);
+      this.selectedDetailError.set('This local contract has no indexer id yet. Use the action flow or import by tx once indexed.');
+      return;
+    }
+
+    try {
+      const [response, actions, utxos] = await Promise.all([
+        this.covenantIndexerService.getCovenant(identifier),
+        this.covenantIndexerService.getCovenantActions(identifier),
+        this.covenantIndexerService.getCovenantUtxos(identifier),
+      ]);
+      const latestAction = this.latestAction(actions);
+      const lockedSompi = utxos.reduce((total, utxo) => total + BigInt(String(utxo.amountSompi ?? 0)), 0n);
+      const updatedEntry: ContractDashboardEntry = {
+        ...entry,
+        latestTxid: latestAction?.txidHex || entry.latestTxid,
+        latestAction: latestAction?.entrypoint || latestAction?.action || entry.latestAction,
+        status: utxos.length > 0 ? 'active' : 'spent',
+        amountSompi: lockedSompi.toString(),
+      };
+      this.selectedDetail.set({ entry: updatedEntry, response, actions, utxos });
+    } catch (error: any) {
+      this.selectedDetailError.set(error?.message || 'Failed to load indexer detail for this contract.');
+    } finally {
+      this.selectedDetailLoading.set(false);
+    }
+  }
+
+  async openDashboardAction(entry: ContractDashboardEntry) {
+    if (entry.registryEntry) {
+      this.selectedContractId.set(entry.registryEntry.id);
+      this.selectContractFromRegistry();
+      this.switchTab('interact');
+      this.selectDefaultFunctionForContract(entry.contractName);
+      return;
+    }
+
+    const identifier = entry.covenantId || entry.scriptHash;
+    if (!identifier) {
+      this.selectedDetailError.set('This contract cannot be opened for actions until it has an indexer covenant id or script hash.');
+      return;
+    }
+
+    try {
+      this.selectedDetailLoading.set(true);
+      const response = await this.fetchIndexerCovenant(identifier);
+      const preview = await this.buildIndexerImportPreview(response);
+      this.indexerImportPreview.set(preview);
+      this.importIndexerPreview();
+      const imported = this.registryService.getAllContracts().find((contract) =>
+        contract.network === this.network() &&
+        (
+          contract.covenantId === preview.covenantId ||
+          (contract.outpoint.txid === preview.outpoint.txid && contract.outpoint.vout === preview.outpoint.vout)
+        ),
+      );
+      if (imported) {
+        this.selectedContractId.set(imported.id);
+        this.selectContractFromRegistry();
+        this.switchTab('interact');
+        this.selectDefaultFunctionForContract(entry.contractName);
+      }
+    } catch (error: any) {
+      this.selectedDetailError.set(error?.message || 'Import this contract before using wallet actions.');
+    } finally {
+      this.selectedDetailLoading.set(false);
+    }
+  }
+
+  private selectDefaultFunctionForContract(contractName: string) {
+    const normalized = this.normalizeContractName(contractName);
+    const preferred: Record<string, string[]> = {
+      DeadManSwitch: ['keepAlive', 'claim'],
+      TimeLockVault: ['spend', 'recover', 'withdraw'],
+      MultiSigVault: ['spend12', 'spend', 'release'],
+      EscrowWithArbiter: ['release', 'refund', 'arbitrate'],
+    };
+    const available = this.availableFunctions();
+    const target = (preferred[normalized] || []).find((name) => available.some((fn) => fn.name === name)) || available[0]?.name;
+    if (target) this.selectFunction(target);
   }
 
   async lookupIndexerImport() {
@@ -1835,8 +2228,65 @@ export class ContractsPageComponent implements OnInit {
    * Format sompi to KAS
    */
   formatSompiToKas(sompi: string): string {
-    const kas = Number(BigInt(sompi)) / 1e8;
-    return kas.toFixed(8).replace(/\.?0+$/, '');
+    try {
+      const kas = Number(BigInt(String(sompi || '0'))) / 1e8;
+      return kas.toFixed(8).replace(/\.?0+$/, '');
+    } catch {
+      return '0';
+    }
+  }
+
+  getSourceLabel(contract: ContractDashboardEntry): string {
+    return contract.source === 'indexer' ? 'Indexer' : 'Local';
+  }
+
+  getStatusLabel(contract: ContractDashboardEntry): string {
+    const labels: Record<ContractDashboardEntry['status'], string> = {
+      active: 'Active',
+      spent: 'Spent',
+      unknown: 'Unknown',
+      'tracking-incomplete': 'Tracking incomplete',
+    };
+    return labels[contract.status] || 'Unknown';
+  }
+
+  formatTimestamp(value: number | undefined | null): string {
+    if (!value) return 'Unknown';
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return 'Unknown';
+    return date.toLocaleString();
+  }
+
+  formatActionName(action: string): string {
+    const labels: Record<string, string> = {
+      deploy: 'Deploy',
+      spend: 'Spend',
+      continuation: 'Continuation',
+      keepAlive: 'Keep Alive',
+      claim: 'Claim',
+      spend12: 'MultiSig Spend',
+      release: 'Release',
+      refund: 'Refund',
+      arbitrate: 'Arbitrate',
+      recover: 'Recover',
+      withdraw: 'Withdraw',
+    };
+    return labels[action] || action;
+  }
+
+  copyContractShareLink(contract: ContractDashboardEntry) {
+    const id = contract.covenantId || contract.scriptHash;
+    if (!id) return;
+
+    // Share links intentionally carry only public lookup state. The receiving
+    // wallet still imports/loads current state from the indexer.
+    const url = new URL(window.location.origin + '/app/contracts');
+    url.searchParams.set('network', this.network());
+    url.searchParams.set('contract', id);
+    navigator.clipboard.writeText(url.toString()).then(
+      () => alert('Contract share link copied.'),
+      () => prompt('Copy this contract link:', url.toString()),
+    );
   }
 
   private fieldToCtorArg(field: TemplateField, rawValue: string | number | undefined): CtorArg {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1248,11 +1248,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // addresses and would miss participant-owned contracts.
       const rows = await this.covenantIndexerService.listCovenants({
         wallet: identifier,
-        classification: 'covenant',
         sort: 'recent',
         limit: 100,
       });
 
+      // Do not add `classification=covenant` here. Fresh wallet-created
+      // template contracts can be indexed as `unknown/unrevealed` while still
+      // carrying a trusted claimedTemplate/claimedArgs payload, so filtering by
+      // classification hides the exact contracts My Contracts needs to show.
       const supportedRows = rows.filter((row) =>
         this.supportedIndexerTemplates.includes(
           this.getIndexerTemplateName(row),

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1343,7 +1343,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   ): ContractDashboardEntry {
     const contractName = this.getIndexerTemplateName(summary);
     const participants = this.indexerParticipants(summary);
-    const status = (summary.activeUtxos ?? 0) > 0 ? 'active' : 'spent';
+    const status = this.statusFromActiveUtxoCount(summary.activeUtxos);
     return {
       id: `indexer:${summary.covenantIdHex || summary.scriptHashHex}`,
       source: 'indexer',
@@ -1599,7 +1599,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           latestAction?.entrypoint ||
           latestAction?.action ||
           entry.latestAction,
-        status: utxos.length > 0 ? 'active' : 'spent',
+        status: this.statusFromActiveUtxoCount(utxos.length),
         amountSompi: lockedSompi.toString(),
       };
       this.selectedDetail.set({
@@ -1610,7 +1610,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       });
       if (
         (this.detailRouteId() || this.activeTab() === 'detail') &&
-        updatedEntry.status !== 'spent'
+        updatedEntry.status === 'active'
       ) {
         await this.prepareDashboardAction(updatedEntry);
       }
@@ -1641,6 +1641,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     this.dashboardError.set(null);
+
+    if (entry.status === 'tracking-incomplete') {
+      this.dashboardError.set(
+        'Actions are disabled because the indexer reports multiple active UTXOs for this covenant. Open details and choose a specific UTXO once the wallet supports UTXO selection.',
+      );
+      this.detailPanelTab.set('details');
+      return false;
+    }
 
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
@@ -1903,8 +1911,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.latestAction(response.actions) ||
       preview.activeAction ||
       response.action;
-    const status =
-      (response.covenant?.activeUtxos ?? 1) > 0 ? 'active' : 'spent';
+    const status = this.statusFromActiveUtxoCount(
+      response.covenant?.activeUtxos,
+    );
     const participants = response.covenant
       ? this.indexerParticipants(response.covenant)
       : preview.args.map((arg) => ({
@@ -1943,6 +1952,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         : 'Open current covenant state',
       indexerSummary: response.covenant,
     };
+  }
+
+  private statusFromActiveUtxoCount(
+    activeUtxos: number | undefined,
+  ): ContractDashboardEntry['status'] {
+    if (activeUtxos === 0) return 'spent';
+    if (activeUtxos === 1) return 'active';
+
+    // The current wallet action flow spends one selected outpoint. If the
+    // indexer reports multiple active UTXOs, showing the contract is fine but
+    // auto-selecting one for a spend would be unsafe until a UTXO picker exists.
+    return 'tracking-incomplete';
   }
 
   private async fetchIndexerCovenant(identifier: string): Promise<{

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -169,6 +169,8 @@ type DeployIndexerState = {
   },
 })
 export class ContractsPageComponent implements OnInit, OnDestroy {
+  readonly MIN_DEPLOY_AMOUNT_KAS = 0.5;
+
   private walletService = inject(WalletService);
   private walletActionService = inject(WalletActionService);
   private qrScannerService = inject(QrScannerService);
@@ -200,7 +202,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (!currentWallet) return 0;
     const mature =
       currentWallet.getCurrentWalletStateBalanceSignalValue()?.mature || 0n;
-    return Math.floor(Number(mature) / 1e8);
+    return Number(mature) / 1e8;
   });
 
   // Computed pubkey for selected account
@@ -961,13 +963,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     const amount = Number(raw);
-    if (!Number.isFinite(amount) || amount <= 0) {
-      this.deployAmountError.set('Amount must be greater than 0');
+    if (!Number.isFinite(amount)) {
+      this.deployAmountError.set('Enter a valid amount');
       return false;
     }
 
-    if (!Number.isInteger(amount)) {
-      this.deployAmountError.set('Use whole KAS increments only');
+    if (amount < this.MIN_DEPLOY_AMOUNT_KAS) {
+      this.deployAmountError.set(
+        `Minimum amount is ${this.MIN_DEPLOY_AMOUNT_KAS} KAS`,
+      );
       return false;
     }
 
@@ -1097,8 +1101,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (!raw) return false;
     const amount = Number(raw);
     return (
-      Number.isInteger(amount) &&
-      amount > 0 &&
+      Number.isFinite(amount) &&
+      amount >= this.MIN_DEPLOY_AMOUNT_KAS &&
       amount <= this.deployAvailableBalance()
     );
   }

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1,10 +1,25 @@
-import { Component, computed, inject, signal, OnInit, OnDestroy, effect } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  OnInit,
+  OnDestroy,
+  effect,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, Subscription } from 'rxjs';
-import { DropdownOption, KcButtonComponent, KcDropdownSelectComponent, KcIconComponent, KcInputComponent, KcTooltipDirective } from 'kaspacom-ui';
+import {
+  DropdownOption,
+  KcButtonComponent,
+  KcDropdownSelectComponent,
+  KcIconComponent,
+  KcInputComponent,
+  KcTooltipDirective,
+} from 'kaspacom-ui';
 import { blake2b } from '@noble/hashes/blake2b';
 import { WalletService } from '../../../../../services/wallet.service';
 import { WalletActionService } from '../../../../../services/wallet-action.service';
@@ -12,7 +27,11 @@ import { QrScannerService } from '../../../../../services/qr-scanner.service';
 import { UtilsHelper } from '../../../../../services/utils.service';
 import { CovenantService } from '../../../../../services/covenant/covenant.service';
 import { RpcService } from '../../../../../services/kaspa-netwrok-services/rpc.service';
-import { ContractRegistryService, ContractRegistryEntry, ContractStatus } from '../../../../../services/covenant/contract-registry.service';
+import {
+  ContractRegistryService,
+  ContractRegistryEntry,
+  ContractStatus,
+} from '../../../../../services/covenant/contract-registry.service';
 import {
   CovenantIndexerService,
   IndexerCovenantAction,
@@ -21,20 +40,42 @@ import {
   IndexerCovenantResponse,
   IndexerCovenantUtxo,
 } from '../../../../../services/covenant/covenant-indexer.service';
-import { CompiledContract, CovenantOutpoint, PartiallySignedSpend, SpendOutput } from '../../../../../services/covenant/covenant-sdk/types';
+import {
+  CompiledContract,
+  CovenantOutpoint,
+  PartiallySignedSpend,
+  SpendOutput,
+} from '../../../../../services/covenant/covenant-sdk/types';
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
-import { CONTRACT_TEMPLATES, ContractTemplate, TemplateField } from '../../../../services/covenant/contract-templates';
-import { CtorArg, TemplatePatcherService } from '../../../../services/covenant/template-patcher.service';
+import {
+  CONTRACT_TEMPLATES,
+  ContractTemplate,
+  TemplateField,
+} from '../../../../services/covenant/contract-templates';
+import {
+  CtorArg,
+  TemplatePatcherService,
+} from '../../../../services/covenant/template-patcher.service';
 import { PublicKey } from '../../../../../../../public/kaspa/kaspa';
 import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
 import { WalletActionType } from '../../../../../types/wallet-action';
-import { CovenantCompletePartialActionResult, CovenantDeployActionResult, CovenantSpendActionResult } from '../../../../../types/wallet-action-result';
+import {
+  CovenantCompletePartialActionResult,
+  CovenantDeployActionResult,
+  CovenantSpendActionResult,
+} from '../../../../../types/wallet-action-result';
 import { FlowPagesService } from '../../../../services/flow-pages.service';
 import { ApprovalFlowService } from '../../../../services/approval-flow.service';
 import { AddressSmartInputComponent } from '../../../../shared/ui/input/address-smart-input/address-smart-input.component';
 import { CovenantDateTimeInputComponent } from './covenant-date-time-input.component';
 
-type TabName = 'deploy' | 'my-contracts' | 'lookup-import' | 'interact' | 'templates' | 'detail';
+type TabName =
+  | 'deploy'
+  | 'my-contracts'
+  | 'lookup-import'
+  | 'interact'
+  | 'templates'
+  | 'detail';
 type ContractDetailTab = 'details' | 'action';
 type CreateMode = 'template' | 'custom';
 type ContractsTransientState = {
@@ -157,7 +198,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   deployAvailableBalance = computed(() => {
     const currentWallet = this.currentWallet();
     if (!currentWallet) return 0;
-    const mature = currentWallet.getCurrentWalletStateBalanceSignalValue()?.mature || 0n;
+    const mature =
+      currentWallet.getCurrentWalletStateBalanceSignalValue()?.mature || 0n;
     return Math.floor(Number(mature) / 1e8);
   });
 
@@ -175,7 +217,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   deployAmount = '';
   deployAmountTouched = false;
   deployAmountError = signal('');
-  deployResult = signal<{ address: string; txid: string; covenantId?: string } | null>(null);
+  deployResult = signal<{
+    address: string;
+    txid: string;
+    covenantId?: string;
+  } | null>(null);
   deployIndexerState = signal<DeployIndexerState | null>(null);
   deployError = signal<string | null>(null);
   isDeploying = signal(false);
@@ -184,7 +230,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   parsedDeployContract = computed(() => {
     try {
       if (!this.deployContractJson()) return null;
-      return this.covenantService.parseCompiledContract(this.deployContractJson());
+      return this.covenantService.parseCompiledContract(
+        this.deployContractJson(),
+      );
     } catch {
       return null;
     }
@@ -207,10 +255,16 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   registryContracts = signal<ContractRegistryEntry[]>([]);
   dashboardContracts = signal<ContractDashboardEntry[]>([]);
   dashboardFilter = signal<ContractDashboardFilter>('active');
-  activeDashboardContracts = computed(() => this.dashboardContracts().filter((contract) => contract.status !== 'spent'));
-  historyDashboardContracts = computed(() => this.dashboardContracts().filter((contract) => contract.status === 'spent'));
+  activeDashboardContracts = computed(() =>
+    this.dashboardContracts().filter((contract) => contract.status !== 'spent'),
+  );
+  historyDashboardContracts = computed(() =>
+    this.dashboardContracts().filter((contract) => contract.status === 'spent'),
+  );
   filteredDashboardContracts = computed(() =>
-    this.dashboardFilter() === 'history' ? this.historyDashboardContracts() : this.activeDashboardContracts(),
+    this.dashboardFilter() === 'history'
+      ? this.historyDashboardContracts()
+      : this.activeDashboardContracts(),
   );
   dashboardLoading = signal(false);
   dashboardError = signal<string | null>(null);
@@ -220,7 +274,12 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   detailPanelTab = signal<ContractDetailTab>('details');
   detailRouteId = signal<string | null>(null);
   detailRouteNotFound = signal(false);
-  private readonly supportedIndexerTemplates = ['DeadManSwitch', 'TimeLockVault', 'MultiSigVault', 'EscrowWithArbiter'];
+  private readonly supportedIndexerTemplates = [
+    'DeadManSwitch',
+    'TimeLockVault',
+    'MultiSigVault',
+    'EscrowWithArbiter',
+  ];
 
   contractTemplates = CONTRACT_TEMPLATES;
   createMode = signal<CreateMode>('template');
@@ -253,7 +312,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   indexerImportPreview = signal<IndexerImportPreview | null>(null);
 
   // DMS keepAlive specific state
-  dmsNewExpiry = '';  // new expiry timestamp (unix seconds) entered by user
+  dmsNewExpiry = ''; // new expiry timestamp (unix seconds) entered by user
   dmsKeepAliveError = signal<string | null>(null);
   interactResult = signal<{ txid: string; functionName: string } | null>(null);
   interactError = signal<string | null>(null);
@@ -266,13 +325,17 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   partialSpendJson = signal<string | null>(null);
   importPartialJson = '';
   isCompletingPartial = signal(false);
-  partialCompleteResult = signal<{ txid: string; functionName: string } | null>(null);
+  partialCompleteResult = signal<{ txid: string; functionName: string } | null>(
+    null,
+  );
   partialCompleteError = signal<string | null>(null);
 
   // Computed selected contract from registry
   selectedContract = computed(() => {
     if (!this.selectedContractId()) return null;
-    return this.registryContracts().find((c) => c.id === this.selectedContractId());
+    return this.registryContracts().find(
+      (c) => c.id === this.selectedContractId(),
+    );
   });
 
   registryContractOptions = computed<DropdownOption[]>(() =>
@@ -286,7 +349,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   // Computed parsed contract from interact JSON
   parsedInteractContract = computed(() => {
     try {
-      const json = this.interactContractJson() || this.selectedContract()?.compiledJson;
+      const json =
+        this.interactContractJson() || this.selectedContract()?.compiledJson;
       if (!json) return null;
       return this.covenantService.parseCompiledContract(json);
     } catch {
@@ -299,12 +363,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const contract = this.parsedInteractContract();
     if (!contract) return [];
     const funcs = contract.abi.filter((entry) =>
-      contract.ast.functions.find((f) => f.name === entry.name && f.entrypoint)
+      contract.ast.functions.find((f) => f.name === entry.name && f.entrypoint),
     );
 
     // Inject 'transfer' action for KCC20 contracts (handled outside the standard ABI flow)
-    if (contract.contract_name === 'KCC20' && !funcs.some((f) => f.name === 'transfer')) {
-      funcs.push({ name: 'transfer', inputs: [{ name: 'recipient', type_name: 'pubkey' }] } as any);
+    if (
+      contract.contract_name === 'KCC20' &&
+      !funcs.some((f) => f.name === 'transfer')
+    ) {
+      funcs.push({
+        name: 'transfer',
+        inputs: [{ name: 'recipient', type_name: 'pubkey' }],
+      } as any);
     }
 
     return funcs;
@@ -321,14 +391,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   extraArgsForFunction(): Array<{ name: string; type_name: string }> {
     const contract = this.parsedInteractContract();
     if (!contract || !this.selectedFunction) return [];
-    const abiEntry = contract.abi.find(e => e.name === this.selectedFunction);
+    const abiEntry = contract.abi.find((e) => e.name === this.selectedFunction);
     if (!abiEntry) return [];
     // For Escrow arbitrate, amountToSeller is collected via the standard
     // "Withdraw Amount (KAS)" field, so we don't render a separate input for it.
-    if (this.selectedFunction === 'arbitrate' && contract.contract_name === 'Escrow') return [];
+    if (
+      this.selectedFunction === 'arbitrate' &&
+      contract.contract_name === 'Escrow'
+    )
+      return [];
     // Only render extra-arg inputs the interact flow can actually collect/pass
     // (collectExtraArgs + completePartialSpend handle int/bool only).
-    return abiEntry.inputs.filter(i => i.type_name === 'int' || i.type_name === 'bool');
+    return abiEntry.inputs.filter(
+      (i) => i.type_name === 'int' || i.type_name === 'bool',
+    );
   }
 
   // Current network
@@ -366,10 +442,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.detailRouteId.set(contractId);
       this.detailRouteNotFound.set(false);
       if (contractId) {
-        const requestedNetwork = this.route.snapshot.queryParamMap.get('network')?.trim();
+        const requestedNetwork = this.route.snapshot.queryParamMap
+          .get('network')
+          ?.trim();
         if (requestedNetwork && requestedNetwork !== this.network()) {
           if (!this.rpcService.setNetwork(requestedNetwork)) {
-            this.selectedDetailError.set(`This contract link targets unsupported network "${requestedNetwork}".`);
+            this.selectedDetailError.set(
+              `This contract link targets unsupported network "${requestedNetwork}".`,
+            );
             return;
           }
           this.activeTab.set('my-contracts');
@@ -389,19 +469,31 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   private restoreTransientState() {
-    const state = this.flowPagesService.getTransientState<ContractsTransientState>('contracts');
+    const state =
+      this.flowPagesService.getTransientState<ContractsTransientState>(
+        'contracts',
+      );
     if (!state) return;
 
     if (state.activeTab) this.activeTab.set(state.activeTab);
-    if (state.selectedFunction !== undefined) this.selectedFunction = state.selectedFunction;
-    if (state.interactContractJson !== undefined) this.interactContractJson.set(state.interactContractJson);
-    if (state.interactOutpointTxid !== undefined) this.interactOutpointTxid = state.interactOutpointTxid;
-    if (state.interactOutpointVout !== undefined) this.interactOutpointVout = state.interactOutpointVout;
-    if (state.interactInputAmount !== undefined) this.interactInputAmount = state.interactInputAmount;
-    if (state.interactOutputAddress !== undefined) this.interactOutputAddress = state.interactOutputAddress;
-    if (state.interactOutputAmount !== undefined) this.interactOutputAmount = state.interactOutputAmount;
-    if (state.partialSpendJson !== undefined) this.partialSpendJson.set(state.partialSpendJson);
-    if (state.interactResult !== undefined) this.interactResult.set(state.interactResult);
+    if (state.selectedFunction !== undefined)
+      this.selectedFunction = state.selectedFunction;
+    if (state.interactContractJson !== undefined)
+      this.interactContractJson.set(state.interactContractJson);
+    if (state.interactOutpointTxid !== undefined)
+      this.interactOutpointTxid = state.interactOutpointTxid;
+    if (state.interactOutpointVout !== undefined)
+      this.interactOutpointVout = state.interactOutpointVout;
+    if (state.interactInputAmount !== undefined)
+      this.interactInputAmount = state.interactInputAmount;
+    if (state.interactOutputAddress !== undefined)
+      this.interactOutputAddress = state.interactOutputAddress;
+    if (state.interactOutputAmount !== undefined)
+      this.interactOutputAmount = state.interactOutputAmount;
+    if (state.partialSpendJson !== undefined)
+      this.partialSpendJson.set(state.partialSpendJson);
+    if (state.interactResult !== undefined)
+      this.interactResult.set(state.interactResult);
 
     this.flowPagesService.saveTransientState('contracts', undefined);
   }
@@ -412,9 +504,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (!contractId) return;
 
     const requestedNetwork = params.get('network')?.trim();
-    if (requestedNetwork && requestedNetwork !== this.network() && !this.rpcService.setNetwork(requestedNetwork)) {
+    if (
+      requestedNetwork &&
+      requestedNetwork !== this.network() &&
+      !this.rpcService.setNetwork(requestedNetwork)
+    ) {
       this.activeTab.set('lookup-import');
-      this.indexerImportError.set(`This contract link targets unsupported network "${requestedNetwork}".`);
+      this.indexerImportError.set(
+        `This contract link targets unsupported network "${requestedNetwork}".`,
+      );
       return;
     }
 
@@ -434,12 +532,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private findDashboardEntryForPreview(preview: IndexerImportPreview): ContractDashboardEntry | undefined {
-    return this.dashboardContracts().find((entry) =>
-      entry.covenantId === preview.covenantId ||
-      entry.scriptHash === preview.action.scriptHashHex ||
-      entry.deployTxid === preview.deployTxid ||
-      entry.currentAddress === preview.contractAddress,
+  private findDashboardEntryForPreview(
+    preview: IndexerImportPreview,
+  ): ContractDashboardEntry | undefined {
+    return this.dashboardContracts().find(
+      (entry) =>
+        entry.covenantId === preview.covenantId ||
+        entry.scriptHash === preview.action.scriptHashHex ||
+        entry.deployTxid === preview.deployTxid ||
+        entry.currentAddress === preview.contractAddress,
     );
   }
 
@@ -461,24 +562,36 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // `/covenants?q=` is the broad import fallback for covenant addresses and
     // fuzzy user input. `/explorer/search` can return template/category hits
     // that are not importable by themselves.
-    const rows = await this.covenantIndexerService.listCovenants({ q: query, sort: 'recent', limit: 10 });
-    const row = rows.find((item) => this.supportedIndexerTemplates.includes(this.getIndexerTemplateName(item)));
-    const identifier = row?.covenantIdHex || row?.scriptHashHex || row?.genesisTxidHex;
+    const rows = await this.covenantIndexerService.listCovenants({
+      q: query,
+      sort: 'recent',
+      limit: 10,
+    });
+    const row = rows.find((item) =>
+      this.supportedIndexerTemplates.includes(
+        this.getIndexerTemplateName(item),
+      ),
+    );
+    const identifier =
+      row?.covenantIdHex || row?.scriptHashHex || row?.genesisTxidHex;
     if (identifier) {
       return await this.fetchIndexerCovenant(identifier);
     }
 
     const searchResults = await this.covenantIndexerService.search(query, 10);
-    const concrete = searchResults.find((result) =>
-      (result.kind === 'covenant' || result.kind === 'transaction') &&
-      !!result.id &&
-      /^[0-9a-fA-F]{64}$/.test(result.id),
+    const concrete = searchResults.find(
+      (result) =>
+        (result.kind === 'covenant' || result.kind === 'transaction') &&
+        !!result.id &&
+        /^[0-9a-fA-F]{64}$/.test(result.id),
     );
     if (concrete?.id) {
       return await this.fetchIndexerCovenant(concrete.id);
     }
 
-    throw new Error('No importable wallet-supported covenant found for that query.');
+    throw new Error(
+      'No importable wallet-supported covenant found for that query.',
+    );
   }
 
   /**
@@ -514,7 +627,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   private syncWalletOwnedTemplateFields() {
     const template = this.activeTemplate();
-    const address = this.selectedAccount()?.getAddress() || this.currentWallet()?.getAddress();
+    const address =
+      this.selectedAccount()?.getAddress() ||
+      this.currentWallet()?.getAddress();
     if (!template || !address) return;
 
     for (const field of template.fields) {
@@ -559,7 +674,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     if (!this.validateAllTemplateFields(true)) {
-      this.templateError.set('Please complete the highlighted fields before deploying.');
+      this.templateError.set(
+        'Please complete the highlighted fields before deploying.',
+      );
       return;
     }
 
@@ -567,10 +684,21 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.generatedContractJson.set(null);
 
     try {
-      const newArgs = template.fields.map((field) => this.fieldToCtorArg(field, this.getTemplateFieldValue(field)));
-      const compiled = await firstValueFrom(this.http.get<any>(template.assetPath));
-      const descriptor = this.templatePatcher.extractPatchDescriptor(compiled, template.placeholderArgs);
-      const patched = this.templatePatcher.applyPatch(compiled, descriptor, newArgs);
+      const newArgs = template.fields.map((field) =>
+        this.fieldToCtorArg(field, this.getTemplateFieldValue(field)),
+      );
+      const compiled = await firstValueFrom(
+        this.http.get<any>(template.assetPath),
+      );
+      const descriptor = this.templatePatcher.extractPatchDescriptor(
+        compiled,
+        template.placeholderArgs,
+      );
+      const patched = this.templatePatcher.applyPatch(
+        compiled,
+        descriptor,
+        newArgs,
+      );
 
       let argsPayload: any[] = [];
       let tmplName = compiled.contract_name;
@@ -578,31 +706,98 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       if (template.id === 'multi-sig-vault') {
         tmplName = 'MultiSigVault';
         argsPayload = [
-          { name: 'signer1', type: 'address', value: this.getTemplateValueByName('key1') },
-          { name: 'signer2', type: 'address', value: this.getTemplateValueByName('key2') },
-          { name: 'signer3', type: 'address', value: this.getTemplateValueByName('key3') },
+          {
+            name: 'signer1',
+            type: 'address',
+            value: this.getTemplateValueByName('key1'),
+          },
+          {
+            name: 'signer2',
+            type: 'address',
+            value: this.getTemplateValueByName('key2'),
+          },
+          {
+            name: 'signer3',
+            type: 'address',
+            value: this.getTemplateValueByName('key3'),
+          },
         ];
       } else if (template.id === 'escrow-with-arbiter') {
         tmplName = 'EscrowWithArbiter';
         argsPayload = [
-          { name: 'buyer', type: 'address', value: this.getTemplateValueByName('buyer') },
-          { name: 'seller', type: 'address', value: this.getTemplateValueByName('seller') },
-          { name: 'arbiter', type: 'address', value: this.templateFormValues['arbiterHash'] },
-          { name: 'timeoutBlueScore', type: 'blueScore', value: String(this.parseDateToUnixMs(String(this.templateFormValues['expiry'] ?? '').trim(), 'Refund Expiry Timestamp')) },
+          {
+            name: 'buyer',
+            type: 'address',
+            value: this.getTemplateValueByName('buyer'),
+          },
+          {
+            name: 'seller',
+            type: 'address',
+            value: this.getTemplateValueByName('seller'),
+          },
+          {
+            name: 'arbiter',
+            type: 'address',
+            value: this.templateFormValues['arbiterHash'],
+          },
+          {
+            name: 'timeoutBlueScore',
+            type: 'blueScore',
+            value: String(
+              this.parseDateToUnixMs(
+                String(this.templateFormValues['expiry'] ?? '').trim(),
+                'Refund Expiry Timestamp',
+              ),
+            ),
+          },
         ];
       } else if (template.id === 'dead-mans-switch') {
         tmplName = 'DeadManSwitch';
         argsPayload = [
-          { name: 'owner', type: 'address', value: this.getTemplateValueByName('owner') },
-          { name: 'heir', type: 'address', value: this.getTemplateValueByName('heir') },
-          { name: 'checkInDeadline', type: 'blueScore', value: String(this.parseDateToUnixMs(String(this.templateFormValues['expiry'] ?? '').trim(), 'Initial Expiry (Unix timestamp)')) },
+          {
+            name: 'owner',
+            type: 'address',
+            value: this.getTemplateValueByName('owner'),
+          },
+          {
+            name: 'heir',
+            type: 'address',
+            value: this.getTemplateValueByName('heir'),
+          },
+          {
+            name: 'checkInDeadline',
+            type: 'blueScore',
+            value: String(
+              this.parseDateToUnixMs(
+                String(this.templateFormValues['expiry'] ?? '').trim(),
+                'Initial Expiry (Unix timestamp)',
+              ),
+            ),
+          },
         ];
       } else if (template.id === 'time-lock-vault') {
         tmplName = 'TimeLockVault';
         argsPayload = [
-          { name: 'signer', type: 'address', value: this.getTemplateValueByName('owner') },
-          { name: 'recoveryKey', type: 'address', value: this.getTemplateValueByName('recovery') },
-          { name: 'unlockBlueScore', type: 'blueScore', value: String(this.parseDateToUnixMs(String(this.templateFormValues['timeout'] ?? '').trim(), 'Unlock Timestamp')) },
+          {
+            name: 'signer',
+            type: 'address',
+            value: this.getTemplateValueByName('owner'),
+          },
+          {
+            name: 'recoveryKey',
+            type: 'address',
+            value: this.getTemplateValueByName('recovery'),
+          },
+          {
+            name: 'unlockBlueScore',
+            type: 'blueScore',
+            value: String(
+              this.parseDateToUnixMs(
+                String(this.templateFormValues['timeout'] ?? '').trim(),
+                'Unlock Timestamp',
+              ),
+            ),
+          },
         ];
       }
 
@@ -610,13 +805,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         patched.tn10 = {
           v: 1,
           tmpl: tmplName,
-          args: argsPayload
+          args: argsPayload,
         };
       }
 
       this.generatedContractJson.set(JSON.stringify(patched, null, 2));
     } catch (error: any) {
-      this.templateError.set(error?.message || 'Failed to generate contract from template');
+      this.templateError.set(
+        error?.message || 'Failed to generate contract from template',
+      );
     }
   }
 
@@ -626,8 +823,13 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.deployIndexerState.set(null);
     this.templateError.set(null);
 
-    if (!this.validateAllTemplateFields(true) || !this.validateDeployAmount(true)) {
-      this.templateError.set('Please complete the highlighted fields before deploying.');
+    if (
+      !this.validateAllTemplateFields(true) ||
+      !this.validateDeployAmount(true)
+    ) {
+      this.templateError.set(
+        'Please complete the highlighted fields before deploying.',
+      );
       return;
     }
 
@@ -638,7 +840,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.deployContractJson.set(generated);
       await this.deployContract();
     } catch (error: any) {
-      this.templateError.set(error?.message || 'Failed to prepare contract for deployment');
+      this.templateError.set(
+        error?.message || 'Failed to prepare contract for deployment',
+      );
     }
   }
 
@@ -654,7 +858,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   isWalletOwnedField(field: TemplateField): boolean {
-    return field.type === 'address' && ['owner', 'buyer', 'key1'].includes(field.paramName);
+    return (
+      field.type === 'address' &&
+      ['owner', 'buyer', 'key1'].includes(field.paramName)
+    );
   }
 
   getFieldHelp(field: TemplateField): string {
@@ -663,14 +870,19 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     const help: Record<string, string> = {
-      recovery: 'A backup wallet that can recover the funds after the unlock date.',
+      recovery:
+        'A backup wallet that can recover the funds after the unlock date.',
       key2: 'A second signer. Any two configured signers can authorize a withdrawal.',
       key3: 'A third signer. Any two configured signers can authorize a withdrawal.',
-      seller: 'The seller receives funds when the buyer and seller both approve release.',
+      seller:
+        'The seller receives funds when the buyer and seller both approve release.',
       heir: 'The beneficiary who can claim the funds if the owner misses the deadline.',
-      arbiterHash: 'Paste the arbiter address or public key. The wallet stores the required blake2b-256 hash in the covenant.',
-      timeout: 'The earliest date when the recovery wallet can use the backup withdrawal path.',
-      expiry: 'The deadline used by this covenant. The wallet converts this date to the timestamp format required by Kaspa.',
+      arbiterHash:
+        'Paste the arbiter address or public key. The wallet stores the required blake2b-256 hash in the covenant.',
+      timeout:
+        'The earliest date when the recovery wallet can use the backup withdrawal path.',
+      expiry:
+        'The deadline used by this covenant. The wallet converts this date to the timestamp format required by Kaspa.',
     };
 
     return help[field.paramName] || field.description;
@@ -681,15 +893,24 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   private getTemplateFieldValue(field: TemplateField): string {
-    return this.templateResolvedAddresses[field.paramName] || this.templateFormValues[field.paramName] || '';
+    return (
+      this.templateResolvedAddresses[field.paramName] ||
+      this.templateFormValues[field.paramName] ||
+      ''
+    );
   }
 
   private getTemplateValueByName(paramName: string): string {
-    return this.templateResolvedAddresses[paramName] || this.templateFormValues[paramName] || '';
+    return (
+      this.templateResolvedAddresses[paramName] ||
+      this.templateFormValues[paramName] ||
+      ''
+    );
   }
 
   onDeployAmountChange(value: any) {
-    this.deployAmount = value === null || value === undefined ? '' : String(value);
+    this.deployAmount =
+      value === null || value === undefined ? '' : String(value);
     this.deployAmountTouched = true;
     this.validateDeployAmount(false);
   }
@@ -705,7 +926,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     const value = this.deployContractJson().trim();
     if (!value) {
-      this.deployContractError.set(this.deployContractTouched ? 'Compiled contract JSON is required' : '');
+      this.deployContractError.set(
+        this.deployContractTouched ? 'Compiled contract JSON is required' : '',
+      );
       return false;
     }
 
@@ -731,7 +954,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     const raw = String(this.deployAmount ?? '').trim();
     if (!raw) {
-      this.deployAmountError.set(this.deployAmountTouched ? 'Amount is required' : '');
+      this.deployAmountError.set(
+        this.deployAmountTouched ? 'Amount is required' : '',
+      );
       return false;
     }
 
@@ -784,8 +1009,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.qrScannerService.startScanning({
       scannerId: `qr-scanner-covenant-${field.paramName}`,
       title: `Scan ${field.label}`,
-      onSuccess: (address: string) => this.onTemplateFieldChange(field, address),
-      onError: (error: string) => console.error('[Contracts] QR scanning error:', error),
+      onSuccess: (address: string) =>
+        this.onTemplateFieldChange(field, address),
+      onError: (error: string) =>
+        console.error('[Contracts] QR scanning error:', error),
     });
   }
 
@@ -837,7 +1064,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   getTemplateFieldError(field: TemplateField): string {
-    return this.templateFieldTouched[field.paramName] ? (this.templateFieldErrors[field.paramName] || '') : '';
+    return this.templateFieldTouched[field.paramName]
+      ? this.templateFieldErrors[field.paramName] || ''
+      : '';
   }
 
   isTemplateFieldValid(field: TemplateField): boolean {
@@ -856,7 +1085,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (!template) return true;
 
     return template.fields.some((field) => {
-      const value = String(this.templateFormValues[field.paramName] ?? '').trim();
+      const value = String(
+        this.templateFormValues[field.paramName] ?? '',
+      ).trim();
       return !value || !!this.templateFieldErrors[field.paramName];
     });
   }
@@ -865,7 +1096,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const raw = String(this.deployAmount ?? '').trim();
     if (!raw) return false;
     const amount = Number(raw);
-    return Number.isInteger(amount) && amount > 0 && amount <= this.deployAvailableBalance();
+    return (
+      Number.isInteger(amount) &&
+      amount > 0 &&
+      amount <= this.deployAvailableBalance()
+    );
   }
 
   private isDeployContractJsonCompleteValid(): boolean {
@@ -902,11 +1137,21 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // the wallet. Local registry entries are merged below so older local-only
       // deployments still remain visible while the indexer catches up.
       const indexerEntries = await this.loadIndexerDashboardEntries();
-      this.dashboardContracts.set(this.mergeDashboardEntries(indexerEntries, updatedLocal.map((entry) => this.localEntryToDashboard(entry))));
+      this.dashboardContracts.set(
+        this.mergeDashboardEntries(
+          indexerEntries,
+          updatedLocal.map((entry) => this.localEntryToDashboard(entry)),
+        ),
+      );
     } catch (error: any) {
       console.warn('[Contracts] Indexer dashboard load failed:', error);
-      this.dashboardError.set(error?.message || 'Indexer tracking is unavailable. Showing locally saved contracts only.');
-      this.dashboardContracts.set(updatedLocal.map((entry) => this.localEntryToDashboard(entry)));
+      this.dashboardError.set(
+        error?.message ||
+          'Indexer tracking is unavailable. Showing locally saved contracts only.',
+      );
+      this.dashboardContracts.set(
+        updatedLocal.map((entry) => this.localEntryToDashboard(entry)),
+      );
     } finally {
       this.dashboardLoading.set(false);
     }
@@ -939,7 +1184,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
         for (const entry of entries) {
           const found = utxos.find(
-            (u: any) => u.outpoint?.transactionId === entry.outpoint.txid && Number(u.outpoint?.index ?? -1) === entry.outpoint.vout
+            (u: any) =>
+              u.outpoint?.transactionId === entry.outpoint.txid &&
+              Number(u.outpoint?.index ?? -1) === entry.outpoint.vout,
           );
 
           const newStatus: ContractStatus = found ? 'active' : 'spent';
@@ -964,17 +1211,27 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   private getCurrentWalletLocalContracts(): ContractRegistryEntry[] {
     const wallet = this.currentWallet();
     const address = wallet?.getAddress()?.toLowerCase();
-    const pubkey = wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString()?.toLowerCase();
+    const pubkey = wallet
+      ?.getPrivateKey()
+      .toPublicKey()
+      .toXOnlyPublicKey()
+      .toString()
+      ?.toLowerCase();
 
     return this.registryService.getAllContracts().filter((contract) => {
       if (contract.network !== this.network()) return false;
       const deployedAddress = contract.deployedBy?.address?.toLowerCase();
       const deployedPubkey = contract.deployedBy?.pubkey?.toLowerCase();
-      return (!!address && deployedAddress === address) || (!!pubkey && deployedPubkey === pubkey);
+      return (
+        (!!address && deployedAddress === address) ||
+        (!!pubkey && deployedPubkey === pubkey)
+      );
     });
   }
 
-  private async loadIndexerDashboardEntries(): Promise<ContractDashboardEntry[]> {
+  private async loadIndexerDashboardEntries(): Promise<
+    ContractDashboardEntry[]
+  > {
     const wallet = this.currentWallet();
     const identifiers = [
       wallet?.getAddress(),
@@ -996,28 +1253,45 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         limit: 100,
       });
 
-      const supportedRows = rows.filter((row) => this.supportedIndexerTemplates.includes(this.getIndexerTemplateName(row)));
-      const entries = supportedRows.map((row) => this.indexerSummaryToDashboard(row));
+      const supportedRows = rows.filter((row) =>
+        this.supportedIndexerTemplates.includes(
+          this.getIndexerTemplateName(row),
+        ),
+      );
+      const entries = supportedRows.map((row) =>
+        this.indexerSummaryToDashboard(row),
+      );
       for (const entry of entries) {
         byKey.set(entry.covenantId || entry.scriptHash || entry.id, entry);
       }
     }
 
-    return Array.from(byKey.values()).sort((a, b) => (this.getEntryTime(b) - this.getEntryTime(a)));
+    return Array.from(byKey.values()).sort(
+      (a, b) => this.getEntryTime(b) - this.getEntryTime(a),
+    );
   }
 
-  private mergeDashboardEntries(indexerEntries: ContractDashboardEntry[], localEntries: ContractDashboardEntry[]): ContractDashboardEntry[] {
+  private mergeDashboardEntries(
+    indexerEntries: ContractDashboardEntry[],
+    localEntries: ContractDashboardEntry[],
+  ): ContractDashboardEntry[] {
     const merged = new Map<string, ContractDashboardEntry>();
     for (const entry of localEntries) {
-      merged.set(entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id, entry);
+      merged.set(
+        entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id,
+        entry,
+      );
     }
     for (const entry of indexerEntries) {
-      const key = entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id;
-      const local = Array.from(merged.values()).find((candidate) =>
-        (!!entry.covenantId && candidate.covenantId === entry.covenantId) ||
-        (!!entry.scriptHash && candidate.scriptHash === entry.scriptHash) ||
-        (!!entry.deployTxid && candidate.deployTxid === entry.deployTxid) ||
-        (!!entry.currentAddress && candidate.currentAddress === entry.currentAddress),
+      const key =
+        entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id;
+      const local = Array.from(merged.values()).find(
+        (candidate) =>
+          (!!entry.covenantId && candidate.covenantId === entry.covenantId) ||
+          (!!entry.scriptHash && candidate.scriptHash === entry.scriptHash) ||
+          (!!entry.deployTxid && candidate.deployTxid === entry.deployTxid) ||
+          (!!entry.currentAddress &&
+            candidate.currentAddress === entry.currentAddress),
       );
 
       merged.set(local?.id || key, {
@@ -1027,10 +1301,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       });
     }
 
-    return Array.from(merged.values()).sort((a, b) => this.getEntryTime(b) - this.getEntryTime(a));
+    return Array.from(merged.values()).sort(
+      (a, b) => this.getEntryTime(b) - this.getEntryTime(a),
+    );
   }
 
-  private localEntryToDashboard(contract: ContractRegistryEntry): ContractDashboardEntry {
+  private localEntryToDashboard(
+    contract: ContractRegistryEntry,
+  ): ContractDashboardEntry {
     const contractName = this.normalizeContractName(contract.contractName);
     const participants = this.localParticipants(contract);
     return {
@@ -1043,16 +1321,23 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       currentAddress: contract.contractAddress,
       covenantId: contract.covenantId,
       deployTxid: contract.deployTxid,
-      latestTxid: contract.spendTxid || contract.outpoint?.txid || contract.deployTxid,
+      latestTxid:
+        contract.spendTxid || contract.outpoint?.txid || contract.deployTxid,
       latestAction: contract.spendTxid ? 'spend' : 'deploy',
       participants,
-      nextActionLabel: this.getNextActionLabel(contractName, contract.status || 'unknown', participants),
+      nextActionLabel: this.getNextActionLabel(
+        contractName,
+        contract.status || 'unknown',
+        participants,
+      ),
       actionHint: 'Open wallet action flow',
       registryEntry: contract,
     };
   }
 
-  private indexerSummaryToDashboard(summary: IndexerCovenantDetails): ContractDashboardEntry {
+  private indexerSummaryToDashboard(
+    summary: IndexerCovenantDetails,
+  ): ContractDashboardEntry {
     const contractName = this.getIndexerTemplateName(summary);
     const participants = this.indexerParticipants(summary);
     const status = (summary.activeUtxos ?? 0) > 0 ? 'active' : 'spent';
@@ -1071,22 +1356,33 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       latestAction: 'deploy',
       deadlineMs: this.extractDeadlineMs(summary),
       participants,
-      nextActionLabel: this.getNextActionLabel(contractName, status, participants),
-      actionHint: summary.claimVerified === false ? 'Template claim is not verified on-chain yet' : 'Open current covenant state',
+      nextActionLabel: this.getNextActionLabel(
+        contractName,
+        status,
+        participants,
+      ),
+      actionHint:
+        summary.claimVerified === false
+          ? 'Template claim is not verified on-chain yet'
+          : 'Open current covenant state',
       indexerSummary: summary,
     };
   }
 
-  private latestAction(actions: IndexerCovenantAction[]): IndexerCovenantAction | undefined {
-    return [...actions].sort((a, b) => (b.blockTimeMs || 0) - (a.blockTimeMs || 0))[0];
+  private latestAction(
+    actions: IndexerCovenantAction[],
+  ): IndexerCovenantAction | undefined {
+    return [...actions].sort(
+      (a, b) => (b.blockTimeMs || 0) - (a.blockTimeMs || 0),
+    )[0];
   }
 
   private getIndexerTemplateName(summary: IndexerCovenantDetails): string {
     return this.normalizeContractName(
       summary.template ||
-      summary.claimedTemplate ||
-      summary.claimedArgs?.tmpl ||
-      'Covenant',
+        summary.claimedTemplate ||
+        summary.claimedArgs?.tmpl ||
+        'Covenant',
     );
   }
 
@@ -1112,27 +1408,66 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return labels[this.normalizeContractName(name)] || name || 'Covenant';
   }
 
-  private localParticipants(contract: ContractRegistryEntry): Array<{ label: string; value: string }> {
-    const participants = [{ label: 'Owner', value: contract.deployedBy.address || contract.deployedBy.pubkey }];
-    const predecessor = contract.predecessorId ? this.registryService.getContract(contract.predecessorId) : undefined;
-    if (predecessor?.deployedBy?.address && predecessor.deployedBy.address !== contract.deployedBy.address) {
-      participants.push({ label: 'Original owner', value: predecessor.deployedBy.address });
+  private localParticipants(
+    contract: ContractRegistryEntry,
+  ): Array<{ label: string; value: string }> {
+    const participants = [
+      {
+        label: 'Owner',
+        value: contract.deployedBy.address || contract.deployedBy.pubkey,
+      },
+    ];
+    const predecessor = contract.predecessorId
+      ? this.registryService.getContract(contract.predecessorId)
+      : undefined;
+    if (
+      predecessor?.deployedBy?.address &&
+      predecessor.deployedBy.address !== contract.deployedBy.address
+    ) {
+      participants.push({
+        label: 'Original owner',
+        value: predecessor.deployedBy.address,
+      });
     }
     return participants;
   }
 
-  private indexerParticipants(summary: IndexerCovenantDetails): Array<{ label: string; value: string }> {
+  private indexerParticipants(
+    summary: IndexerCovenantDetails,
+  ): Array<{ label: string; value: string }> {
     const source = {
       ...(summary.constructor || {}),
       ...this.argsArrayToRecord(summary.claimedArgs?.args || []),
     };
-    const roles = ['owner', 'heir', 'signer', 'recovery', 'key1', 'key2', 'key3', 'buyer', 'seller', 'arbiter', 'arbiterHash'];
+    const roles = [
+      'owner',
+      'heir',
+      'signer',
+      'recovery',
+      'key1',
+      'key2',
+      'key3',
+      'buyer',
+      'seller',
+      'arbiter',
+      'arbiterHash',
+    ];
     return roles
-      .filter((role) => source[role] !== undefined && source[role] !== null && source[role] !== '')
-      .map((role) => ({ label: this.roleLabel(role), value: String(source[role]) }));
+      .filter(
+        (role) =>
+          source[role] !== undefined &&
+          source[role] !== null &&
+          source[role] !== '',
+      )
+      .map((role) => ({
+        label: this.roleLabel(role),
+        value: String(source[role]),
+      }));
   }
 
-  private argsArrayToRecord(args: IndexerCovenantArg[]): Record<string, string> {
+  private argsArrayToRecord(
+    args: IndexerCovenantArg[],
+  ): Record<string, string> {
     return args.reduce<Record<string, string>>((record, arg) => {
       record[arg.name] = String(arg.value);
       return record;
@@ -1156,13 +1491,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return labels[role] || role;
   }
 
-  private getNextActionLabel(contractName: string, status: ContractDashboardEntry['status'], participants: Array<{ label: string; value: string }>): string {
+  private getNextActionLabel(
+    contractName: string,
+    status: ContractDashboardEntry['status'],
+    participants: Array<{ label: string; value: string }>,
+  ): string {
     if (status !== 'active') return 'View history';
     const normalized = this.normalizeContractName(contractName);
     const currentRole = this.currentWalletRole(participants);
-    if (normalized === 'DeadManSwitch') return currentRole === 'Owner' ? 'Keep Alive' : 'Claim';
-    if (normalized === 'TimeLockVault') return currentRole === 'Recovery' ? 'Recover' : 'Withdraw';
-    if (normalized === 'MultiSigVault') return currentRole.startsWith('Signer') ? 'Sign / Complete' : 'Open Actions';
+    if (normalized === 'DeadManSwitch')
+      return currentRole === 'Owner' ? 'Keep Alive' : 'Claim';
+    if (normalized === 'TimeLockVault')
+      return currentRole === 'Recovery' ? 'Recover' : 'Withdraw';
+    if (normalized === 'MultiSigVault')
+      return currentRole.startsWith('Signer')
+        ? 'Sign / Complete'
+        : 'Open Actions';
     if (normalized === 'EscrowWithArbiter') {
       if (currentRole === 'Arbiter') return 'Arbitrate';
       if (currentRole === 'Buyer') return 'Release / Refund';
@@ -1171,22 +1515,37 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return 'Open Actions';
   }
 
-  private currentWalletRole(participants: Array<{ label: string; value: string }>): string {
+  private currentWalletRole(
+    participants: Array<{ label: string; value: string }>,
+  ): string {
     const wallet = this.currentWallet();
     const candidates = [
       wallet?.getAddress(),
       wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString(),
-    ].filter((value): value is string => !!value).map((value) => value.toLowerCase());
+    ]
+      .filter((value): value is string => !!value)
+      .map((value) => value.toLowerCase());
 
-    return participants.find((participant) => candidates.includes(String(participant.value).toLowerCase()))?.label || '';
+    return (
+      participants.find((participant) =>
+        candidates.includes(String(participant.value).toLowerCase()),
+      )?.label || ''
+    );
   }
 
-  private extractDeadlineMs(summary: IndexerCovenantDetails): number | undefined {
+  private extractDeadlineMs(
+    summary: IndexerCovenantDetails,
+  ): number | undefined {
     const source = {
       ...(summary.constructor || {}),
       ...this.argsArrayToRecord(summary.claimedArgs?.args || []),
     };
-    const raw = source['checkInDeadline'] ?? source['expiry'] ?? source['timeout'] ?? source['timeoutBlueScore'] ?? source['unlockBlueScore'];
+    const raw =
+      source['checkInDeadline'] ??
+      source['expiry'] ??
+      source['timeout'] ??
+      source['timeoutBlueScore'] ??
+      source['unlockBlueScore'];
     if (raw === undefined || raw === null || raw === '') return undefined;
     const numeric = Number(raw);
     if (!Number.isFinite(numeric) || numeric <= 0) return undefined;
@@ -1196,7 +1555,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   private getEntryTime(entry: ContractDashboardEntry): number {
-    return entry.indexerSummary?.createdAtMs || entry.registryEntry?.deployedAt || 0;
+    return (
+      entry.indexerSummary?.createdAtMs || entry.registryEntry?.deployedAt || 0
+    );
   }
 
   async openContractDetail(entry: ContractDashboardEntry) {
@@ -1211,7 +1572,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
       this.selectedDetailLoading.set(false);
-      this.selectedDetailError.set('This local contract has no indexer id yet. Use the action flow or import by tx once indexed.');
+      this.selectedDetailError.set(
+        'This local contract has no indexer id yet. Use the action flow or import by tx once indexed.',
+      );
       return;
     }
 
@@ -1222,20 +1585,36 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         this.covenantIndexerService.getCovenantUtxos(identifier),
       ]);
       const latestAction = this.latestAction(actions);
-      const lockedSompi = utxos.reduce((total, utxo) => total + BigInt(String(utxo.amountSompi ?? 0)), 0n);
+      const lockedSompi = utxos.reduce(
+        (total, utxo) => total + BigInt(String(utxo.amountSompi ?? 0)),
+        0n,
+      );
       const updatedEntry: ContractDashboardEntry = {
         ...entry,
         latestTxid: latestAction?.txidHex || entry.latestTxid,
-        latestAction: latestAction?.entrypoint || latestAction?.action || entry.latestAction,
+        latestAction:
+          latestAction?.entrypoint ||
+          latestAction?.action ||
+          entry.latestAction,
         status: utxos.length > 0 ? 'active' : 'spent',
         amountSompi: lockedSompi.toString(),
       };
-      this.selectedDetail.set({ entry: updatedEntry, response, actions, utxos });
-      if ((this.detailRouteId() || this.activeTab() === 'detail') && updatedEntry.status !== 'spent') {
+      this.selectedDetail.set({
+        entry: updatedEntry,
+        response,
+        actions,
+        utxos,
+      });
+      if (
+        (this.detailRouteId() || this.activeTab() === 'detail') &&
+        updatedEntry.status !== 'spent'
+      ) {
         await this.prepareDashboardAction(updatedEntry);
       }
     } catch (error: any) {
-      this.selectedDetailError.set(error?.message || 'Failed to load indexer detail for this contract.');
+      this.selectedDetailError.set(
+        error?.message || 'Failed to load indexer detail for this contract.',
+      );
     } finally {
       this.selectedDetailLoading.set(false);
       this.scrollContractsContentToTop();
@@ -1248,7 +1627,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     await this.openContractDetail(entry);
   }
 
-  private async prepareDashboardAction(entry: ContractDashboardEntry): Promise<boolean> {
+  private async prepareDashboardAction(
+    entry: ContractDashboardEntry,
+  ): Promise<boolean> {
     if (entry.registryEntry) {
       this.selectedContractId.set(entry.registryEntry.id);
       this.selectContractFromRegistry();
@@ -1260,7 +1641,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
-      this.dashboardError.set('This contract cannot be opened for actions until it has an indexer covenant id or script hash.');
+      this.dashboardError.set(
+        'This contract cannot be opened for actions until it has an indexer covenant id or script hash.',
+      );
       return false;
     }
 
@@ -1269,22 +1652,28 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       const response = await this.fetchIndexerCovenant(identifier);
       const preview = await this.buildIndexerImportPreview(response);
       this.indexerImportPreview.set(preview);
-      this.importIndexerPreview();
-      const imported = this.registryService.getAllContracts().find((contract) =>
-        contract.network === this.network() &&
-        (
-          contract.covenantId === preview.covenantId ||
-          (contract.outpoint.txid === preview.outpoint.txid && contract.outpoint.vout === preview.outpoint.vout)
-        ),
-      );
+      this.importIndexerPreview({ stayOnCurrentTab: true });
+      const imported = this.registryService
+        .getAllContracts()
+        .find(
+          (contract) =>
+            contract.network === this.network() &&
+            (contract.covenantId === preview.covenantId ||
+              (contract.outpoint.txid === preview.outpoint.txid &&
+                contract.outpoint.vout === preview.outpoint.vout)),
+        );
       if (imported) {
         this.selectedContractId.set(imported.id);
         this.selectContractFromRegistry();
         this.selectDefaultFunctionForContract(entry.contractName);
+        this.activeTab.set('detail');
+        this.detailPanelTab.set('action');
         return true;
       }
     } catch (error: any) {
-      this.dashboardError.set(error?.message || 'Import this contract before using wallet actions.');
+      this.dashboardError.set(
+        error?.message || 'Import this contract before using wallet actions.',
+      );
     } finally {
       this.selectedDetailLoading.set(false);
     }
@@ -1299,8 +1688,12 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   private scrollContractsContentToTop() {
     setTimeout(() => {
-      document.querySelector<HTMLElement>('.contracts-container')?.scrollTo({ top: 0, behavior: 'auto' });
-      document.querySelector<HTMLElement>('.flow-page-body')?.scrollTo({ top: 0, behavior: 'auto' });
+      document
+        .querySelector<HTMLElement>('.contracts-container')
+        ?.scrollTo({ top: 0, behavior: 'auto' });
+      document
+        .querySelector<HTMLElement>('.flow-page-body')
+        ?.scrollTo({ top: 0, behavior: 'auto' });
     });
   }
 
@@ -1311,7 +1704,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   setContractDetailTab(tab: ContractDetailTab) {
-    if (tab === 'action' && this.selectedDetail()?.entry.status === 'spent') return;
+    if (tab === 'action' && this.selectedDetail()?.entry.status === 'spent')
+      return;
     this.detailPanelTab.set(tab);
     this.scrollContractsContentToTop();
   }
@@ -1332,19 +1726,36 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (this.dashboardLoading()) return;
 
     const entry = this.findDashboardEntryByRouteId(routeId);
-    if (!entry) {
-      if (this.dashboardContracts().length === 0) return;
-      this.detailRouteNotFound.set(true);
-      this.selectedDetail.set(null);
+    if (entry) {
+      this.detailRouteNotFound.set(false);
+      await this.openContractDetail(entry);
       return;
     }
 
-    this.detailRouteNotFound.set(false);
-    await this.openContractDetail(entry);
+    try {
+      const response = await this.resolveIndexerImportQuery(routeId);
+      const preview = await this.buildIndexerImportPreview(response);
+      const existing = this.findDashboardEntryForPreview(preview);
+      this.detailRouteNotFound.set(false);
+      await this.openContractDetail(
+        existing || this.indexerPreviewToDashboard(preview, response),
+      );
+    } catch (error: any) {
+      this.detailRouteNotFound.set(true);
+      this.selectedDetail.set(null);
+      this.selectedDetailError.set(
+        error?.message ||
+          'Contract not found for this wallet or indexer network.',
+      );
+    }
   }
 
-  private findDashboardEntryByRouteId(routeId: string): ContractDashboardEntry | undefined {
-    return this.dashboardContracts().find((entry) => this.getContractRouteId(entry) === routeId);
+  private findDashboardEntryByRouteId(
+    routeId: string,
+  ): ContractDashboardEntry | undefined {
+    return this.dashboardContracts().find(
+      (entry) => this.getContractRouteId(entry) === routeId,
+    );
   }
 
   private getContractRouteId(entry: ContractDashboardEntry): string {
@@ -1374,7 +1785,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       EscrowWithArbiter: ['release', 'refund', 'arbitrate'],
     };
     const available = this.availableFunctions();
-    const target = (preferred[normalized] || []).find((name) => available.some((fn) => fn.name === name)) || available[0]?.name;
+    const target =
+      (preferred[normalized] || []).find((name) =>
+        available.some((fn) => fn.name === name),
+      ) || available[0]?.name;
     if (target) this.selectFunction(target);
   }
 
@@ -1384,7 +1798,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.indexerImportPreview.set(null);
 
     if (!query) {
-      this.indexerImportError.set('Enter a covenant ID, script hash, transaction ID, contract address, or share-link value.');
+      this.indexerImportError.set(
+        'Enter a covenant ID, script hash, transaction ID, contract address, or share-link value.',
+      );
       return;
     }
 
@@ -1395,13 +1811,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.indexerImportPreview.set(preview);
     } catch (error: any) {
       console.warn('[Contracts] Indexer import lookup failed:', error);
-      this.indexerImportError.set(error?.message || 'Failed to load covenant from indexer');
+      this.indexerImportError.set(
+        error?.message || 'Failed to load covenant from indexer',
+      );
     } finally {
       this.indexerImportLoading.set(false);
     }
   }
 
-  importIndexerPreview() {
+  importIndexerPreview(options: { stayOnCurrentTab?: boolean } = {}) {
     const preview = this.indexerImportPreview();
     if (!preview) {
       this.indexerImportError.set('Look up a covenant before importing it.');
@@ -1410,23 +1828,32 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     const existing = this.registryService.getAllContracts().find((entry) => {
       if (entry.network !== this.network()) return false;
-      const sameOutpoint = entry.outpoint.txid === preview.outpoint.txid && entry.outpoint.vout === preview.outpoint.vout;
+      const sameOutpoint =
+        entry.outpoint.txid === preview.outpoint.txid &&
+        entry.outpoint.vout === preview.outpoint.vout;
       if (sameOutpoint) return true;
 
       const sameAddress = entry.contractAddress === preview.contractAddress;
       if (!sameAddress) return false;
 
-      return entry.covenantId === preview.covenantId || entry.deployTxid === preview.deployTxid;
+      return (
+        entry.covenantId === preview.covenantId ||
+        entry.deployTxid === preview.deployTxid
+      );
     });
     if (existing) {
       this.indexerImportError.set('This covenant is already in My Contracts.');
       this.indexerImportPreview.set(null);
-      this.activeTab.set('my-contracts');
+      if (!options.stayOnCurrentTab) {
+        this.activeTab.set('my-contracts');
+      }
       return;
     }
 
     const wallet = this.currentWallet();
-    const compiled = this.covenantService.parseCompiledContract(preview.compiledJson);
+    const compiled = this.covenantService.parseCompiledContract(
+      preview.compiledJson,
+    );
     const entry: ContractRegistryEntry = {
       id: this.registryService.generateId(),
       contractName: compiled.contract_name || preview.template.name,
@@ -1437,7 +1864,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       amountSompi: preview.amountSompi,
       deployedBy: {
         address: wallet?.getAddress() || '',
-        pubkey: wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString() || '',
+        pubkey:
+          wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString() ||
+          '',
         accountName: wallet?.getDisplayName() || 'Imported',
       },
       deployedAt: preview.deployedAt,
@@ -1450,8 +1879,67 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.registryService.addContract(entry);
     this.indexerImportQuery = '';
     this.indexerImportPreview.set(null);
-    this.activeTab.set('my-contracts');
+    if (!options.stayOnCurrentTab) {
+      this.activeTab.set('my-contracts');
+    }
     this.loadContracts();
+  }
+
+  private indexerPreviewToDashboard(
+    preview: IndexerImportPreview,
+    response: {
+      action: IndexerCovenantAction;
+      actions: IndexerCovenantAction[];
+      covenant?: IndexerCovenantDetails;
+    },
+  ): ContractDashboardEntry {
+    const contractName = this.normalizeContractName(
+      preview.templateName || preview.template.name,
+    );
+    const latestAction =
+      this.latestAction(response.actions) ||
+      preview.activeAction ||
+      response.action;
+    const status =
+      (response.covenant?.activeUtxos ?? 1) > 0 ? 'active' : 'spent';
+    const participants = response.covenant
+      ? this.indexerParticipants(response.covenant)
+      : preview.args.map((arg) => ({
+          label: this.roleLabel(arg.name),
+          value: String(arg.value),
+        }));
+
+    return {
+      id: `indexer:${preview.covenantId}`,
+      source: 'indexer',
+      contractName,
+      displayName: this.getTemplateDisplayName(contractName),
+      status,
+      amountSompi: preview.amountSompi,
+      currentAddress: preview.contractAddress,
+      covenantId: preview.covenantId,
+      scriptHash:
+        response.covenant?.scriptHashHex ||
+        preview.activeAction.scriptHashHex ||
+        response.action.scriptHashHex,
+      deployTxid: preview.deployTxid,
+      latestTxid: latestAction?.txidHex || preview.deployTxid,
+      latestAction:
+        latestAction?.entrypoint || latestAction?.action || 'deploy',
+      deadlineMs: response.covenant
+        ? this.extractDeadlineMs(response.covenant)
+        : undefined,
+      participants,
+      nextActionLabel: this.getNextActionLabel(
+        contractName,
+        status,
+        participants,
+      ),
+      actionHint: preview.isLatestContinuation
+        ? 'Open latest continuation state'
+        : 'Open current covenant state',
+      indexerSummary: response.covenant,
+    };
   }
 
   private async fetchIndexerCovenant(identifier: string): Promise<{
@@ -1461,7 +1949,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }> {
     try {
       const byCovenant = await this.fetchIndexerCovenantByIdOrHash(identifier);
-      const deployAction = (byCovenant.actions || []).find((action) => action.action === 'deploy') || byCovenant.actions?.[0];
+      const deployAction =
+        (byCovenant.actions || []).find(
+          (action) => action.action === 'deploy',
+        ) || byCovenant.actions?.[0];
       if (deployAction) {
         return await this.resolveLatestIndexerCovenant({
           action: deployAction,
@@ -1473,16 +1964,23 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // Try tx lookup below; the identifier may be a deploy transaction id.
     }
 
-    const byTx = await this.covenantIndexerService.getTransactionActions(identifier);
-    const deployAction = byTx.find((action) => action.action === 'deploy') || byTx[0];
+    const byTx =
+      await this.covenantIndexerService.getTransactionActions(identifier);
+    const deployAction =
+      byTx.find((action) => action.action === 'deploy') || byTx[0];
     if (!deployAction) {
       throw new Error('No covenant deploy action found for that identifier.');
     }
 
     if (deployAction.covenantIdHex) {
       try {
-        const byCovenant = await this.fetchIndexerCovenantByIdOrHash(deployAction.covenantIdHex);
-        const canonicalDeploy = (byCovenant.actions || []).find((action) => action.action === 'deploy') || deployAction;
+        const byCovenant = await this.fetchIndexerCovenantByIdOrHash(
+          deployAction.covenantIdHex,
+        );
+        const canonicalDeploy =
+          (byCovenant.actions || []).find(
+            (action) => action.action === 'deploy',
+          ) || deployAction;
         return await this.resolveLatestIndexerCovenant({
           action: canonicalDeploy,
           actions: byCovenant.actions || [canonicalDeploy],
@@ -1496,9 +1994,13 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return { action: deployAction, actions: byTx };
   }
 
-  private async fetchIndexerCovenantByIdOrHash(identifier: string): Promise<IndexerCovenantResponse> {
+  private async fetchIndexerCovenantByIdOrHash(
+    identifier: string,
+  ): Promise<IndexerCovenantResponse> {
     try {
-      return await this.covenantIndexerService.getCovenantByCanonicalId(identifier);
+      return await this.covenantIndexerService.getCovenantByCanonicalId(
+        identifier,
+      );
     } catch {
       return await this.covenantIndexerService.getCovenant(identifier);
     }
@@ -1514,15 +2016,26 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     covenant?: IndexerCovenantDetails;
   }> {
     const latestAction = this.getLatestCovenantOutputAction(response.actions);
-    const latestScriptHash = this.extractScriptHashFromScriptPubKey(latestAction?.outputs?.scriptPubKeyHex);
-    if (!latestScriptHash || latestScriptHash === response.covenant?.scriptHashHex) {
+    const latestScriptHash = this.extractScriptHashFromScriptPubKey(
+      latestAction?.outputs?.scriptPubKeyHex,
+    );
+    if (
+      !latestScriptHash ||
+      latestScriptHash === response.covenant?.scriptHashHex
+    ) {
       return response;
     }
 
     try {
-      const latest = await this.fetchIndexerCovenantByIdOrHash(latestScriptHash);
-      const latestDeploy = (latest.actions || []).find((action) => action.action === 'deploy') || latest.actions?.[0];
-      if (latestDeploy && (latest.covenant?.claimedTemplate || latest.covenant?.claimedArgs?.tmpl)) {
+      const latest =
+        await this.fetchIndexerCovenantByIdOrHash(latestScriptHash);
+      const latestDeploy =
+        (latest.actions || []).find((action) => action.action === 'deploy') ||
+        latest.actions?.[0];
+      if (
+        latestDeploy &&
+        (latest.covenant?.claimedTemplate || latest.covenant?.claimedArgs?.tmpl)
+      ) {
         return {
           action: latestDeploy,
           actions: latest.actions || [latestDeploy],
@@ -1544,31 +2057,60 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const { action, actions, covenant } = response;
     const activeAction = this.getLatestCovenantOutputAction(actions) || action;
     const covenantId = covenant?.covenantIdHex || action.covenantIdHex;
-    const deployTxid = activeAction.txidHex || covenant?.genesisTxidHex || action.txidHex;
-    const contractAddress = activeAction.outputs?.address || activeAction.address || covenant?.address || action.address || action.outputs?.address;
-    const amountSompi = String(activeAction.outputs?.amountSompi ?? covenant?.totalAmountSompi ?? action.outputs?.amountSompi ?? '');
-    const vout = Number(activeAction.outputs?.vout ?? action.outputs?.vout ?? 0);
-    const templateName = covenant?.claimedTemplate || covenant?.claimedArgs?.tmpl;
+    const deployTxid =
+      activeAction.txidHex || covenant?.genesisTxidHex || action.txidHex;
+    const contractAddress =
+      activeAction.outputs?.address ||
+      activeAction.address ||
+      covenant?.address ||
+      action.address ||
+      action.outputs?.address;
+    const amountSompi = String(
+      activeAction.outputs?.amountSompi ??
+        covenant?.totalAmountSompi ??
+        action.outputs?.amountSompi ??
+        '',
+    );
+    const vout = Number(
+      activeAction.outputs?.vout ?? action.outputs?.vout ?? 0,
+    );
+    const templateName =
+      covenant?.claimedTemplate || covenant?.claimedArgs?.tmpl;
     const args = covenant?.claimedArgs?.args || [];
 
     if (!covenantId || !deployTxid || !contractAddress || !amountSompi) {
-      throw new Error('Indexer response is missing covenant id, deploy transaction, address, or amount.');
+      throw new Error(
+        'Indexer response is missing covenant id, deploy transaction, address, or amount.',
+      );
     }
     if (!templateName || args.length === 0) {
-      throw new Error('This covenant has no revealed template claim, so it cannot be imported.');
+      throw new Error(
+        'This covenant has no revealed template claim, so it cannot be imported.',
+      );
     }
 
-    const template = this.templateForIndexerName(templateName) || this.templateForIndexerArgs(args);
+    const template =
+      this.templateForIndexerName(templateName) ||
+      this.templateForIndexerArgs(args);
     if (!template) {
-      throw new Error(`Unsupported covenant template "${templateName}". Only local wallet templates can be imported.`);
+      throw new Error(
+        `Unsupported covenant template "${templateName}". Only local wallet templates can be imported.`,
+      );
     }
 
     const fieldValues = this.indexerArgsToTemplateValues(template, args);
-    const compiled = await this.compileTemplateWithFieldValues(template, fieldValues);
+    const compiled = await this.compileTemplateWithFieldValues(
+      template,
+      fieldValues,
+    );
     const computedAddress = this.covenantService.getContractAddress(compiled);
-    const isLatestContinuation = !!activeAction.outputs?.address && activeAction.outputs.address !== computedAddress;
+    const isLatestContinuation =
+      !!activeAction.outputs?.address &&
+      activeAction.outputs.address !== computedAddress;
     if (computedAddress !== contractAddress) {
-      throw new Error('Template parameters do not match the covenant address reported by the indexer.');
+      throw new Error(
+        'Template parameters do not match the covenant address reported by the indexer.',
+      );
     }
 
     return {
@@ -1584,18 +2126,30 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       template,
       templateName,
       amountSompi,
-      deployedAt: activeAction.blockTimeMs || covenant?.createdAtMs || action.blockTimeMs || Date.now(),
+      deployedAt:
+        activeAction.blockTimeMs ||
+        covenant?.createdAtMs ||
+        action.blockTimeMs ||
+        Date.now(),
       isLatestContinuation,
     };
   }
 
-  private getLatestCovenantOutputAction(actions: IndexerCovenantAction[]): IndexerCovenantAction | undefined {
+  private getLatestCovenantOutputAction(
+    actions: IndexerCovenantAction[],
+  ): IndexerCovenantAction | undefined {
     return actions
-      .filter((action) => !!action.outputs && (action.action === 'continuation' || action.action === 'deploy'))
+      .filter(
+        (action) =>
+          !!action.outputs &&
+          (action.action === 'continuation' || action.action === 'deploy'),
+      )
       .sort((a, b) => (b.blockTimeMs || 0) - (a.blockTimeMs || 0))[0];
   }
 
-  private extractScriptHashFromScriptPubKey(scriptPubKeyHex: string | undefined): string | undefined {
+  private extractScriptHashFromScriptPubKey(
+    scriptPubKeyHex: string | undefined,
+  ): string | undefined {
     const normalized = scriptPubKeyHex?.trim().toLowerCase();
     if (!normalized) return undefined;
 
@@ -1604,7 +2158,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return match?.[1];
   }
 
-  private templateForIndexerName(templateName: string): ContractTemplate | undefined {
+  private templateForIndexerName(
+    templateName: string,
+  ): ContractTemplate | undefined {
     const normalized = this.normalizeTemplateName(templateName);
     if (normalized.includes('deadman')) {
       return this.templateById('dead-mans-switch');
@@ -1630,19 +2186,30 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       deadman: 'dead-mans-switch',
     };
     const templateId = aliases[normalized];
-    return CONTRACT_TEMPLATES.find((template) =>
-      template.id === templateId ||
-      this.normalizeTemplateName(template.id) === normalized ||
-      this.normalizeTemplateName(template.name) === normalized,
+    return CONTRACT_TEMPLATES.find(
+      (template) =>
+        template.id === templateId ||
+        this.normalizeTemplateName(template.id) === normalized ||
+        this.normalizeTemplateName(template.name) === normalized,
     );
   }
 
-  private templateForIndexerArgs(args: IndexerCovenantArg[]): ContractTemplate | undefined {
+  private templateForIndexerArgs(
+    args: IndexerCovenantArg[],
+  ): ContractTemplate | undefined {
     const names = new Set(args.map((arg) => arg.name));
-    if (names.has('owner') && names.has('heir') && names.has('checkInDeadline')) {
+    if (
+      names.has('owner') &&
+      names.has('heir') &&
+      names.has('checkInDeadline')
+    ) {
       return this.templateById('dead-mans-switch');
     }
-    if (names.has('signer') && names.has('recoveryKey') && names.has('unlockBlueScore')) {
+    if (
+      names.has('signer') &&
+      names.has('recoveryKey') &&
+      names.has('unlockBlueScore')
+    ) {
       return this.templateById('time-lock-vault');
     }
     if (names.has('signer1') && names.has('signer2') && names.has('signer3')) {
@@ -1659,14 +2226,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   private normalizeTemplateName(value: string): string {
-    return String(value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    return String(value ?? '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '');
   }
 
-  private indexerArgsToTemplateValues(template: ContractTemplate, args: IndexerCovenantArg[]): Record<string, string> {
+  private indexerArgsToTemplateValues(
+    template: ContractTemplate,
+    args: IndexerCovenantArg[],
+  ): Record<string, string> {
     const byName = new Map(args.map((arg) => [arg.name, String(arg.value)]));
     const requireArg = (name: string): string => {
       const value = byName.get(name);
-      if (!value) throw new Error(`Indexer response is missing "${name}" for ${template.name}.`);
+      if (!value)
+        throw new Error(
+          `Indexer response is missing "${name}" for ${template.name}.`,
+        );
       return value;
     };
 
@@ -1701,11 +2276,25 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async compileTemplateWithFieldValues(template: ContractTemplate, fieldValues: Record<string, string>): Promise<CompiledContract> {
-    const newArgs = template.fields.map((field) => this.fieldToCtorArg(field, fieldValues[field.paramName]));
-    const compiled = await firstValueFrom(this.http.get<any>(template.assetPath));
-    const descriptor = this.templatePatcher.extractPatchDescriptor(compiled, template.placeholderArgs);
-    return this.templatePatcher.applyPatch(compiled, descriptor, newArgs) as CompiledContract;
+  private async compileTemplateWithFieldValues(
+    template: ContractTemplate,
+    fieldValues: Record<string, string>,
+  ): Promise<CompiledContract> {
+    const newArgs = template.fields.map((field) =>
+      this.fieldToCtorArg(field, fieldValues[field.paramName]),
+    );
+    const compiled = await firstValueFrom(
+      this.http.get<any>(template.assetPath),
+    );
+    const descriptor = this.templatePatcher.extractPatchDescriptor(
+      compiled,
+      template.placeholderArgs,
+    );
+    return this.templatePatcher.applyPatch(
+      compiled,
+      descriptor,
+      newArgs,
+    ) as CompiledContract;
   }
 
   /**
@@ -1719,7 +2308,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   /**
    * Get param display string (for template)
    */
-  getParamTypes(params: Array<{ name: string; type_ref: { base: string } }>): string {
+  getParamTypes(
+    params: Array<{ name: string; type_ref: { base: string } }>,
+  ): string {
     return params.map((p) => `${p.name}:${p.type_ref.base}`).join(', ');
   }
 
@@ -1760,7 +2351,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
       // Build human-readable description
       const pubkeyParams = constructorPubkeys.filter((p) =>
-        fnParams.some((fp) => fp.type === 'pubkey' && fp.name === p.name)
+        fnParams.some((fp) => fp.type === 'pubkey' && fp.name === p.name),
       );
 
       let description = `Function "${fn.name}" can be called`;
@@ -1815,18 +2406,21 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       const compiled = this.covenantService.parseCompiledContract(contractJson);
       const amountSompi = BigInt(Math.floor(amountKas * 1e8));
 
-      if (this.currentWallet()?.getIdWithAccount() !== wallet.getIdWithAccount()) {
+      if (
+        this.currentWallet()?.getIdWithAccount() !== wallet.getIdWithAccount()
+      ) {
         this.walletService.selectCurrentWallet(wallet.getIdWithAccount());
       }
 
-      const actionResult = await this.walletActionService.validateAndDoActionAfterApproval({
-        type: WalletActionType.COVENANT_DEPLOY,
-        data: {
-          compiledContractJson: contractJson,
-          contractName: compiled.contract_name || 'Covenant',
-          amountSompi,
-        },
-      });
+      const actionResult =
+        await this.walletActionService.validateAndDoActionAfterApproval({
+          type: WalletActionType.COVENANT_DEPLOY,
+          data: {
+            compiledContractJson: contractJson,
+            contractName: compiled.contract_name || 'Covenant',
+            amountSompi,
+          },
+        });
 
       if (!actionResult.success || !actionResult.result) {
         this.deployError.set('Covenant deployment was rejected or failed');
@@ -1866,11 +2460,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         this.registryService.addContract(entry);
         void this.trackDeployIndexing(result.txid, entry.id, result.covenantId);
       } catch (e) {
-        console.error('[Deploy] Contract deployed but failed to save to registry:', e);
+        console.error(
+          '[Deploy] Contract deployed but failed to save to registry:',
+          e,
+        );
         this.deployError.set(
           `Contract deployed (txid ${result.txid}), but saving it locally failed. Record the outpoint to interact later: ${result.outpoint.txid}:${result.outpoint.vout}.`,
         );
-        void this.trackDeployIndexing(result.txid, undefined, result.covenantId);
+        void this.trackDeployIndexing(
+          result.txid,
+          undefined,
+          result.covenantId,
+        );
       }
     } catch (error: any) {
       console.error('[Deploy] Failed:', error);
@@ -1880,7 +2481,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async trackDeployIndexing(txid: string, registryEntryId?: string, initialCovenantId?: string) {
+  private async trackDeployIndexing(
+    txid: string,
+    registryEntryId?: string,
+    initialCovenantId?: string,
+  ) {
     this.deployIndexerState.set({
       txid,
       status: 'checking',
@@ -1890,20 +2495,30 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     for (let attempt = 1; attempt <= 8; attempt++) {
       try {
-        const status = await this.covenantIndexerService.getTransactionSettlementStatus(txid);
+        const status =
+          await this.covenantIndexerService.getTransactionSettlementStatus(
+            txid,
+          );
         const actions = status.actions || [];
-        const indexedCovenantId = initialCovenantId || actions.find((action) => action.covenantIdHex)?.covenantIdHex;
+        const indexedCovenantId =
+          initialCovenantId ||
+          actions.find((action) => action.covenantIdHex)?.covenantIdHex;
 
         if (status.indexed) {
           if (registryEntryId && indexedCovenantId) {
-            this.registryService.updateContract(registryEntryId, { covenantId: indexedCovenantId });
+            this.registryService.updateContract(registryEntryId, {
+              covenantId: indexedCovenantId,
+            });
           }
-          this.deployResult.update((current) => current ? { ...current, covenantId: indexedCovenantId } : current);
+          this.deployResult.update((current) =>
+            current ? { ...current, covenantId: indexedCovenantId } : current,
+          );
           this.deployIndexerState.set({
             txid,
             status: 'indexed',
             covenantId: indexedCovenantId,
-            message: 'Indexed. This contract can now be shared and tracked from My Contracts.',
+            message:
+              'Indexed. This contract can now be shared and tracked from My Contracts.',
           });
           await this.loadContracts();
           return;
@@ -1921,7 +2536,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           txid,
           status: 'unavailable',
           covenantId: initialCovenantId,
-          message: error?.message || 'Indexer status is unavailable. The deployment tx was still returned by the wallet.',
+          message:
+            error?.message ||
+            'Indexer status is unavailable. The deployment tx was still returned by the wallet.',
         });
         return;
       }
@@ -1933,7 +2550,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       txid,
       status: 'not-indexed',
       covenantId: initialCovenantId,
-      message: 'Deployment broadcasted, but the indexer has not confirmed it yet. Refresh My Contracts in a moment.',
+      message:
+        'Deployment broadcasted, but the indexer has not confirmed it yet. Refresh My Contracts in a moment.',
     });
   }
 
@@ -1942,7 +2560,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    */
   selectContractFromRegistry() {
     // Look up the selected entry from the loaded registry list.
-    const contract = this.registryContracts().find((c) => c.id === this.selectedContractId());
+    const contract = this.registryContracts().find(
+      (c) => c.id === this.selectedContractId(),
+    );
     if (contract) {
       this.interactContractJson.set(contract.compiledJson);
       this.interactOutpointTxid = contract.outpoint.txid;
@@ -1971,7 +2591,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const vout = parseInt(this.interactOutpointVout, 10);
     const inputAmountSompi = this.interactInputAmount;
     const functionName = this.selectedFunction;
-    const outputAddress = this.interactResolvedOutputAddress || this.interactOutputAddress;
+    const outputAddress =
+      this.interactResolvedOutputAddress || this.interactOutputAddress;
     const outputAmountKas = parseFloat(this.interactOutputAmount);
 
     if (!contractJson) {
@@ -2009,22 +2630,29 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       if (functionName === 'arbitrate' && compiled.contract_name === 'Escrow') {
         // Escrow arbitrate: the "Withdraw Amount (KAS)" field is reused as amountToSeller.
         if (isNaN(outputAmountKas) || outputAmountKas <= 0) {
-          this.interactError.set('Enter the amount to send to the seller in the "Withdraw Amount" field');
+          this.interactError.set(
+            'Enter the amount to send to the seller in the "Withdraw Amount" field',
+          );
           return;
         }
         const amountToSellerSompi = BigInt(Math.floor(outputAmountKas * 1e8));
-        const amountToBuyerSompi = inputAmount > amountToSellerSompi
-          ? inputAmount - amountToSellerSompi
-          : 0n;
+        const amountToBuyerSompi =
+          inputAmount > amountToSellerSompi
+            ? inputAmount - amountToSellerSompi
+            : 0n;
 
         // Derive seller/buyer addresses from pubkeys baked into the compiled script.
         // Escrow constructor order: buyer (param 0), seller (param 1).
         const pubkeys = this.extractPubkeysFromScript(compiled);
         const buyerAddress = pubkeys[0] ? this.pubkeyToAddress(pubkeys[0]) : '';
-        const sellerAddress = pubkeys[1] ? this.pubkeyToAddress(pubkeys[1]) : '';
+        const sellerAddress = pubkeys[1]
+          ? this.pubkeyToAddress(pubkeys[1])
+          : '';
 
         if (!sellerAddress || !buyerAddress) {
-          this.interactError.set('Could not derive buyer/seller addresses from contract script');
+          this.interactError.set(
+            'Could not derive buyer/seller addresses from contract script',
+          );
           return;
         }
 
@@ -2035,28 +2663,32 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         extraArgsOverride = { amountToSeller: amountToSellerSompi };
 
         if (!this.isMultiSigFunction(functionName)) {
-        const result = await this.runCovenantSpendAction(
-          compiled,
-          contractJson,
-          outpoint,
-          inputAmount,
-          functionName,
-          outputs,
+          const result = await this.runCovenantSpendAction(
+            compiled,
+            contractJson,
+            outpoint,
+            inputAmount,
+            functionName,
+            outputs,
             extraArgsOverride,
-          undefined,
-          this.useSenderFee,
-        );
-        if (!result) return;
-        this.interactResult.set({ txid: result.txid, functionName: result.functionName });
-        if (this.selectedContractId()) {
-          this.registryService.updateContract(this.selectedContractId(), {
-            status: 'spent', spendTxid: result.txid, lastChecked: Date.now(),
+            undefined,
+            this.useSenderFee,
+          );
+          if (!result) return;
+          this.interactResult.set({
+            txid: result.txid,
+            functionName: result.functionName,
           });
-          this.loadContracts();
+          if (this.selectedContractId()) {
+            this.registryService.updateContract(this.selectedContractId(), {
+              status: 'spent',
+              spendTxid: result.txid,
+              lastChecked: Date.now(),
+            });
+            this.loadContracts();
+          }
+          return;
         }
-        return;
-        }
-
       } else if (this.functionRequiresOutput(functionName)) {
         // Withdrawal function — validate user-provided output
         if (!outputAddress) {
@@ -2067,52 +2699,76 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.interactError.set('Output amount must be greater than 0');
           return;
         }
-        outputs = [{
-          address: outputAddress,
-          amount: BigInt(Math.floor(outputAmountKas * 1e8)),
-        }];
+        outputs = [
+          {
+            address: outputAddress,
+            amount: BigInt(Math.floor(outputAmountKas * 1e8)),
+          },
+        ];
       } else if (this.isDmsKeepAlive()) {
         // DMS keepAlive — delegate to the dedicated method which handles new-contract generation
-        await this.executeDmsKeepAlive(compiled, contractJson, outpoint, inputAmount);
+        await this.executeDmsKeepAlive(
+          compiled,
+          contractJson,
+          outpoint,
+          inputAmount,
+        );
         return;
       } else {
         // Redeploy function (keepAlive, increment) — send full balance minus fee back to covenant
         // We set it to full amount and the SDK will deduct the actual network fee from the output if useSenderFee is false
-        const covenantAddress = this.covenantService.getContractAddress(compiled);
+        const covenantAddress =
+          this.covenantService.getContractAddress(compiled);
         const redeployAmount = inputAmount;
-        outputs = [{
-          address: covenantAddress,
-          amount: redeployAmount,
-        }];
+        outputs = [
+          {
+            address: covenantAddress,
+            amount: redeployAmount,
+          },
+        ];
       }
 
-
       // Collect extra args (int, bool params like escrow arbitrate's amountToSeller)
-      const extraArgs = extraArgsOverride || this.collectExtraArgs(compiled, functionName);
+      const extraArgs =
+        extraArgsOverride || this.collectExtraArgs(compiled, functionName);
 
       // Multi-sig functions: build partial spend instead of broadcasting
       if (this.isMultiSigFunction(functionName)) {
-        const approvalResult = await this.walletActionService.validateAndApproveAction({
-          type: WalletActionType.COVENANT_SPEND,
-          data: {
-            compiledContractJson: contractJson,
-            contractName: compiled.contract_name || 'Covenant',
-            outpoint,
-            inputAmountSompi: inputAmount,
-            functionName,
-            outputs,
-            extraArgs: Object.keys(extraArgs).length > 0 ? extraArgs : undefined,
-            useSenderFee: false,
-          },
-        });
+        const approvalResult =
+          await this.walletActionService.validateAndApproveAction({
+            type: WalletActionType.COVENANT_SPEND,
+            data: {
+              compiledContractJson: contractJson,
+              contractName: compiled.contract_name || 'Covenant',
+              outpoint,
+              inputAmountSompi: inputAmount,
+              functionName,
+              outputs,
+              extraArgs:
+                Object.keys(extraArgs).length > 0 ? extraArgs : undefined,
+              useSenderFee: false,
+            },
+          });
 
-        if (!approvalResult.isApproved || approvalResult.priorityFee === undefined) {
-          this.interactError.set('Covenant partial signing was rejected or failed');
+        if (
+          !approvalResult.isApproved ||
+          approvalResult.priorityFee === undefined
+        ) {
+          this.interactError.set(
+            'Covenant partial signing was rejected or failed',
+          );
           return;
         }
 
         const partial = await this.covenantService.buildPartial(
-          compiled, functionName, outpoint, inputAmount, outputs, privateKey, approvalResult.priorityFee, extraArgs,
+          compiled,
+          functionName,
+          outpoint,
+          inputAmount,
+          outputs,
+          privateKey,
+          approvalResult.priorityFee,
+          extraArgs,
         );
         const partialJson = JSON.stringify(partial, null, 2);
         this.partialSpendJson.set(partialJson);
@@ -2133,8 +2789,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         } satisfies ContractsTransientState);
         this.approvalFlowService.closeApproval();
         navigator.clipboard.writeText(partialJson).then(
-          () => { },
-          () => { } // Clipboard may not be available
+          () => {},
+          () => {}, // Clipboard may not be available
         );
         this.interactResult.set({
           txid: '(partial — share with co-signer)',
@@ -2142,7 +2798,6 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         });
         return;
       }
-
 
       const result = await this.runCovenantSpendAction(
         compiled,
@@ -2153,7 +2808,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         outputs,
         Object.keys(extraArgs).length > 0 ? extraArgs : undefined,
         undefined,
-        this.useSenderFee
+        this.useSenderFee,
       );
       if (!result) return;
 
@@ -2176,7 +2831,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.registryService.updateContract(this.selectedContractId(), {
             lastChecked: Date.now(),
             outpoint: { txid: result.txid, vout: 0 },
-            amountSompi: (inputAmount).toString(), // The registry doesn't accurately know the post-fee amount until refreshed, but setting inputAmount is close enough
+            amountSompi: inputAmount.toString(), // The registry doesn't accurately know the post-fee amount until refreshed, but setting inputAmount is close enough
           });
           // Update the interact form with the new outpoint
           this.interactOutpointTxid = result.txid;
@@ -2211,7 +2866,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // 1. Validate new expiry
     const newExpiryRaw = this.dmsNewExpiry?.toString().trim();
     if (!newExpiryRaw) {
-      this.interactError.set('Enter the new expiry timestamp for the refreshed contract.');
+      this.interactError.set(
+        'Enter the new expiry timestamp for the refreshed contract.',
+      );
       return;
     }
     let newExpiryMs: number;
@@ -2226,7 +2883,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     //    The DMS constructor order is: owner (param 0), heir (param 1).
     const pubkeys = this.extractPubkeysFromScript(compiled);
     if (pubkeys.length < 2) {
-      this.interactError.set('Could not extract owner/heir pubkeys from the contract script.');
+      this.interactError.set(
+        'Could not extract owner/heir pubkeys from the contract script.',
+      );
       return;
     }
     const ownerPubkeyBytes = this.hexStringToBytes(pubkeys[0]);
@@ -2237,21 +2896,48 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     let newCompiled: CompiledContract;
     try {
       const template = await firstValueFrom(
-        this.http.get<any>('assets/covenant-templates/dead-mans-switch.json')
+        this.http.get<any>('assets/covenant-templates/dead-mans-switch.json'),
       );
-      const DMS_TEMPLATE = CONTRACT_TEMPLATES.find(t => t.id === 'dead-mans-switch')!;
-      const descriptor = this.templatePatcher.extractPatchDescriptor(template, DMS_TEMPLATE.placeholderArgs);
+      const DMS_TEMPLATE = CONTRACT_TEMPLATES.find(
+        (t) => t.id === 'dead-mans-switch',
+      )!;
+      const descriptor = this.templatePatcher.extractPatchDescriptor(
+        template,
+        DMS_TEMPLATE.placeholderArgs,
+      );
 
-      const newArgs: import('../../../../services/covenant/template-patcher.service').CtorArg[] = [
-        { kind: 'array', data: Array.from(ownerPubkeyBytes).map(b => ({ kind: 'byte' as const, data: b })) },
-        { kind: 'array', data: Array.from(heirPubkeyBytes).map(b => ({ kind: 'byte' as const, data: b })) },
-        { kind: 'int', data: newExpiryMs },
-      ];
+      const newArgs: import('../../../../services/covenant/template-patcher.service').CtorArg[] =
+        [
+          {
+            kind: 'array',
+            data: Array.from(ownerPubkeyBytes).map((b) => ({
+              kind: 'byte' as const,
+              data: b,
+            })),
+          },
+          {
+            kind: 'array',
+            data: Array.from(heirPubkeyBytes).map((b) => ({
+              kind: 'byte' as const,
+              data: b,
+            })),
+          },
+          { kind: 'int', data: newExpiryMs },
+        ];
 
-      const patched = this.templatePatcher.applyPatch(template, descriptor, newArgs);
+      const patched = this.templatePatcher.applyPatch(
+        template,
+        descriptor,
+        newArgs,
+      );
       // Attach TN10 metadata using the current registry entry's stored values
-      const currentEntry = this.registryContracts().find(c => c.id === this.selectedContractId());
-      const ownerAddress = currentEntry?.deployedBy?.address || this.currentWallet()?.getAddress() || '';
+      const currentEntry = this.registryContracts().find(
+        (c) => c.id === this.selectedContractId(),
+      );
+      const ownerAddress =
+        currentEntry?.deployedBy?.address ||
+        this.currentWallet()?.getAddress() ||
+        '';
       const heirAddress = this.pubkeyToAddress(pubkeys[1]);
       patched.tn10 = {
         v: 1,
@@ -2259,28 +2945,39 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         args: [
           { name: 'owner', type: 'address', value: ownerAddress },
           { name: 'heir', type: 'address', value: heirAddress },
-          { name: 'checkInDeadline', type: 'blueScore', value: String(newExpiryMs) },
+          {
+            name: 'checkInDeadline',
+            type: 'blueScore',
+            value: String(newExpiryMs),
+          },
         ],
       };
       newCompiledJson = JSON.stringify(patched);
       newCompiled = this.covenantService.parseCompiledContract(newCompiledJson);
     } catch (e: any) {
-      this.interactError.set(e?.message || 'Failed to generate new DMS contract.');
+      this.interactError.set(
+        e?.message || 'Failed to generate new DMS contract.',
+      );
       return;
     }
 
-    const newContractAddress = this.covenantService.getContractAddress(newCompiled);
+    const newContractAddress =
+      this.covenantService.getContractAddress(newCompiled);
 
     // 4. Get the covenant ID from the registry for the old contract (for CovenantBinding)
-    const oldEntry = this.registryContracts().find(c => c.id === this.selectedContractId());
+    const oldEntry = this.registryContracts().find(
+      (c) => c.id === this.selectedContractId(),
+    );
     const oldCovenantId = oldEntry?.covenantId;
 
     // Build spend output: full amount → new DMS address, with CovenantBinding if we have a covenantId
-    const spendOutputs: SpendOutput[] = [{
-      address: newContractAddress,
-      amount: inputAmount,
-      covenantId: oldCovenantId,  // attach binding to preserve lineage
-    }];
+    const spendOutputs: SpendOutput[] = [
+      {
+        address: newContractAddress,
+        amount: inputAmount,
+        covenantId: oldCovenantId, // attach binding to preserve lineage
+      },
+    ];
 
     // Build the payload hex for the new contract
     let newPayloadHex: string | undefined;
@@ -2288,7 +2985,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       try {
         const payloadJson = JSON.stringify({ tn10: newCompiled.tn10 });
         const payloadBytes = new TextEncoder().encode(payloadJson);
-        newPayloadHex = Array.from(payloadBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+        newPayloadHex = Array.from(payloadBytes)
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('');
       } catch (err) {
         console.warn('Failed to encode new contract payload:', err);
       }
@@ -2322,27 +3021,32 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     // Register the new continuation contract
     const wallet = this.currentWallet()!;
-    const newEntry: import('../../../../../services/covenant/contract-registry.service').ContractRegistryEntry = {
-      id: this.registryService.generateId(),
-      contractName: 'DeadManSwitch',
-      compiledJson: newCompiledJson,
-      deployTxid: result.txid,
-      contractAddress: newContractAddress,
-      outpoint: { txid: result.txid, vout: 0 },
-      amountSompi: inputAmount.toString(),
-      deployedBy: {
-        address: wallet.getAddress(),
-        pubkey: wallet.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString(),
-        accountName: wallet.getDisplayName(),
-      },
-      deployedAt: Date.now(),
-      network: this.network(),
-      status: 'active',
-      lastChecked: Date.now(),
-      accessRoles: this.parseAccessRoles(newCompiled),
-      covenantId: oldCovenantId ?? result.covenantId,
-      predecessorId: this.selectedContractId() || undefined,
-    };
+    const newEntry: import('../../../../../services/covenant/contract-registry.service').ContractRegistryEntry =
+      {
+        id: this.registryService.generateId(),
+        contractName: 'DeadManSwitch',
+        compiledJson: newCompiledJson,
+        deployTxid: result.txid,
+        contractAddress: newContractAddress,
+        outpoint: { txid: result.txid, vout: 0 },
+        amountSompi: inputAmount.toString(),
+        deployedBy: {
+          address: wallet.getAddress(),
+          pubkey: wallet
+            .getPrivateKey()
+            .toPublicKey()
+            .toXOnlyPublicKey()
+            .toString(),
+          accountName: wallet.getDisplayName(),
+        },
+        deployedAt: Date.now(),
+        network: this.network(),
+        status: 'active',
+        lastChecked: Date.now(),
+        accessRoles: this.parseAccessRoles(newCompiled),
+        covenantId: oldCovenantId ?? result.covenantId,
+        predecessorId: this.selectedContractId() || undefined,
+      };
     this.registryService.addContract(newEntry);
 
     // Auto-select the new contract in the interact form
@@ -2378,21 +3082,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     useSenderFee = false,
     transactionPayloadHex?: string,
   ): Promise<CovenantSpendActionResult | undefined> {
-    const actionResult = await this.walletActionService.validateAndDoActionAfterApproval({
-      type: WalletActionType.COVENANT_SPEND,
-      data: {
-        compiledContractJson: contractJson,
-        contractName: compiled.contract_name || 'Covenant',
-        outpoint,
-        inputAmountSompi,
-        functionName,
-        outputs,
-        extraArgs,
-        covenantId,
-        useSenderFee,
-        transactionPayloadHex,
-      },
-    });
+    const actionResult =
+      await this.walletActionService.validateAndDoActionAfterApproval({
+        type: WalletActionType.COVENANT_SPEND,
+        data: {
+          compiledContractJson: contractJson,
+          contractName: compiled.contract_name || 'Covenant',
+          outpoint,
+          inputAmountSompi,
+          functionName,
+          outputs,
+          extraArgs,
+          covenantId,
+          useSenderFee,
+          transactionPayloadHex,
+        },
+      });
 
     if (!actionResult.success || !actionResult.result) {
       this.interactError.set('Covenant interaction was rejected or failed');
@@ -2405,12 +3110,21 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   /**
    * Check if current account can call a function
    */
-  canCallFunction(contract: ContractRegistryEntry, functionName: string): boolean {
-    const currentPubkey = this.currentWallet()?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString();
+  canCallFunction(
+    contract: ContractRegistryEntry,
+    functionName: string,
+  ): boolean {
+    const currentPubkey = this.currentWallet()
+      ?.getPrivateKey()
+      .toPublicKey()
+      .toXOnlyPublicKey()
+      .toString();
     if (!currentPubkey) return false;
 
     // Check if the function requires a specific pubkey that matches the current account
-    const role = contract.accessRoles.find((r) => r.functionName === functionName);
+    const role = contract.accessRoles.find(
+      (r) => r.functionName === functionName,
+    );
     if (!role) return false;
 
     // If function has pubkey params, check if any constructor param matches current pubkey
@@ -2463,7 +3177,13 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         utxos,
       });
 
-      console.log('[Lookup] Found', utxos.length, 'UTXOs, total:', totalSompi.toString(), 'sompi');
+      console.log(
+        '[Lookup] Found',
+        utxos.length,
+        'UTXOs, total:',
+        totalSompi.toString(),
+        'sompi',
+      );
     } catch (err: any) {
       console.error('[Lookup] Failed:', err);
       this.lookupError.set(err?.message || 'Failed to query contract address');
@@ -2581,7 +3301,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   copyDeployedContractShareLink() {
-    const id = this.deployIndexerState()?.covenantId || this.deployResult()?.covenantId;
+    const id =
+      this.deployIndexerState()?.covenantId || this.deployResult()?.covenantId;
     if (!id) return;
 
     const url = new URL(`${window.location.origin}/app/contracts/${id}`);
@@ -2596,7 +3317,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  private fieldToCtorArg(field: TemplateField, rawValue: string | number | undefined): CtorArg {
+  private fieldToCtorArg(
+    field: TemplateField,
+    rawValue: string | number | undefined,
+  ): CtorArg {
     const value = String(rawValue ?? '').trim();
     if (!value) {
       throw new Error(`${field.label} is required`);
@@ -2604,7 +3328,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     switch (field.type) {
       case 'address':
-        return this.bytesArg(this.templatePatcher.kaspaAddressToPubkeyBytes(value));
+        return this.bytesArg(
+          this.templatePatcher.kaspaAddressToPubkeyBytes(value),
+        );
       case 'hash32':
         return this.bytesArg(this.parseHash32(value, field.label));
       case 'int_days': {
@@ -2613,7 +3339,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         // Max ~194 days (3-byte encoding limit: 16,777,215 / 86400 ≈ 194)
         const days = this.parseWholeNumber(value, field.label);
         if (days > 194) {
-          throw new Error(`${field.label}: maximum is 194 days (template encoding limit)`);
+          throw new Error(
+            `${field.label}: maximum is 194 days (template encoding limit)`,
+          );
         }
         return this.intArg(days * 86400);
       }
@@ -2622,7 +3350,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       case 'int_timestamp':
         return this.intArg(this.parseDateToUnixMs(value, field.label));
       default:
-        throw new Error(`Unsupported template field type: ${(field as { type: string }).type}`);
+        throw new Error(
+          `Unsupported template field type: ${(field as { type: string }).type}`,
+        );
     }
   }
 
@@ -2714,7 +3444,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   isDmsKeepAlive(): boolean {
     const contract = this.parsedInteractContract();
     if (!contract || this.selectedFunction !== 'keepAlive') return false;
-    return (contract.contract_name || '').toLowerCase().replace(/[\s_-]/g, '').includes('deadman');
+    return (contract.contract_name || '')
+      .toLowerCase()
+      .replace(/[\s_-]/g, '')
+      .includes('deadman');
   }
 
   /**
@@ -2723,9 +3456,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   isMultiSigFunction(fnName: string): boolean {
     const contract = this.parsedInteractContract();
     if (!contract) return false;
-    const abiEntry = contract.abi.find(e => e.name === fnName);
+    const abiEntry = contract.abi.find((e) => e.name === fnName);
     if (!abiEntry) return false;
-    return abiEntry.inputs.filter(i => i.type_name === 'sig').length > 1;
+    return abiEntry.inputs.filter((i) => i.type_name === 'sig').length > 1;
   }
 
   /**
@@ -2764,15 +3497,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // Redeploy function (keepAlive on other contracts, increment): auto-fill covenant address + correct amount
       const contract = this.parsedInteractContract();
       if (contract) {
-        this.interactOutputAddress = this.covenantService.getContractAddress(contract);
+        this.interactOutputAddress =
+          this.covenantService.getContractAddress(contract);
       }
       const inputSompi = this.interactInputAmount;
       if (inputSompi) {
         try {
           const outputSompi = BigInt(inputSompi);
           const outputKas = Number(outputSompi) / 1e8;
-          this.interactOutputAmount = outputKas.toFixed(8).replace(/\.?0+$/, '');
-        } catch { /* ignore */ }
+          this.interactOutputAmount = outputKas
+            .toFixed(8)
+            .replace(/\.?0+$/, '');
+        } catch {
+          /* ignore */
+        }
       }
     }
   }
@@ -2782,14 +3520,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    */
   getFunctionLabel(name: string): string {
     const labels: Record<string, string> = {
-      'spend': '💰 Withdraw',
-      'recover': '🔐 Recovery Withdraw',
-      'claim': '📥 Claim',
-      'release': '🔓 Release',
-      'refund': '↩️ Refund',
-      'increment': '➕ Increment',
-      'keepAlive': '♻️ Keep Alive',
-      'execute': '⚡ Execute',
+      spend: '💰 Withdraw',
+      recover: '🔐 Recovery Withdraw',
+      claim: '📥 Claim',
+      release: '🔓 Release',
+      refund: '↩️ Refund',
+      increment: '➕ Increment',
+      keepAlive: '♻️ Keep Alive',
+      execute: '⚡ Execute',
     };
     return labels[name] || name;
   }
@@ -2803,26 +3541,34 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     // Contract-type-specific descriptions
     const contextual: Record<string, Record<string, string>> = {
-      'timelockvault': {
-        'spend': 'Withdraw your locked funds immediately using the owner key.',
-        'recover': 'Emergency recovery using the backup key. Only available after the timelock expires.',
+      timelockvault: {
+        spend: 'Withdraw your locked funds immediately using the owner key.',
+        recover:
+          'Emergency recovery using the backup key. Only available after the timelock expires.',
       },
-      'deadmansswitch': {
-        'keepAlive': 'Prove you\'re still active. Re-deploys the contract with a fresh expiry — no withdrawal needed.',
-        'claim': 'Claim the inheritance. Only available if the owner missed their keepAlive deadline.',
+      deadmansswitch: {
+        keepAlive:
+          "Prove you're still active. Re-deploys the contract with a fresh expiry — no withdrawal needed.",
+        claim:
+          'Claim the inheritance. Only available if the owner missed their keepAlive deadline.',
       },
-      'escrow': {
-        'release': 'Both buyer and seller agree to release funds to the recipient.',
-        'refund': 'Cancel the escrow and return funds to the sender. May require timelock expiry.',
+      escrow: {
+        release:
+          'Both buyer and seller agree to release funds to the recipient.',
+        refund:
+          'Cancel the escrow and return funds to the sender. May require timelock expiry.',
       },
-      'multisigvault': {
-        'spend12': 'Withdraw using 2-of-3 multi-sig. Requires signatures from two key holders.',
+      multisigvault: {
+        spend12:
+          'Withdraw using 2-of-3 multi-sig. Requires signatures from two key holders.',
       },
-      'counter': {
-        'increment': 'Increment the on-chain counter. The contract is re-deployed with the updated state.',
+      counter: {
+        increment:
+          'Increment the on-chain counter. The contract is re-deployed with the updated state.',
       },
-      'kcc20': {
-        'transfer': 'Transfer KCC20 tokens to another user. Enter the recipient Kaspa address and the token amount to send. Both UTXOs remain locked in the covenant.',
+      kcc20: {
+        transfer:
+          'Transfer KCC20 tokens to another user. Enter the recipient Kaspa address and the token amount to send. Both UTXOs remain locked in the covenant.',
       },
     };
 
@@ -2836,14 +3582,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
     // Fallback generic descriptions
     const fallback: Record<string, string> = {
-      'spend': 'Withdraw funds using the owner key. Available immediately — no timelock.',
-      'recover': 'Emergency withdrawal using the recovery key. Only available after the timelock expires.',
-      'claim': 'Claim the funds locked in this contract.',
-      'release': 'Release the locked funds to the designated recipient.',
-      'refund': 'Return the locked funds to the original sender.',
-      'increment': 'Update the on-chain state. The contract is re-deployed with new values.',
-      'keepAlive': 'Re-deploy the contract with a refreshed timer. No funds are withdrawn.',
-      'execute': 'Execute this contract\'s logic.',
+      spend:
+        'Withdraw funds using the owner key. Available immediately — no timelock.',
+      recover:
+        'Emergency withdrawal using the recovery key. Only available after the timelock expires.',
+      claim: 'Claim the funds locked in this contract.',
+      release: 'Release the locked funds to the designated recipient.',
+      refund: 'Return the locked funds to the original sender.',
+      increment:
+        'Update the on-chain state. The contract is re-deployed with new values.',
+      keepAlive:
+        'Re-deploy the contract with a refreshed timer. No funds are withdrawn.',
+      execute: "Execute this contract's logic.",
     };
 
     return fallback[name] || `Call the "${name}" function on this contract.`;
@@ -2887,16 +3637,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.qrScannerService.startScanning({
       scannerId: 'qr-scanner-covenant-interact-output',
       title: 'Scan recipient address',
-      onSuccess: (address: string) => this.onInteractOutputAddressChange(address),
-      onError: (error: string) => console.error('[Contracts] QR scanning error:', error),
+      onSuccess: (address: string) =>
+        this.onInteractOutputAddressChange(address),
+      onError: (error: string) =>
+        console.error('[Contracts] QR scanning error:', error),
     });
   }
 
   onInteractOutputAmountChange(value: any) {
-    this.interactOutputAmount = value === null || value === undefined ? '' : String(value);
+    this.interactOutputAmount =
+      value === null || value === undefined ? '' : String(value);
     this.interactError.set(null);
   }
-
 
   /**
    * Handle hash32 field input — if user pastes a 32-byte pubkey (64 hex chars),
@@ -2919,7 +3671,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // If user pastes a Kaspa address, extract pubkey and hash it
     if (normalized.startsWith('kaspa') || normalized.startsWith('kaspatest')) {
       try {
-        const pubkeyBytes = this.templatePatcher.kaspaAddressToPubkeyBytes(value.trim());
+        const pubkeyBytes = this.templatePatcher.kaspaAddressToPubkeyBytes(
+          value.trim(),
+        );
         const hashHex = this.computeBlake2bHex(pubkeyBytes);
         this.templateFormValues[paramName] = hashHex;
         this.templateFormValues[paramName + '_isAutoHashed'] = 'true';
@@ -2945,17 +3699,23 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    */
   private computeBlake2bHex(input: ArrayLike<number>): string {
     const hash = blake2b(Uint8Array.from(input), { dkLen: 32 });
-    return Array.from(hash).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+    return Array.from(hash)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
   }
 
   /**
    * Compute blake2b-256 hash of a hex value and update the field
    */
   computeBlake2bHash(paramName: string) {
-    const value = (this.templateFormValues[paramName] || '').trim().replace(/^0x/i, '');
+    const value = (this.templateFormValues[paramName] || '')
+      .trim()
+      .replace(/^0x/i, '');
     if (!/^[0-9a-fA-F]{64}$/.test(value)) return;
 
-    this.templateFormValues[paramName] = this.computeBlake2bHex(this.hex32ToBytes(value));
+    this.templateFormValues[paramName] = this.computeBlake2bHex(
+      this.hex32ToBytes(value),
+    );
     this.templateFormValues[paramName + '_isAutoHashed'] = 'true';
   }
 
@@ -2964,8 +3724,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   /**
    * Collect extra args from the form into a Record<string, bigint> for the SDK.
    */
-  private collectExtraArgs(compiled: CompiledContract, functionName: string): Record<string, bigint> {
-    const abiEntry = compiled.abi.find(e => e.name === functionName);
+  private collectExtraArgs(
+    compiled: CompiledContract,
+    functionName: string,
+  ): Record<string, bigint> {
+    const abiEntry = compiled.abi.find((e) => e.name === functionName);
     if (!abiEntry) return {};
 
     const result: Record<string, bigint> = {};
@@ -2997,23 +3760,28 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     if (!this.importPartialJson.trim()) {
-      this.partialCompleteError.set('Paste the partial spend JSON from the co-signer');
+      this.partialCompleteError.set(
+        'Paste the partial spend JSON from the co-signer',
+      );
       return;
     }
 
     try {
       this.isCompletingPartial.set(true);
       const partial: PartiallySignedSpend = JSON.parse(this.importPartialJson);
-      const actionResult = await this.walletActionService.validateAndDoActionAfterApproval({
-        type: WalletActionType.COVENANT_COMPLETE_PARTIAL,
-        data: {
-          partialSpendJson: this.importPartialJson,
-          contractName: this.getPartialContractName(partial),
-        },
-      });
+      const actionResult =
+        await this.walletActionService.validateAndDoActionAfterApproval({
+          type: WalletActionType.COVENANT_COMPLETE_PARTIAL,
+          data: {
+            partialSpendJson: this.importPartialJson,
+            contractName: this.getPartialContractName(partial),
+          },
+        });
 
       if (!actionResult.success || !actionResult.result) {
-        this.partialCompleteError.set('Covenant interaction was rejected or failed');
+        this.partialCompleteError.set(
+          'Covenant interaction was rejected or failed',
+        );
         return;
       }
 
@@ -3034,7 +3802,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         this.loadContracts();
       }
     } catch (error: any) {
-      this.partialCompleteError.set(error?.message || 'Failed to complete partial spend');
+      this.partialCompleteError.set(
+        error?.message || 'Failed to complete partial spend',
+      );
     } finally {
       this.isCompletingPartial.set(false);
     }
@@ -3074,7 +3844,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     for (let i = 0; i <= scriptBytes.length - 33; i++) {
       if (scriptBytes[i] === 0x20) {
         const pkHex = Array.from(scriptBytes.slice(i + 1, i + 33))
-          .map(b => b.toString(16).padStart(2, '0'))
+          .map((b) => b.toString(16).padStart(2, '0'))
           .join('');
         if (!seen.includes(pkHex)) seen.push(pkHex);
       }
@@ -3087,7 +3857,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    */
   private pubkeyToAddress(pkHex: string): string {
     try {
-      return new PublicKey(pkHex).toAddress(this.rpcService.getNetwork()).toString();
+      return new PublicKey(pkHex)
+        .toAddress(this.rpcService.getNetwork())
+        .toString();
     } catch (e) {
       console.warn('[Contracts] pubkeyToAddress failed for', pkHex, e);
       return '';

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1,9 +1,9 @@
-import { Component, computed, inject, signal, OnInit, effect } from '@angular/core';
+import { Component, computed, inject, signal, OnInit, OnDestroy, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { firstValueFrom, Subscription } from 'rxjs';
 import { DropdownOption, KcButtonComponent, KcDropdownSelectComponent, KcIconComponent, KcInputComponent, KcTooltipDirective } from 'kaspacom-ui';
 import { blake2b } from '@noble/hashes/blake2b';
 import { WalletService } from '../../../../../services/wallet.service';
@@ -34,7 +34,8 @@ import { ApprovalFlowService } from '../../../../services/approval-flow.service'
 import { AddressSmartInputComponent } from '../../../../shared/ui/input/address-smart-input/address-smart-input.component';
 import { CovenantDateTimeInputComponent } from './covenant-date-time-input.component';
 
-type TabName = 'deploy' | 'my-contracts' | 'lookup-import' | 'interact' | 'templates';
+type TabName = 'deploy' | 'my-contracts' | 'lookup-import' | 'interact' | 'templates' | 'detail';
+type ContractDetailTab = 'details' | 'action';
 type CreateMode = 'template' | 'custom';
 type ContractsTransientState = {
   activeTab?: TabName;
@@ -67,7 +68,8 @@ type IndexerImportPreview = {
   isLatestContinuation: boolean;
 };
 
-type ContractDashboardSource = 'indexer' | 'local';
+type ContractDashboardSource = 'indexer' | 'local' | 'both';
+type ContractDashboardFilter = 'active' | 'history';
 
 type ContractDashboardEntry = {
   id: string;
@@ -125,7 +127,7 @@ type DeployIndexerState = {
     '[class.full-height]': 'true',
   },
 })
-export class ContractsPageComponent implements OnInit {
+export class ContractsPageComponent implements OnInit, OnDestroy {
   private walletService = inject(WalletService);
   private walletActionService = inject(WalletActionService);
   private qrScannerService = inject(QrScannerService);
@@ -140,6 +142,8 @@ export class ContractsPageComponent implements OnInit {
   private flowPagesService = inject(FlowPagesService);
   private approvalFlowService = inject(ApprovalFlowService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private routeSubscription?: Subscription;
 
   // Current active tab
   activeTab = signal<TabName>('deploy');
@@ -202,11 +206,20 @@ export class ContractsPageComponent implements OnInit {
   // Contract registry (my contracts tab)
   registryContracts = signal<ContractRegistryEntry[]>([]);
   dashboardContracts = signal<ContractDashboardEntry[]>([]);
+  dashboardFilter = signal<ContractDashboardFilter>('active');
+  activeDashboardContracts = computed(() => this.dashboardContracts().filter((contract) => contract.status !== 'spent'));
+  historyDashboardContracts = computed(() => this.dashboardContracts().filter((contract) => contract.status === 'spent'));
+  filteredDashboardContracts = computed(() =>
+    this.dashboardFilter() === 'history' ? this.historyDashboardContracts() : this.activeDashboardContracts(),
+  );
   dashboardLoading = signal(false);
   dashboardError = signal<string | null>(null);
   selectedDetail = signal<ContractDetailState | null>(null);
   selectedDetailLoading = signal(false);
   selectedDetailError = signal<string | null>(null);
+  detailPanelTab = signal<ContractDetailTab>('details');
+  detailRouteId = signal<string | null>(null);
+  detailRouteNotFound = signal(false);
   private readonly supportedIndexerTemplates = ['DeadManSwitch', 'TimeLockVault', 'MultiSigVault', 'EscrowWithArbiter'];
 
   contractTemplates = CONTRACT_TEMPLATES;
@@ -348,8 +361,31 @@ export class ContractsPageComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.routeSubscription = this.route.paramMap.subscribe((params) => {
+      const contractId = params.get('contractId');
+      this.detailRouteId.set(contractId);
+      this.detailRouteNotFound.set(false);
+      if (contractId) {
+        const requestedNetwork = this.route.snapshot.queryParamMap.get('network')?.trim();
+        if (requestedNetwork && requestedNetwork !== this.network()) {
+          if (!this.rpcService.setNetwork(requestedNetwork)) {
+            this.selectedDetailError.set(`This contract link targets unsupported network "${requestedNetwork}".`);
+            return;
+          }
+          this.activeTab.set('my-contracts');
+          return;
+        }
+        this.detailPanelTab.set('details');
+        this.activeTab.set('detail');
+        void this.openDetailFromRoute(contractId);
+      }
+    });
     this.restoreTransientState();
     void this.applyInboundContractLink();
+  }
+
+  ngOnDestroy() {
+    this.routeSubscription?.unsubscribe();
   }
 
   private restoreTransientState() {
@@ -392,7 +428,8 @@ export class ContractsPageComponent implements OnInit {
     await this.loadContracts();
     const existing = this.findDashboardEntryForPreview(preview);
     if (existing) {
-      this.activeTab.set('my-contracts');
+      this.detailPanelTab.set('details');
+      this.activeTab.set('detail');
       await this.openContractDetail(existing);
     }
   }
@@ -851,15 +888,13 @@ export class ContractsPageComponent implements OnInit {
     this.selectedDetail.set(null);
     this.selectedDetailError.set(null);
 
-    const allContracts = this.registryService.getAllContracts();
-    const currentNetwork = this.network();
-    const filtered = allContracts.filter((c) => c.network === currentNetwork);
+    const filtered = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(filtered);
 
     // Check on-chain status for each contract
     await this.refreshContractStatuses(filtered);
 
-    const updatedLocal = this.registryService.getAllContracts().filter((c) => c.network === this.network());
+    const updatedLocal = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(updatedLocal);
 
     try {
@@ -874,6 +909,11 @@ export class ContractsPageComponent implements OnInit {
       this.dashboardContracts.set(updatedLocal.map((entry) => this.localEntryToDashboard(entry)));
     } finally {
       this.dashboardLoading.set(false);
+    }
+
+    const routeId = this.detailRouteId();
+    if (routeId) {
+      await this.openDetailFromRoute(routeId);
     }
   }
 
@@ -917,8 +957,21 @@ export class ContractsPageComponent implements OnInit {
     }
 
     // Reload with updated statuses
-    const updated = this.registryService.getAllContracts().filter((c) => c.network === this.network());
+    const updated = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(updated);
+  }
+
+  private getCurrentWalletLocalContracts(): ContractRegistryEntry[] {
+    const wallet = this.currentWallet();
+    const address = wallet?.getAddress()?.toLowerCase();
+    const pubkey = wallet?.getPrivateKey().toPublicKey().toXOnlyPublicKey().toString()?.toLowerCase();
+
+    return this.registryService.getAllContracts().filter((contract) => {
+      if (contract.network !== this.network()) return false;
+      const deployedAddress = contract.deployedBy?.address?.toLowerCase();
+      const deployedPubkey = contract.deployedBy?.pubkey?.toLowerCase();
+      return (!!address && deployedAddress === address) || (!!pubkey && deployedPubkey === pubkey);
+    });
   }
 
   private async loadIndexerDashboardEntries(): Promise<ContractDashboardEntry[]> {
@@ -944,7 +997,7 @@ export class ContractsPageComponent implements OnInit {
       });
 
       const supportedRows = rows.filter((row) => this.supportedIndexerTemplates.includes(this.getIndexerTemplateName(row)));
-      const entries = await Promise.all(supportedRows.map((row) => this.indexerSummaryToDashboard(row)));
+      const entries = supportedRows.map((row) => this.indexerSummaryToDashboard(row));
       for (const entry of entries) {
         byKey.set(entry.covenantId || entry.scriptHash || entry.id, entry);
       }
@@ -963,11 +1016,13 @@ export class ContractsPageComponent implements OnInit {
       const local = Array.from(merged.values()).find((candidate) =>
         (!!entry.covenantId && candidate.covenantId === entry.covenantId) ||
         (!!entry.scriptHash && candidate.scriptHash === entry.scriptHash) ||
+        (!!entry.deployTxid && candidate.deployTxid === entry.deployTxid) ||
         (!!entry.currentAddress && candidate.currentAddress === entry.currentAddress),
       );
 
       merged.set(local?.id || key, {
         ...entry,
+        source: local ? 'both' : entry.source,
         registryEntry: local?.registryEntry,
       });
     }
@@ -997,11 +1052,10 @@ export class ContractsPageComponent implements OnInit {
     };
   }
 
-  private async indexerSummaryToDashboard(summary: IndexerCovenantDetails): Promise<ContractDashboardEntry> {
+  private indexerSummaryToDashboard(summary: IndexerCovenantDetails): ContractDashboardEntry {
     const contractName = this.getIndexerTemplateName(summary);
     const participants = this.indexerParticipants(summary);
     const status = (summary.activeUtxos ?? 0) > 0 ? 'active' : 'spent';
-    const latestAction = await this.getLatestActionForSummary(summary);
     return {
       id: `indexer:${summary.covenantIdHex || summary.scriptHashHex}`,
       source: 'indexer',
@@ -1013,28 +1067,14 @@ export class ContractsPageComponent implements OnInit {
       covenantId: summary.covenantIdHex,
       scriptHash: summary.scriptHashHex,
       deployTxid: summary.genesisTxidHex,
-      latestTxid: latestAction?.txidHex || summary.genesisTxidHex,
-      latestAction: latestAction?.entrypoint || latestAction?.action || 'deploy',
+      latestTxid: summary.genesisTxidHex,
+      latestAction: 'deploy',
       deadlineMs: this.extractDeadlineMs(summary),
       participants,
       nextActionLabel: this.getNextActionLabel(contractName, status, participants),
       actionHint: summary.claimVerified === false ? 'Template claim is not verified on-chain yet' : 'Open current covenant state',
       indexerSummary: summary,
     };
-  }
-
-  private async getLatestActionForSummary(summary: IndexerCovenantDetails): Promise<IndexerCovenantAction | undefined> {
-    const identifier = summary.covenantIdHex || summary.scriptHashHex;
-    if (!identifier) return undefined;
-
-    try {
-      const actions = await this.covenantIndexerService.getCovenantActions(identifier);
-      return this.latestAction(actions);
-    } catch {
-      // Card rendering should survive indexer action lookup failures; detail
-      // view will surface the precise error if the user opens this contract.
-      return undefined;
-    }
   }
 
   private latestAction(actions: IndexerCovenantAction[]): IndexerCovenantAction | undefined {
@@ -1122,13 +1162,13 @@ export class ContractsPageComponent implements OnInit {
     const currentRole = this.currentWalletRole(participants);
     if (normalized === 'DeadManSwitch') return currentRole === 'Owner' ? 'Keep Alive' : 'Claim';
     if (normalized === 'TimeLockVault') return currentRole === 'Recovery' ? 'Recover' : 'Withdraw';
-    if (normalized === 'MultiSigVault') return currentRole.startsWith('Signer') ? 'Sign / Complete' : 'View details';
+    if (normalized === 'MultiSigVault') return currentRole.startsWith('Signer') ? 'Sign / Complete' : 'Open Actions';
     if (normalized === 'EscrowWithArbiter') {
       if (currentRole === 'Arbiter') return 'Arbitrate';
       if (currentRole === 'Buyer') return 'Release / Refund';
       if (currentRole === 'Seller') return 'Release';
     }
-    return 'View details';
+    return 'Open Actions';
   }
 
   private currentWalletRole(participants: Array<{ label: string; value: string }>): string {
@@ -1163,6 +1203,10 @@ export class ContractsPageComponent implements OnInit {
     this.selectedDetailLoading.set(true);
     this.selectedDetailError.set(null);
     this.selectedDetail.set({ entry, actions: [], utxos: [] });
+    if (this.detailRouteId() || this.activeTab() === 'detail') {
+      this.clearInteractContractSelection();
+    }
+    this.scrollContractsContentToTop();
 
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
@@ -1187,20 +1231,29 @@ export class ContractsPageComponent implements OnInit {
         amountSompi: lockedSompi.toString(),
       };
       this.selectedDetail.set({ entry: updatedEntry, response, actions, utxos });
+      if ((this.detailRouteId() || this.activeTab() === 'detail') && updatedEntry.status !== 'spent') {
+        await this.prepareDashboardAction(updatedEntry);
+      }
     } catch (error: any) {
       this.selectedDetailError.set(error?.message || 'Failed to load indexer detail for this contract.');
     } finally {
       this.selectedDetailLoading.set(false);
+      this.scrollContractsContentToTop();
     }
   }
 
   async openDashboardAction(entry: ContractDashboardEntry) {
+    this.detailPanelTab.set('action');
+    this.activeTab.set('detail');
+    await this.openContractDetail(entry);
+  }
+
+  private async prepareDashboardAction(entry: ContractDashboardEntry): Promise<boolean> {
     if (entry.registryEntry) {
       this.selectedContractId.set(entry.registryEntry.id);
       this.selectContractFromRegistry();
-      this.switchTab('interact');
       this.selectDefaultFunctionForContract(entry.contractName);
-      return;
+      return true;
     }
 
     this.dashboardError.set(null);
@@ -1208,7 +1261,7 @@ export class ContractsPageComponent implements OnInit {
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
       this.dashboardError.set('This contract cannot be opened for actions until it has an indexer covenant id or script hash.');
-      return;
+      return false;
     }
 
     try {
@@ -1227,13 +1280,89 @@ export class ContractsPageComponent implements OnInit {
       if (imported) {
         this.selectedContractId.set(imported.id);
         this.selectContractFromRegistry();
-        this.switchTab('interact');
         this.selectDefaultFunctionForContract(entry.contractName);
+        return true;
       }
     } catch (error: any) {
       this.dashboardError.set(error?.message || 'Import this contract before using wallet actions.');
     } finally {
+      this.selectedDetailLoading.set(false);
     }
+    return false;
+  }
+
+  setDashboardFilter(filter: ContractDashboardFilter) {
+    this.dashboardFilter.set(filter);
+    this.selectedDetail.set(null);
+    this.selectedDetailError.set(null);
+  }
+
+  private scrollContractsContentToTop() {
+    setTimeout(() => {
+      document.querySelector<HTMLElement>('.contracts-container')?.scrollTo({ top: 0, behavior: 'auto' });
+      document.querySelector<HTMLElement>('.flow-page-body')?.scrollTo({ top: 0, behavior: 'auto' });
+    });
+  }
+
+  navigateToContractDetail(entry: ContractDashboardEntry) {
+    this.detailPanelTab.set('details');
+    this.activeTab.set('detail');
+    void this.openContractDetail(entry);
+  }
+
+  setContractDetailTab(tab: ContractDetailTab) {
+    if (tab === 'action' && this.selectedDetail()?.entry.status === 'spent') return;
+    this.detailPanelTab.set(tab);
+    this.scrollContractsContentToTop();
+  }
+
+  backToContractsList() {
+    const wasRouteDetail = !!this.detailRouteId();
+    if (wasRouteDetail) {
+      void this.router.navigate(['/app/contracts']);
+    }
+    this.selectedDetail.set(null);
+    this.selectedDetailError.set(null);
+    this.detailRouteId.set(null);
+    this.detailRouteNotFound.set(false);
+    this.activeTab.set('my-contracts');
+  }
+
+  private async openDetailFromRoute(routeId: string) {
+    if (this.dashboardLoading()) return;
+
+    const entry = this.findDashboardEntryByRouteId(routeId);
+    if (!entry) {
+      if (this.dashboardContracts().length === 0) return;
+      this.detailRouteNotFound.set(true);
+      this.selectedDetail.set(null);
+      return;
+    }
+
+    this.detailRouteNotFound.set(false);
+    await this.openContractDetail(entry);
+  }
+
+  private findDashboardEntryByRouteId(routeId: string): ContractDashboardEntry | undefined {
+    return this.dashboardContracts().find((entry) => this.getContractRouteId(entry) === routeId);
+  }
+
+  private getContractRouteId(entry: ContractDashboardEntry): string {
+    return entry.covenantId || entry.scriptHash || entry.deployTxid || entry.id;
+  }
+
+  private clearInteractContractSelection() {
+    this.selectedContractId.set('');
+    this.interactContractJson.set('');
+    this.interactOutpointTxid = '';
+    this.interactOutpointVout = '';
+    this.interactInputAmount = '';
+    this.selectedFunction = '';
+    this.interactError.set(null);
+    this.interactResult.set(null);
+    this.partialSpendJson.set(null);
+    this.partialCompleteError.set(null);
+    this.partialCompleteResult.set(null);
   }
 
   private selectDefaultFunctionForContract(contractName: string) {
@@ -2395,7 +2524,12 @@ export class ContractsPageComponent implements OnInit {
   }
 
   getSourceLabel(contract: ContractDashboardEntry): string {
-    return contract.source === 'indexer' ? 'Indexer' : 'Local';
+    return this.getSourceLabels(contract).join(' + ');
+  }
+
+  getSourceLabels(contract: ContractDashboardEntry): string[] {
+    if (contract.source === 'both') return ['Local', 'Indexer'];
+    return [contract.source === 'indexer' ? 'Indexer' : 'Local'];
   }
 
   getStatusLabel(contract: ContractDashboardEntry): string {
@@ -2438,9 +2572,8 @@ export class ContractsPageComponent implements OnInit {
 
     // Share links intentionally carry only public lookup state. The receiving
     // wallet still imports/loads current state from the indexer.
-    const url = new URL(window.location.origin + '/app/contracts');
+    const url = new URL(`${window.location.origin}/app/contracts/${id}`);
     url.searchParams.set('network', this.network());
-    url.searchParams.set('contract', id);
     navigator.clipboard.writeText(url.toString()).then(
       () => alert('Contract share link copied.'),
       () => prompt('Copy this contract link:', url.toString()),
@@ -2451,9 +2584,8 @@ export class ContractsPageComponent implements OnInit {
     const id = this.deployIndexerState()?.covenantId || this.deployResult()?.covenantId;
     if (!id) return;
 
-    const url = new URL(window.location.origin + '/app/contracts');
+    const url = new URL(`${window.location.origin}/app/contracts/${id}`);
     url.searchParams.set('network', this.network());
-    url.searchParams.set('contract', id);
     navigator.clipboard.writeText(url.toString()).then(
       () => alert('Contract share link copied.'),
       () => prompt('Copy this contract link:', url.toString()),

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal, OnInit, effect } from '@angular/co
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { DropdownOption, KcButtonComponent, KcDropdownSelectComponent, KcIconComponent, KcInputComponent, KcTooltipDirective } from 'kaspacom-ui';
 import { blake2b } from '@noble/hashes/blake2b';
@@ -96,6 +97,13 @@ type ContractDetailState = {
   utxos: IndexerCovenantUtxo[];
 };
 
+type DeployIndexerState = {
+  txid: string;
+  status: 'checking' | 'indexed' | 'not-indexed' | 'unavailable';
+  message: string;
+  covenantId?: string;
+};
+
 @Component({
   selector: 'app-contracts-page',
   imports: [
@@ -131,6 +139,7 @@ export class ContractsPageComponent implements OnInit {
   private kaspaL1NetworkService = inject(KaspaL1NetworkService);
   private flowPagesService = inject(FlowPagesService);
   private approvalFlowService = inject(ApprovalFlowService);
+  private route = inject(ActivatedRoute);
 
   // Current active tab
   activeTab = signal<TabName>('deploy');
@@ -162,7 +171,8 @@ export class ContractsPageComponent implements OnInit {
   deployAmount = '';
   deployAmountTouched = false;
   deployAmountError = signal('');
-  deployResult = signal<{ address: string; txid: string } | null>(null);
+  deployResult = signal<{ address: string; txid: string; covenantId?: string } | null>(null);
+  deployIndexerState = signal<DeployIndexerState | null>(null);
   deployError = signal<string | null>(null);
   isDeploying = signal(false);
 
@@ -339,6 +349,7 @@ export class ContractsPageComponent implements OnInit {
 
   ngOnInit() {
     this.restoreTransientState();
+    void this.applyInboundContractLink();
   }
 
   private restoreTransientState() {
@@ -357,6 +368,80 @@ export class ContractsPageComponent implements OnInit {
     if (state.interactResult !== undefined) this.interactResult.set(state.interactResult);
 
     this.flowPagesService.saveTransientState('contracts', undefined);
+  }
+
+  private async applyInboundContractLink() {
+    const params = this.route.snapshot.queryParamMap;
+    const contractId = params.get('contract')?.trim();
+    if (!contractId) return;
+
+    const requestedNetwork = params.get('network')?.trim();
+    if (requestedNetwork && requestedNetwork !== this.network() && !this.rpcService.setNetwork(requestedNetwork)) {
+      this.activeTab.set('lookup-import');
+      this.indexerImportError.set(`This contract link targets unsupported network "${requestedNetwork}".`);
+      return;
+    }
+
+    this.activeTab.set('lookup-import');
+    this.indexerImportQuery = contractId;
+    await this.lookupIndexerImport();
+
+    const preview = this.indexerImportPreview();
+    if (!preview) return;
+
+    await this.loadContracts();
+    const existing = this.findDashboardEntryForPreview(preview);
+    if (existing) {
+      this.activeTab.set('my-contracts');
+      await this.openContractDetail(existing);
+    }
+  }
+
+  private findDashboardEntryForPreview(preview: IndexerImportPreview): ContractDashboardEntry | undefined {
+    return this.dashboardContracts().find((entry) =>
+      entry.covenantId === preview.covenantId ||
+      entry.scriptHash === preview.action.scriptHashHex ||
+      entry.deployTxid === preview.deployTxid ||
+      entry.currentAddress === preview.contractAddress,
+    );
+  }
+
+  private async resolveIndexerImportQuery(query: string): Promise<{
+    action: IndexerCovenantAction;
+    actions: IndexerCovenantAction[];
+    covenant?: IndexerCovenantDetails;
+  }> {
+    const isHexIdentifier = /^[0-9a-fA-F]{64}$/.test(query);
+    if (isHexIdentifier) {
+      try {
+        return await this.fetchIndexerCovenant(query);
+      } catch {
+        // Fall through to search/list fallback; the input may be indexed only
+        // through a newer canonical/script-hash/search path.
+      }
+    }
+
+    // `/covenants?q=` is the broad import fallback for covenant addresses and
+    // fuzzy user input. `/explorer/search` can return template/category hits
+    // that are not importable by themselves.
+    const rows = await this.covenantIndexerService.listCovenants({ q: query, sort: 'recent', limit: 10 });
+    const row = rows.find((item) => this.supportedIndexerTemplates.includes(this.getIndexerTemplateName(item)));
+    const identifier = row?.covenantIdHex || row?.scriptHashHex || row?.genesisTxidHex;
+    if (identifier) {
+      return await this.fetchIndexerCovenant(identifier);
+    }
+
+    const searchResults = await this.covenantIndexerService.search(query, 10);
+    const concrete = searchResults.find((result) =>
+      (result.kind === 'covenant' || result.kind === 'transaction') &&
+      !!result.id &&
+      /^[0-9a-fA-F]{64}$/.test(result.id),
+    );
+    if (concrete?.id) {
+      return await this.fetchIndexerCovenant(concrete.id);
+    }
+
+    throw new Error('No importable wallet-supported covenant found for that query.');
   }
 
   /**
@@ -409,6 +494,7 @@ export class ContractsPageComponent implements OnInit {
     this.templateError.set(null);
     this.deployError.set(null);
     this.deployResult.set(null);
+    this.deployIndexerState.set(null);
     this.deployContractTouched = false;
     this.deployContractError.set('');
     this.validateDeployAmount(false);
@@ -420,6 +506,7 @@ export class ContractsPageComponent implements OnInit {
     this.templateError.set(null);
     this.deployError.set(null);
     this.deployResult.set(null);
+    this.deployIndexerState.set(null);
     this.deployContractTouched = false;
     this.deployContractError.set('');
     this.templateFieldTouched = {};
@@ -499,6 +586,7 @@ export class ContractsPageComponent implements OnInit {
   async deployTemplateContract() {
     this.deployError.set(null);
     this.deployResult.set(null);
+    this.deployIndexerState.set(null);
     this.templateError.set(null);
 
     if (!this.validateAllTemplateFields(true) || !this.validateDeployAmount(true)) {
@@ -1085,7 +1173,7 @@ export class ContractsPageComponent implements OnInit {
 
     try {
       const [response, actions, utxos] = await Promise.all([
-        this.covenantIndexerService.getCovenant(identifier),
+        this.fetchIndexerCovenantByIdOrHash(identifier),
         this.covenantIndexerService.getCovenantActions(identifier),
         this.covenantIndexerService.getCovenantUtxos(identifier),
       ]);
@@ -1165,14 +1253,14 @@ export class ContractsPageComponent implements OnInit {
     this.indexerImportError.set(null);
     this.indexerImportPreview.set(null);
 
-    if (!/^[0-9a-fA-F]{64}$/.test(query)) {
-      this.indexerImportError.set('Enter a 64-character deploy transaction ID or covenant ID.');
+    if (!query) {
+      this.indexerImportError.set('Enter a covenant ID, script hash, transaction ID, contract address, or share-link value.');
       return;
     }
 
     try {
       this.indexerImportLoading.set(true);
-      const response = await this.fetchIndexerCovenant(query);
+      const response = await this.resolveIndexerImportQuery(query);
       const preview = await this.buildIndexerImportPreview(response);
       this.indexerImportPreview.set(preview);
     } catch (error: any) {
@@ -1242,7 +1330,7 @@ export class ContractsPageComponent implements OnInit {
     covenant?: IndexerCovenantDetails;
   }> {
     try {
-      const byCovenant = await this.covenantIndexerService.getCovenant(identifier);
+      const byCovenant = await this.fetchIndexerCovenantByIdOrHash(identifier);
       const deployAction = (byCovenant.actions || []).find((action) => action.action === 'deploy') || byCovenant.actions?.[0];
       if (deployAction) {
         return await this.resolveLatestIndexerCovenant({
@@ -1263,7 +1351,7 @@ export class ContractsPageComponent implements OnInit {
 
     if (deployAction.covenantIdHex) {
       try {
-        const byCovenant = await this.covenantIndexerService.getCovenant(deployAction.covenantIdHex);
+        const byCovenant = await this.fetchIndexerCovenantByIdOrHash(deployAction.covenantIdHex);
         const canonicalDeploy = (byCovenant.actions || []).find((action) => action.action === 'deploy') || deployAction;
         return await this.resolveLatestIndexerCovenant({
           action: canonicalDeploy,
@@ -1276,6 +1364,14 @@ export class ContractsPageComponent implements OnInit {
     }
 
     return { action: deployAction, actions: byTx };
+  }
+
+  private async fetchIndexerCovenantByIdOrHash(identifier: string): Promise<IndexerCovenantResponse> {
+    try {
+      return await this.covenantIndexerService.getCovenantByCanonicalId(identifier);
+    } catch {
+      return await this.covenantIndexerService.getCovenant(identifier);
+    }
   }
 
   private async resolveLatestIndexerCovenant(response: {
@@ -1294,7 +1390,7 @@ export class ContractsPageComponent implements OnInit {
     }
 
     try {
-      const latest = await this.covenantIndexerService.getCovenant(latestScriptHash);
+      const latest = await this.fetchIndexerCovenantByIdOrHash(latestScriptHash);
       const latestDeploy = (latest.actions || []).find((action) => action.action === 'deploy') || latest.actions?.[0];
       if (latestDeploy && (latest.covenant?.claimedTemplate || latest.covenant?.claimedArgs?.tmpl)) {
         return {
@@ -1559,6 +1655,7 @@ export class ContractsPageComponent implements OnInit {
   async deployContract() {
     this.deployError.set(null);
     this.deployResult.set(null);
+    this.deployIndexerState.set(null);
 
     const wallet = this.selectedAccount();
     if (!wallet) {
@@ -1632,15 +1729,18 @@ export class ContractsPageComponent implements OnInit {
       this.deployResult.set({
         address: result.contractAddress,
         txid: result.txid,
+        covenantId: result.covenantId,
       });
 
       try {
         this.registryService.addContract(entry);
+        void this.trackDeployIndexing(result.txid, entry.id, result.covenantId);
       } catch (e) {
         console.error('[Deploy] Contract deployed but failed to save to registry:', e);
         this.deployError.set(
           `Contract deployed (txid ${result.txid}), but saving it locally failed. Record the outpoint to interact later: ${result.outpoint.txid}:${result.outpoint.vout}.`,
         );
+        void this.trackDeployIndexing(result.txid, undefined, result.covenantId);
       }
     } catch (error: any) {
       console.error('[Deploy] Failed:', error);
@@ -1648,6 +1748,63 @@ export class ContractsPageComponent implements OnInit {
     } finally {
       this.isDeploying.set(false);
     }
+  }
+
+  private async trackDeployIndexing(txid: string, registryEntryId?: string, initialCovenantId?: string) {
+    this.deployIndexerState.set({
+      txid,
+      status: 'checking',
+      covenantId: initialCovenantId,
+      message: 'Waiting for the indexer to see this deployment...',
+    });
+
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      try {
+        const status = await this.covenantIndexerService.getTransactionSettlementStatus(txid);
+        const actions = status.actions || [];
+        const indexedCovenantId = initialCovenantId || actions.find((action) => action.covenantIdHex)?.covenantIdHex;
+
+        if (status.indexed) {
+          if (registryEntryId && indexedCovenantId) {
+            this.registryService.updateContract(registryEntryId, { covenantId: indexedCovenantId });
+          }
+          this.deployResult.update((current) => current ? { ...current, covenantId: indexedCovenantId } : current);
+          this.deployIndexerState.set({
+            txid,
+            status: 'indexed',
+            covenantId: indexedCovenantId,
+            message: 'Indexed. This contract can now be shared and tracked from My Contracts.',
+          });
+          await this.loadContracts();
+          return;
+        }
+
+        this.deployIndexerState.set({
+          txid,
+          status: 'checking',
+          covenantId: indexedCovenantId,
+          message: `Waiting for indexer confirmation (${attempt}/8)...`,
+        });
+      } catch (error: any) {
+        console.warn('[Contracts] Deploy indexing check failed:', error);
+        this.deployIndexerState.set({
+          txid,
+          status: 'unavailable',
+          covenantId: initialCovenantId,
+          message: error?.message || 'Indexer status is unavailable. The deployment tx was still returned by the wallet.',
+        });
+        return;
+      }
+
+      await this.delay(2500);
+    }
+
+    this.deployIndexerState.set({
+      txid,
+      status: 'not-indexed',
+      covenantId: initialCovenantId,
+      message: 'Deployment broadcasted, but the indexer has not confirmed it yet. Refresh My Contracts in a moment.',
+    });
   }
 
   /**
@@ -2275,7 +2432,7 @@ export class ContractsPageComponent implements OnInit {
   }
 
   copyContractShareLink(contract: ContractDashboardEntry) {
-    const id = contract.covenantId || contract.scriptHash;
+    const id = contract.covenantId;
     if (!id) return;
 
     // Share links intentionally carry only public lookup state. The receiving
@@ -2287,6 +2444,23 @@ export class ContractsPageComponent implements OnInit {
       () => alert('Contract share link copied.'),
       () => prompt('Copy this contract link:', url.toString()),
     );
+  }
+
+  copyDeployedContractShareLink() {
+    const id = this.deployIndexerState()?.covenantId || this.deployResult()?.covenantId;
+    if (!id) return;
+
+    const url = new URL(window.location.origin + '/app/contracts');
+    url.searchParams.set('network', this.network());
+    url.searchParams.set('contract', id);
+    navigator.clipboard.writeText(url.toString()).then(
+      () => alert('Contract share link copied.'),
+      () => prompt('Copy this contract link:', url.toString()),
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private fieldToCtorArg(field: TemplateField, rawValue: string | number | undefined): CtorArg {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1203,9 +1203,11 @@ export class ContractsPageComponent implements OnInit {
       return;
     }
 
+    this.dashboardError.set(null);
+
     const identifier = entry.covenantId || entry.scriptHash;
     if (!identifier) {
-      this.selectedDetailError.set('This contract cannot be opened for actions until it has an indexer covenant id or script hash.');
+      this.dashboardError.set('This contract cannot be opened for actions until it has an indexer covenant id or script hash.');
       return;
     }
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1229,9 +1229,8 @@ export class ContractsPageComponent implements OnInit {
         this.selectDefaultFunctionForContract(entry.contractName);
       }
     } catch (error: any) {
-      this.selectedDetailError.set(error?.message || 'Import this contract before using wallet actions.');
+      this.dashboardError.set(error?.message || 'Import this contract before using wallet actions.');
     } finally {
-      this.selectedDetailLoading.set(false);
     }
   }
 

--- a/src/app/v2/pages/app/logged.routes.ts
+++ b/src/app/v2/pages/app/logged.routes.ts
@@ -41,6 +41,12 @@ export const loggedRoutes: Routes = [
         data: { animation: 'Activity' },
       },
       {
+        path: 'contracts/:contractId',
+        canActivate: [DevelopGuard],
+        component: ContractsPageComponent,
+        data: { animation: 'Contracts' },
+      },
+      {
         path: 'contracts',
         canActivate: [DevelopGuard],
         component: ContractsPageComponent,


### PR DESCRIPTION
## Summary

- Expands the covenant indexer client to cover wallet contract tracking endpoints: list/detail, canonical ID lookup, actions, UTXOs, address events, tx settlement status, and explorer search.
- Reworks the Contracts `My Contracts` tab to prefer indexer-backed wallet tracking via `/covenants?wallet=...`, while preserving local registry entries as fallback/cache.
- Adds a current-state detail panel with active UTXOs, action timeline, share links, source badges, and role-aware next-action labels for the four v1 templates.
- Completes the next functional gaps: share-link receive flow, broader import lookup by ID/tx/address/search, post-deploy indexer confirmation, and canonical-ID share links.
- Adds `docs/contracts-indexer-product-plan.md` with the Claude Design brief and `docs/kcw-contracts-ticket-updates.md` with the exact KCW ticket refinements.

## Jira

- Updated KCW-77 through KCW-84 descriptions directly in Jira with endpoint-aware acceptance criteria.
- Added a reference comment to each ticket linking back to this PR and the repo handoff doc.

## Notes for review

- This is functional/data-flow wiring, not a final visual design pass.
- Comments in the component explain why `/covenants?wallet=` is used instead of address-only covenant lookup and why local registry entries are merged.
- Share links carry only `network` and canonical covenant ID. Receiving wallets preview the import, and already-tracked contracts open their existing detail instead of duplicating local registry state.
- Existing manual/advanced interaction flow is left in place; indexer-only cards import into that flow before action execution.

## Validation

- Live TN10 probes confirmed `/explorer/search`, `/covenants?q=`, `/covenants/by-id/{id}`, `/covenants/{id}`, and `/tx/{txid}/settlement-status` response shapes.
- Jira read-back confirmed KCW-77 through KCW-84 were updated and each has the PR/reference comment.
- `npm run build:dev` passes.
- Build still emits pre-existing duplicate-member warnings from `public/kaspa/kaspa.js`.