### PR TITLE
2/9 - Upgrade Angular 20 -> 21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,17 @@
       "name": "wallet-front-new",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "^20.3.26",
+        "@angular/animations": "^21.2.18",
         "@angular/cdk": "^20.2.14",
-        "@angular/common": "^20.3.26",
-        "@angular/compiler": "^20.3.26",
-        "@angular/core": "^20.3.26",
-        "@angular/forms": "^20.3.26",
-        "@angular/platform-browser": "^20.3.26",
-        "@angular/platform-browser-dynamic": "^20.3.26",
-        "@angular/platform-server": "^20.3.26",
-        "@angular/router": "^20.3.26",
-        "@angular/ssr": "^20.3.32",
+        "@angular/common": "^21.2.18",
+        "@angular/compiler": "^21.2.18",
+        "@angular/core": "^21.2.18",
+        "@angular/forms": "^21.2.18",
+        "@angular/platform-browser": "^21.2.18",
+        "@angular/platform-browser-dynamic": "^21.2.18",
+        "@angular/platform-server": "^21.2.18",
+        "@angular/router": "^21.2.18",
+        "@angular/ssr": "^21.2.19",
         "@kaspacom/swap-sdk": "^1.1.26",
         "@kaspacom/ui": "^1.0.51",
         "@kaspacom/wallet-messages": "^1.0.35",
@@ -39,9 +39,9 @@
         "zone.js": "~0.15.1"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^20.3.32",
-        "@angular/cli": "^20.3.32",
-        "@angular/compiler-cli": "^20.3.26",
+        "@angular-devkit/build-angular": "^21.2.19",
+        "@angular/cli": "^21.2.19",
+        "@angular/compiler-cli": "^21.2.18",
         "@playwright/test": "^1.48.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
@@ -58,7 +58,7 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "npm": "^10.9.1",
         "prettier": "^3.5.3",
-        "typescript": "~5.8.3"
+        "typescript": "~5.9.3"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.45.1"
@@ -71,57 +71,57 @@
       "license": "MIT"
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.1.0.tgz",
-      "integrity": "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.14.1.tgz",
+      "integrity": "sha512-Dkj0BgPiLAaim9sbQ97UKDFHJE/880wgStAM18U++NaJ/2Cws34J5731ovJifr6E3Pv4T2CqvMXf8qLCC417Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.35.0.tgz",
-      "integrity": "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.48.1.tgz",
+      "integrity": "sha512-LV5qCJdj+/m9I+Aj91o+glYszrzd7CX6NgKaYdTOj4+tUYfbS62pwYgUfZprYNayhkQpVFcrW8x8ZlIHpS23Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.35.0.tgz",
-      "integrity": "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.48.1.tgz",
+      "integrity": "sha512-/AVoMqHhPm14CcHq7mwB+bUJbfCv+jrxlNvRjXAuO+TQa+V37N8k1b0ijaRBPdmSjULMd8KtJbQyUyabXOu6Kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.35.0.tgz",
-      "integrity": "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.48.1.tgz",
+      "integrity": "sha512-VXO+qu2Ep6ota28ktvBm3sG53wUHS2n7bgLWmce5jTskdlCD0/JrV4tnBm1l7qpla1CeoQb8D7ShFhad+UoSOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -129,151 +129,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.35.0.tgz",
-      "integrity": "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.48.1.tgz",
+      "integrity": "sha512-zl+Qyb0nLg+Y5YvKp1Ij+u9OaPaKg2/EPzTwKNiVyOHnQJlFxmXyUZL1EInczAZsEY8hVpPCLtNfhMhfxluXKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.35.0.tgz",
-      "integrity": "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.48.1.tgz",
+      "integrity": "sha512-r89Qf9Oo9mKWQXumRu/1LtvVJAmEDpn8mHZMc485pRfQUMAwSSrsnaw1tQ3sszqzEgAr1c7rw6fjBI+zrAXTOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.35.0.tgz",
-      "integrity": "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.48.1.tgz",
+      "integrity": "sha512-TPKNPKfghKG/bMSc7mQYD9HxHRUkBZA4q1PEmHgICaSeHQscGqL4wBrKkhfPlDV1uYBKW02pbFMUhsOt7p4ZpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.35.0.tgz",
-      "integrity": "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.48.1.tgz",
+      "integrity": "sha512-4Fu7dnzQyQmMFknYwTiN/HxPbH4DyxvQ1m+IxpPp5oslOgz8m6PG5qhiGbqJzH4HiT1I58ecDiCAC716UyVA8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.35.0.tgz",
-      "integrity": "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.48.1.tgz",
+      "integrity": "sha512-/RFq3TqtXDUUawwic/A9xylA2P3LDMO8dNhphHAUOU51b1ZLHrmZ6YYJm3df1APz7xLY1aht6okCQf+/vmrV9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.35.0.tgz",
-      "integrity": "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.48.1.tgz",
+      "integrity": "sha512-Of0jTeAZRyRhC7XzDSjJef0aBkgRcvRAaw0ooYRlOw57APii7lZdq+layuNdeL72BRq1snaJhoMMwkmLIpJScw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.35.0.tgz",
-      "integrity": "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.48.1.tgz",
+      "integrity": "sha512-bE7JcpFXzxF5zHwj/vkl2eiCBvyR1zQ7aoUdO+GDXxGp0DGw7nI0p8Xj6u8VmRQ+RDuPcICFQcCwRIJT5tDJFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/client-common": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.35.0.tgz",
-      "integrity": "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.48.1.tgz",
+      "integrity": "sha512-MK3wZ2koLDnvH/AmqIF1EKbJlhRS5j74OZGkLpxI4rYvNi9Jn/C7vb5DytBnQ4KUWts7QsmbdwHkxY5txQHXVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0"
+        "@algolia/client-common": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.35.0.tgz",
-      "integrity": "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.48.1.tgz",
+      "integrity": "sha512-2oDT43Y5HWRSIQMPQI4tA/W+TN/N2tjggZCUsqQV440kxzzoPGsvv9QP1GhQ4CoDa+yn6ygUsGp6Dr+a9sPPSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0"
+        "@algolia/client-common": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.35.0.tgz",
-      "integrity": "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.48.1.tgz",
+      "integrity": "sha512-xcaCqbhupVWhuBP1nwbk1XNvwrGljozutEiLx06mvqDf3o8cHyEgQSHS4fKJM+UAggaWVnnFW+Nne5aQ8SUJXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.35.0"
+        "@algolia/client-common": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -294,14 +294,17 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2003.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.32.tgz",
-      "integrity": "sha512-V5d531w97LENARKdYk5Km0F2rt8NPEL3rXUQk7+gbo9r/jgLWn9GU3VHQ30oBWXnU7Vu00Hdp/8yFeYgpWqSow==",
+      "version": "0.2102.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.19.tgz",
+      "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.32",
+        "@angular-devkit/core": "21.2.19",
         "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -310,63 +313,63 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.32.tgz",
-      "integrity": "sha512-1prN/HmTkL2TTd4zoNz/fFOds9eUc78winkjvBRxTL+OuUQMIeWIjpUui53mk2qdeW9ImiITcqCQVpZL95fLvQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.19.tgz",
+      "integrity": "sha512-AlPZT9E7+1gp4TJ4CK8Kefsyo2dx8riREjDTyAYe4++BeWRIjxsaypgHgTZER3CtkugLXr0wknvsCw4i+A3qSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.32",
-        "@angular-devkit/build-webpack": "0.2003.32",
-        "@angular-devkit/core": "20.3.32",
-        "@angular/build": "20.3.32",
+        "@angular-devkit/architect": "0.2102.19",
+        "@angular-devkit/build-webpack": "0.2102.19",
+        "@angular-devkit/core": "21.2.19",
+        "@angular/build": "21.2.19",
         "@babel/core": "7.29.7",
-        "@babel/generator": "7.28.3",
+        "@babel/generator": "7.29.1",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "7.28.0",
-        "@babel/plugin-transform-async-to-generator": "7.27.1",
-        "@babel/plugin-transform-runtime": "7.28.3",
-        "@babel/preset-env": "7.28.3",
-        "@babel/runtime": "7.28.3",
+        "@babel/plugin-transform-async-generator-functions": "7.29.0",
+        "@babel/plugin-transform-async-to-generator": "7.28.6",
+        "@babel/plugin-transform-runtime": "7.29.0",
+        "@babel/preset-env": "7.29.2",
+        "@babel/runtime": "7.29.2",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "20.3.32",
+        "@ngtools/webpack": "21.2.19",
         "ansi-colors": "4.1.3",
-        "autoprefixer": "10.4.21",
+        "autoprefixer": "10.4.27",
         "babel-loader": "10.0.0",
-        "browserslist": "^4.21.5",
+        "browserslist": "^4.26.0",
         "copy-webpack-plugin": "14.0.0",
-        "css-loader": "7.1.2",
+        "css-loader": "7.1.3",
         "esbuild-wasm": "0.28.1",
-        "fast-glob": "3.3.3",
         "http-proxy-middleware": "3.0.7",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
         "karma-source-map-support": "1.4.0",
-        "less": "4.4.0",
-        "less-loader": "12.3.0",
+        "less": "4.4.2",
+        "less-loader": "12.3.1",
         "license-webpack-plugin": "4.0.2",
         "loader-utils": "3.3.1",
-        "mini-css-extract-plugin": "2.9.4",
-        "open": "10.2.0",
-        "ora": "8.2.0",
+        "mini-css-extract-plugin": "2.10.0",
+        "open": "11.0.0",
+        "ora": "9.3.0",
         "picomatch": "4.0.4",
         "piscina": "5.2.0",
         "postcss": "8.5.12",
-        "postcss-loader": "8.1.1",
+        "postcss-loader": "8.2.0",
         "resolve-url-loader": "5.0.0",
         "rxjs": "7.8.2",
-        "sass": "1.90.0",
-        "sass-loader": "16.0.5",
-        "semver": "7.7.2",
+        "sass": "1.97.3",
+        "sass-loader": "16.0.7",
+        "semver": "7.7.4",
         "source-map-loader": "5.0.0",
         "source-map-support": "0.5.21",
-        "terser": "5.43.1",
+        "terser": "5.46.0",
+        "tinyglobby": "0.2.15",
         "tree-kill": "1.2.2",
         "tslib": "2.8.1",
-        "webpack": "5.105.0",
-        "webpack-dev-middleware": "7.4.2",
+        "webpack": "5.105.2",
+        "webpack-dev-middleware": "7.4.5",
         "webpack-dev-server": "5.2.5",
         "webpack-merge": "6.0.1",
         "webpack-subresource-integrity": "5.1.0"
@@ -380,22 +383,22 @@
         "esbuild": "0.28.1"
       },
       "peerDependencies": {
-        "@angular/compiler-cli": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/localize": "^20.0.0",
-        "@angular/platform-browser": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.32",
+        "@angular/compiler-cli": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/localize": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/platform-server": "^21.0.0",
+        "@angular/service-worker": "^21.0.0",
+        "@angular/ssr": "^21.2.19",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
-        "jest": "^29.5.0 || ^30.2.0",
-        "jest-environment-jsdom": "^29.5.0 || ^30.2.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
         "karma": "^6.3.0",
-        "ng-packagr": "^20.0.0",
+        "ng-packagr": "^21.0.0",
         "protractor": "^7.0.0",
         "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "typescript": ">=5.8 <6.0"
+        "typescript": ">=5.9 <6.0"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -442,14 +445,65 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2003.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.32.tgz",
-      "integrity": "sha512-dFyM5Qkgl6wgSb8EJF8uZCt9K+VUsDP8APS5siCNHyhjzjACqDevk5RwqWCfPU/QjzlgCp11MbkKr/Y2sgaDcw==",
+    "node_modules/@angular-devkit/build-angular/node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.32",
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack": {
+      "version": "0.2102.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.19.tgz",
+      "integrity": "sha512-T8omQt2QSbNOCTPvOJkt7zg9EtaFt1x6ZiJaqZrq/GK729dD/RGYF0hZqi2AeAE7OMyutFhrDREr2WrNqv1nWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": "0.2102.19",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -463,9 +517,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.32.tgz",
-      "integrity": "sha512-pXipSsYP/XTEAljmwqgy1u3GR/ZzSMg1FERINekGT61Th1pGhzjs02rPgbyftqz2e5/tfQ6XgTP7xYzm3+S35Q==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -482,7 +536,7 @@
         "yarn": ">= 1.13.0"
       },
       "peerDependencies": {
-        "chokidar": "^4.0.0"
+        "chokidar": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "chokidar": {
@@ -491,16 +545,16 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.32.tgz",
-      "integrity": "sha512-UxWncmJTcYMDEaAKRi3QHU3qXivIcIOulFOKozW8svfs/A43Oq1GG4kvDZ+WVf/w2UWTmMaSlfFa4KIQciSIDA==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.19.tgz",
+      "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.32",
+        "@angular-devkit/core": "21.2.19",
         "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.17",
-        "ora": "8.2.0",
+        "magic-string": "0.30.21",
+        "ora": "9.3.0",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -510,9 +564,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.26.tgz",
-      "integrity": "sha512-hfNrX19v8xs/usNkELSqc6q5IwBfS2GGW8sQ4OMpxAmLZDJwaLUxkj48t8VYhUFezsIfzR+sDEi6ZQBOaMIYug==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
+      "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -521,42 +575,43 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.26"
+        "@angular/core": "21.2.18"
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.32.tgz",
-      "integrity": "sha512-ph/qcT6C7RYriU5dxXfNrYBEvCwU4acxTNoxkdGQHYxM7iOKT0K1YO6v5JBNRZ1S4LOJhWmGaWzJ+sRei0iGsQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.19.tgz",
+      "integrity": "sha512-emy9mqrTXAwhZzcvx8MaHyz+cUR06PVGxnqy91+bpDxPP9S5x67sPoOkY9y/ETFFhRpB5ULlUxyq0eN/pi6QOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.32",
+        "@angular-devkit/architect": "0.2102.19",
         "@babel/core": "7.29.7",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
-        "@inquirer/confirm": "5.1.14",
-        "@vitejs/plugin-basic-ssl": "2.1.0",
-        "beasties": "0.3.5",
-        "browserslist": "^4.23.0",
+        "@inquirer/confirm": "5.1.21",
+        "@vitejs/plugin-basic-ssl": "2.1.4",
+        "beasties": "0.4.1",
+        "browserslist": "^4.26.0",
         "esbuild": "0.28.1",
         "https-proxy-agent": "7.0.6",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
-        "listr2": "9.0.1",
-        "magic-string": "0.30.17",
+        "listr2": "9.0.5",
+        "magic-string": "0.30.21",
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.0",
         "picomatch": "4.0.4",
         "piscina": "5.2.0",
-        "rollup": "4.59.0",
-        "sass": "1.90.0",
-        "semver": "7.7.2",
+        "rolldown": "1.0.0-rc.4",
+        "sass": "1.97.3",
+        "semver": "7.7.4",
         "source-map-support": "0.5.21",
-        "tinyglobby": "0.2.14",
+        "tinyglobby": "0.2.15",
+        "undici": "7.28.0",
         "vite": "7.3.6",
-        "watchpack": "2.4.4"
+        "watchpack": "2.5.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -564,25 +619,25 @@
         "yarn": ">= 1.13.0"
       },
       "optionalDependencies": {
-        "lmdb": "3.4.2"
+        "lmdb": "3.5.1"
       },
       "peerDependencies": {
-        "@angular/compiler": "^20.0.0",
-        "@angular/compiler-cli": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/localize": "^20.0.0",
-        "@angular/platform-browser": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.32",
+        "@angular/compiler": "^21.0.0",
+        "@angular/compiler-cli": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/localize": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/platform-server": "^21.0.0",
+        "@angular/service-worker": "^21.0.0",
+        "@angular/ssr": "^21.2.19",
         "karma": "^6.4.0",
         "less": "^4.2.0",
-        "ng-packagr": "^20.0.0",
+        "ng-packagr": "^21.0.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
         "tslib": "^2.3.0",
-        "typescript": ">=5.8 <6.0",
-        "vitest": "^3.1.1"
+        "typescript": ">=5.9 <6.0",
+        "vitest": "^4.0.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -623,6 +678,29 @@
         }
       }
     },
+    "node_modules/@angular/build/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular/build/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@angular/cdk": {
       "version": "20.2.14",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.14.tgz",
@@ -639,30 +717,30 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.32.tgz",
-      "integrity": "sha512-WIMbTrEJYVVz4Phs8nn6yK/bzCSt1dDlxtAEnS2melTWXKGF6WK/OqVaH0+Cox0SNagA81dvvSbGlFYCxncYfQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.19.tgz",
+      "integrity": "sha512-i78NzvoNonAY17QgzSmqrYnXHmEfraLv4wZ/o/m3efxuz61ZJ+5X/PsCeAhbwBvQfRrPRQaJV2tK9vGjHa+U6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.32",
-        "@angular-devkit/core": "20.3.32",
-        "@angular-devkit/schematics": "20.3.32",
-        "@inquirer/prompts": "7.8.2",
-        "@listr2/prompt-adapter-inquirer": "3.0.1",
+        "@angular-devkit/architect": "0.2102.19",
+        "@angular-devkit/core": "21.2.19",
+        "@angular-devkit/schematics": "21.2.19",
+        "@inquirer/prompts": "7.10.1",
+        "@listr2/prompt-adapter-inquirer": "3.0.5",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "20.3.32",
+        "@schematics/angular": "21.2.19",
         "@yarnpkg/lockfile": "1.1.0",
-        "algoliasearch": "5.35.0",
-        "ini": "5.0.0",
+        "algoliasearch": "5.48.1",
+        "ini": "6.0.0",
         "jsonc-parser": "3.3.1",
-        "listr2": "9.0.1",
-        "npm-package-arg": "13.0.0",
+        "listr2": "9.0.5",
+        "npm-package-arg": "13.0.2",
         "pacote": "21.5.1",
-        "resolve": "1.22.10",
-        "semver": "7.7.2",
+        "parse5-html-rewriting-stream": "8.0.0",
+        "semver": "7.7.4",
         "yargs": "18.0.0",
-        "zod": "4.1.13"
+        "zod": "4.3.6"
       },
       "bin": {
         "ng": "bin/ng.js"
@@ -673,10 +751,23 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular/cli/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular/common": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.26.tgz",
-      "integrity": "sha512-35+aHaCmldFZ2qFiH83+cHcDXwUqSEuUR5DVApcd+Ku8PfIIGo8uMiD5++Qq7QIUTbZCD2glAiE9jLroGrf1Cw==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.18.tgz",
+      "integrity": "sha512-gZugZ8gX/KkACIZ3/ekoImLu5z8a0Iu9O5b84kh8e+++VUjmkmd19IygBsq/8/fF3vKf0UcIKcx3P6A/gb2DJw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -685,14 +776,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.26",
+        "@angular/core": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.26.tgz",
-      "integrity": "sha512-H4DVTBCiyM4dGytFi2C8sMGflxXzPnoQ6Ajfs4hJ/Dekg6ypfvW5Ze7BDh4TaMQvaX2joM5LhBYW5jTxBx66hA==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.18.tgz",
+      "integrity": "sha512-ccnDuKLuzIa0ayijR+alarsHNWIksuGV/lxGTZ0t6/0+B6J/RXupz6M2IO6ZHHEcg8r7pcrLCUBTyp3FoiRJrg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -702,15 +793,15 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.26.tgz",
-      "integrity": "sha512-3rHtC87ecldvaiFHwQEZ6Wx3QaZ/Q7b0Gb7XORDOjn/M+5CYZ4rQsvbxE5TUjwreg07oQ4Y2h8ADESXTJEUYOQ==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.18.tgz",
+      "integrity": "sha512-L5zbIp7YfTTB4I4xT33FgEBanzhppNejzZX0HJOEqKDyDL2jXq+flt83lE0XVuRJ6/zrG+UKj0B+y/CK6Ro7Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.29.7",
         "@jridgewell/sourcemap-codec": "^1.4.14",
-        "chokidar": "^4.0.0",
+        "chokidar": "^5.0.0",
         "convert-source-map": "^1.5.1",
         "reflect-metadata": "^0.2.0",
         "semver": "^7.0.0",
@@ -725,8 +816,8 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.26",
-        "typescript": ">=5.8 <6.0"
+        "@angular/compiler": "21.2.18",
+        "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -735,9 +826,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.26.tgz",
-      "integrity": "sha512-v+YtZ9eQVDb6v3V1TbUUBHU63FEp8Hqqqb3UhM4MLAOm0chyyh9jah7FiHr3HbCKrV1f4long1coftFK/KThog==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.18.tgz",
+      "integrity": "sha512-AG4bb6GU0+qp+vVBjc/IhSPjgcRX8QsCb8jzN8dDyhnjsyuuG/LlIiU0l6n65BI9SGKE9m6TfsJ1ObkkAiE5KQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -746,9 +837,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.26",
+        "@angular/compiler": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.15.0"
+        "zone.js": "~0.15.0 || ~0.16.0"
       },
       "peerDependenciesMeta": {
         "@angular/compiler": {
@@ -760,27 +851,28 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.26.tgz",
-      "integrity": "sha512-ia0YaPVjlG2oBFKCfaAgqQ0jGRrhGTAcrbZG3tVeFDpi7LQ6WdP3Syw2H+0D3GPyzpl/5UqU10Fum5Wr1br4QQ==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.18.tgz",
+      "integrity": "sha512-TrRuiNjIzrrNtQgpJVH5gultQrvBlawa+tTzIpxBfIqLpkHrTPZLtYu118EUk6jhWzgRhKYUorInjJe+sSxC+w==",
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.26",
-        "@angular/core": "20.3.26",
-        "@angular/platform-browser": "20.3.26",
+        "@angular/common": "21.2.18",
+        "@angular/core": "21.2.18",
+        "@angular/platform-browser": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.26.tgz",
-      "integrity": "sha512-In4wUiLUUT9LqyV9Rjz78k/dsnKAwec4AtDmwZoX8/ZmeJOSH7g5X1gTM+hxTxmifmZkrapQjXR299IcfIkzrw==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.18.tgz",
+      "integrity": "sha512-zltF+3HrlgtZbYg8U98LhG0dyGm1aHT3Px8//9wjqi/TUY8UlHsYKByL197QtVWDBjf/dekzXdz5c+iyVtanLQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -789,9 +881,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "20.3.26",
-        "@angular/common": "20.3.26",
-        "@angular/core": "20.3.26"
+        "@angular/animations": "21.2.18",
+        "@angular/common": "21.2.18",
+        "@angular/core": "21.2.18"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -800,9 +892,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.26.tgz",
-      "integrity": "sha512-/9eq0GGmtMoBV5UvcjvhnV4ZDcgZr15h+dzoxkZodUncb2z7fxybSyha7wWD9aTeabZ/q/KYVUSnoYqVyBhbVQ==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.18.tgz",
+      "integrity": "sha512-doTDss6GhDTGjVuuANlzFrdYKBqHQVlWgy2tiTjy9EbrmMTOOHg0D6yUQXh1ZqmUWKDZ3owkUjUNGiXt92rQ6w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -811,16 +903,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.26",
-        "@angular/compiler": "20.3.26",
-        "@angular/core": "20.3.26",
-        "@angular/platform-browser": "20.3.26"
+        "@angular/common": "21.2.18",
+        "@angular/compiler": "21.2.18",
+        "@angular/core": "21.2.18",
+        "@angular/platform-browser": "21.2.18"
       }
     },
     "node_modules/@angular/platform-server": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-20.3.26.tgz",
-      "integrity": "sha512-BsI17intl+3r04hrhN6wemElMzVuwROXsu6//8g1ChHuIV3qWfQp6LYEhnOCBIuooNO6/T6CylEBkql9d5GAwg==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-21.2.18.tgz",
+      "integrity": "sha512-xtnMoL24Oqc8gD1jW2CU2whps9Hwbem8szFJoFbPIKIOY63mKd235bcyOMpioLmPPIeSE3AQil+yDh9Y6qn/mQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0",
@@ -830,17 +922,17 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.26",
-        "@angular/compiler": "20.3.26",
-        "@angular/core": "20.3.26",
-        "@angular/platform-browser": "20.3.26",
+        "@angular/common": "21.2.18",
+        "@angular/compiler": "21.2.18",
+        "@angular/core": "21.2.18",
+        "@angular/platform-browser": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/router": {
-      "version": "20.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.26.tgz",
-      "integrity": "sha512-q0k0b5uuQx93Trk4qEMYe8LoPOozheRBIjze51q+LUTlLXWik4W0ughXLiTJL346KRudR/vB5ksfZP8b6WlQyA==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.18.tgz",
+      "integrity": "sha512-Xix19uG1YthC8IslhWKSfPdhscVWREBGVJZW2OnRmLef8F7DvhF49S6vOywaBo+Uahe0egkmgWDNpEwxAzsgLw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -849,25 +941,25 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.26",
-        "@angular/core": "20.3.26",
-        "@angular/platform-browser": "20.3.26",
+        "@angular/common": "21.2.18",
+        "@angular/core": "21.2.18",
+        "@angular/platform-browser": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/ssr": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-20.3.32.tgz",
-      "integrity": "sha512-2pumQJH2VQidLQD2h2uKnqUEEubFLVBwyZR8a01UBThZ9eC1vtPwKZEtUriLDfK9iSjDByA643v8LxXaWfKcig==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-21.2.19.tgz",
+      "integrity": "sha512-2Jey57S6G3W1JOo8bWF++JDTJOqNJFRDCP9F4CpcAvSilPD6kpdb3kI5wTM3FH14vec1uQtkU4W2Fd6r4BTF2g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/router": "^20.0.0"
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/platform-server": "^21.0.0",
+        "@angular/router": "^21.0.0"
       },
       "peerDependenciesMeta": {
         "@angular/platform-server": {
@@ -966,14 +1058,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -1123,28 +1215,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -1540,15 +1610,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1558,14 +1628,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-remap-async-to-generator": "^7.27.1"
       },
       "engines": {
@@ -2258,14 +2328,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
+      "integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "babel-plugin-polyfill-corejs2": "^0.4.14",
         "babel-plugin-polyfill-corejs3": "^0.13.0",
         "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -2437,81 +2507,81 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
-      "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/compat-data": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.27.1",
-        "@babel/plugin-syntax-import-attributes": "^7.27.1",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
-        "@babel/plugin-transform-async-to-generator": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.0",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.28.3",
-        "@babel/plugin-transform-classes": "^7.28.3",
-        "@babel/plugin-transform-computed-properties": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.28.0",
-        "@babel/plugin-transform-dotall-regex": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
         "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
         "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/plugin-transform-for-of": "^7.27.1",
         "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
         "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
         "@babel/plugin-transform-member-expression-literals": "^7.27.1",
         "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
         "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
         "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
         "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
         "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.27.1",
-        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.3",
-        "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.29.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
         "@babel/plugin-transform-sticky-regex": "^7.27.1",
         "@babel/plugin-transform-template-literals": "^7.27.1",
         "@babel/plugin-transform-typeof-symbol": "^7.27.1",
         "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
         "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "core-js-compat": "^3.43.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -2519,6 +2589,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
@@ -2547,9 +2631,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3358,6 +3442,14 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@harperfast/extended-iterable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@harperfast/extended-iterable/-/extended-iterable-1.0.3.tgz",
+      "integrity": "sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -3407,14 +3499,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -3602,22 +3694,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.2.tgz",
-      "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.2.1",
-        "@inquirer/confirm": "^5.1.14",
-        "@inquirer/editor": "^4.2.17",
-        "@inquirer/expand": "^4.0.17",
-        "@inquirer/input": "^4.2.1",
-        "@inquirer/number": "^3.0.17",
-        "@inquirer/password": "^4.0.17",
-        "@inquirer/rawlist": "^4.1.5",
-        "@inquirer/search": "^3.1.0",
-        "@inquirer/select": "^4.3.1"
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
       },
       "engines": {
         "node": ">=18"
@@ -4276,26 +4368,26 @@
       "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.1.tgz",
-      "integrity": "sha512-3XFmGwm3u6ioREG+ynAQB7FoxfajgQnMhIu8wC5eo/Lsih4aKDg0VuIMGaOsYn7hJSJagSeaD4K8yfpkEoDEmA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.5.tgz",
+      "integrity": "sha512-WELs+hj6xcilkloBXYf9XXK8tYEnKsgLj01Xl5ONUJpKjmT5hGVUzNUS5tooUxs7pGMrw+jFD/41WpqW4V3LDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/type": "^3.0.7"
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@inquirer/prompts": ">= 3 < 8",
-        "listr2": "9.0.1"
+        "listr2": "9.0.5"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.2.tgz",
-      "integrity": "sha512-NK80WwDoODyPaSazKbzd3NEJ3ygePrkERilZshxBViBARNz21rmediktGHExoj9n5t9+ChlgLlxecdFKLCuCKg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.1.tgz",
+      "integrity": "sha512-tpfN4kKrrMpQ+If1l8bhmoNkECJi0iOu6AEdrTJvWVC+32sLxTARX5Rsu579mPImRP9YFWfWgeRQ5oav7zApQQ==",
       "cpu": [
         "arm64"
       ],
@@ -4307,9 +4399,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.2.tgz",
-      "integrity": "sha512-zevaowQNmrp3U7Fz1s9pls5aIgpKRsKb3dZWDINtLiozh3jZI9fBrI19lYYBxqdyiIyNdlyiidPnwPShj4aK+w==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.1.tgz",
+      "integrity": "sha512-+a2tTfc3rmWhLAolFUWRgJtpSuu+Fw/yjn4rF406NMxhfjbMuiOUTDRvRlMFV+DzyjkwnokisskHbCWkS3Ly5w==",
       "cpu": [
         "x64"
       ],
@@ -4321,9 +4413,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.2.tgz",
-      "integrity": "sha512-OmHCULY17rkx/RoCoXlzU7LyR8xqrksgdYWwtYa14l/sseezZ8seKWXcogHcjulBddER5NnEFV4L/Jtr2nyxeg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.1.tgz",
+      "integrity": "sha512-0EgcE6reYr8InjD7V37EgXcYrloqpxVPINy3ig1MwDSbl6LF/vXTYRH9OE1Ti1D8YZnB35ZH9aTcdfSb5lql2A==",
       "cpu": [
         "arm"
       ],
@@ -4335,9 +4427,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.2.tgz",
-      "integrity": "sha512-ZBEfbNZdkneebvZs98Lq30jMY8V9IJzckVeigGivV7nTHJc+89Ctomp1kAIWKlwIG0ovCDrFI448GzFPORANYg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.1.tgz",
+      "integrity": "sha512-aoERa5B6ywXdyFeYGQ1gbQpkMkDbEo45qVoXE5QpIRavqjnyPwjOulMkmkypkmsbJ5z4Wi0TBztON8agCTG0Vg==",
       "cpu": [
         "arm64"
       ],
@@ -4349,9 +4441,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.2.tgz",
-      "integrity": "sha512-vL9nM17C77lohPYE4YaAQvfZCSVJSryE4fXdi8M7uWPBnU+9DJabgKVAeyDb84ZM2vcFseoBE4/AagVtJeRE7g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.1.tgz",
+      "integrity": "sha512-SqNDY1+vpji7bh0sFH5wlWyFTOzjbDOl0/kB5RLLYDAFyd/uw3n7wyrmas3rYPpAW7z18lMOi1yKlTPv967E3g==",
       "cpu": [
         "x64"
       ],
@@ -4363,9 +4455,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.2.tgz",
-      "integrity": "sha512-SXWjdBfNDze4ZPeLtYIzsIeDJDJ/SdsA0pEXcUBayUIMO0FQBHfVZZyHXQjjHr4cvOAzANBgIiqaXRwfMhzmLw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.1.tgz",
+      "integrity": "sha512-50v0O1Lt37cwrmR9vWZK5hRW0Aw+KEmxJJ75fge/zIYdvNKB/0bSMSVR5Uc2OV9JhosIUyklOmrEvavwNJ8D6w==",
       "cpu": [
         "arm64"
       ],
@@ -4377,9 +4469,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.2.tgz",
-      "integrity": "sha512-IY+r3bxKW6Q6sIPiMC0L533DEfRJSXibjSI3Ft/w9Q8KQBNqEIvUFXt+09wV8S5BRk0a8uSF19YWxuRwEfI90g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.1.tgz",
+      "integrity": "sha512-qwosvPyl+zpUlp3gRb7UcJ3H8S28XHCzkv0Y0EgQToXjQP91ZD67EHSCDmaLjtKhe+GVIW5om1KUpzVLA0l6pg==",
       "cpu": [
         "x64"
       ],
@@ -5173,10 +5265,29 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@ngtools/webpack": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.32.tgz",
-      "integrity": "sha512-a3KWNfv3NEyNHdGusIP/+lfLtjH7L5rcqgouBm6v3t1vHQ4zg2sNgoYIQIJCAJnFI2b080YrP9jh2FqKTCJlug==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.19.tgz",
+      "integrity": "sha512-CT7P2yCXIMgSldgA1HQoEtdyYuZ994nnDkPuXJXXry/qfwlHL6FN1se641ZSxdutLgHQL7GRrV+0vhpUieEd3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5185,8 +5296,8 @@
         "yarn": ">= 1.13.0"
       },
       "peerDependencies": {
-        "@angular/compiler-cli": "^20.0.0",
-        "typescript": ">=5.8 <6.0",
+        "@angular/compiler-cli": "^21.0.0",
+        "typescript": ">=5.9 <6.0",
         "webpack": "^5.54.0"
       }
     },
@@ -5212,44 +5323,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -5312,16 +5385,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/git/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@npmcli/git/node_modules/isexe": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -5340,16 +5403,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/git/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/git/node_modules/which": {
@@ -5471,16 +5524,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@npmcli/package-json/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
@@ -5547,14 +5590,14 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/run-script/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.113.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.113.0.tgz",
+      "integrity": "sha512-Tp3XmgxwNQ9pEN9vxgJBAqdRamHibi76iowQ38O2I4PMpcvNRQNVsU2n1x1nv9yh0XoTrGFzf7cZSGxmixxrhA==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -6078,10 +6121,250 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-vRq9f4NzvbdZavhQbjkJBx7rRebDKYR9zHfO/Wg486+I7bSecdUapzCm5cyXoK+LHokTxgSq7A5baAXUZkIz0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-kFgEvkWLqt3YCgKB5re9RlIrx9bRsvyVUnaTakEpOPuLGzLpLapYxE9BufJNvPg8GjT6mB1alN4yN1NjzoeM8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-JXmaOJGsL/+rsmMfutcDjxWM2fTaVgCHGoXS7nE8Z3c9NAYjGqHvXrAhMUZvMpHS/k7Mg+X7n/MVKb7NYWKKww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-ep3Catd6sPnHTM0P4hNEvIv5arnDvk01PfyJIJ+J3wVCG1eEaPo09tvFqdtcaTrkwQy0VWR24uz+cb4IsK53Qw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.4.tgz",
+      "integrity": "sha512-LwA5ayKIpnsgXJEwWc3h8wPiS33NMIHd9BhsV92T8VetVAbGe2qXlJwNVDGHN5cOQ22R9uYvbrQir2AB+ntT2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-AC1WsGdlV1MtGay/OQ4J9T7GRadVnpYRzTcygV1hKnypbYN20Yh4t6O1Sa2qRBMqv1etulUknqXjc3CTIsBu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-lU+6rgXXViO61B4EudxtVMXSOfiZONR29Sys5VGSetUY7X8mg9FCKIIjcPPj8xNDeYzKl+H8F/qSKOBVFJChCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-DZaN1f0PGp/bSvKhtw50pPsnln4T13ycDq1FrDWRiHmWt1JeW+UtYg9touPFf8yt993p8tS2QjybpzKNTxYEwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-RnGxwZLN7fhMMAItnD6dZ7lvy+TI7ba+2V54UF4dhaWa/p8I/ys1E73KO6HmPmgz92ZkfD8TXS1IMV8+uhbR9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-6lcI79+X8klGiGd8yHuTgQRjuuJYNggmEml+RsyN596P23l/zf9FVmJ7K0KVKkFAeYEdg0iMUKyIxiV5vebDNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.4.tgz",
+      "integrity": "sha512-wz7ohsKCAIWy91blZ/1FlpPdqrsm1xpcEOQVveWoL6+aSPKL4VUcoYmmzuLTssyZxRpEwzuIxL/GDsvpjaBtOw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.4.tgz",
+      "integrity": "sha512-cfiMrfuWCIgsFmcVG0IPuO6qTRHvF7NuG3wngX1RZzc6dU8FuBFb+J3MIR5WrdTNozlumfgL4cvz+R4ozBCvsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.4.tgz",
+      "integrity": "sha512-p6UeR9y7ht82AH57qwGuFYn69S6CZ7LLKdCKy/8T3zS9VTrJei2/CGsTUV45Da4Z9Rbhc7G4gyWQ/Ioamqn09g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.4.tgz",
+      "integrity": "sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -6093,9 +6376,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -6107,9 +6390,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -6121,9 +6404,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -6135,9 +6418,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -6149,9 +6432,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -6163,9 +6446,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -6180,9 +6463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -6197,9 +6480,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -6214,9 +6497,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -6231,9 +6514,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -6248,9 +6531,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -6265,9 +6548,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -6282,9 +6565,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -6299,9 +6582,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -6316,9 +6599,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -6333,9 +6616,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -6366,9 +6649,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -6383,9 +6666,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -6397,9 +6680,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -6411,9 +6694,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -6425,9 +6708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -6439,9 +6722,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -6453,9 +6736,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -6467,14 +6750,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "20.3.32",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.32.tgz",
-      "integrity": "sha512-asporFGNP/U4p/A6jHqRmC8zGBxsSbjA/17I0p1tIW4HLbDTwJ0Z1gTSGpkHGRGTeowPZZSCj7s0IWVoaBCjnA==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.19.tgz",
+      "integrity": "sha512-eL+UU9eizoadhDB4YEctRmmo0A5iwrSmGzeuEa6akrq8nLGVWM8zO91HTJutkPqGQjelF+UOiOShsQSZAU9SIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.32",
-        "@angular-devkit/schematics": "20.3.32",
+        "@angular-devkit/core": "21.2.19",
+        "@angular-devkit/schematics": "21.2.19",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6922,16 +7205,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@sigstore/tuf": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
@@ -6966,6 +7239,12 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tufjs/canonical-json": {
@@ -7029,6 +7308,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -7106,9 +7396,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7329,9 +7619,9 @@
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
-      "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.4.tgz",
+      "integrity": "sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7666,26 +7956,26 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.35.0.tgz",
-      "integrity": "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.48.1.tgz",
+      "integrity": "sha512-Rf7xmeuIo7nb6S4mp4abW2faW8DauZyE2faBIKFaUfP3wnpOvNSbiI5AwVhqBNj0jPgBWEvhyCu0sLjN2q77Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.1.0",
-        "@algolia/client-abtesting": "5.35.0",
-        "@algolia/client-analytics": "5.35.0",
-        "@algolia/client-common": "5.35.0",
-        "@algolia/client-insights": "5.35.0",
-        "@algolia/client-personalization": "5.35.0",
-        "@algolia/client-query-suggestions": "5.35.0",
-        "@algolia/client-search": "5.35.0",
-        "@algolia/ingestion": "1.35.0",
-        "@algolia/monitoring": "1.35.0",
-        "@algolia/recommend": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
+        "@algolia/abtesting": "1.14.1",
+        "@algolia/client-abtesting": "5.48.1",
+        "@algolia/client-analytics": "5.48.1",
+        "@algolia/client-common": "5.48.1",
+        "@algolia/client-insights": "5.48.1",
+        "@algolia/client-personalization": "5.48.1",
+        "@algolia/client-query-suggestions": "5.48.1",
+        "@algolia/client-search": "5.48.1",
+        "@algolia/ingestion": "1.48.1",
+        "@algolia/monitoring": "1.48.1",
+        "@algolia/recommend": "5.48.1",
+        "@algolia/requester-browser-xhr": "5.48.1",
+        "@algolia/requester-fetch": "5.48.1",
+        "@algolia/requester-node-http": "5.48.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -7825,9 +8115,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
       "dev": true,
       "funding": [
         {
@@ -7845,10 +8135,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -7969,9 +8258,9 @@
       "license": "MIT"
     },
     "node_modules/beasties": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/beasties/-/beasties-0.3.5.tgz",
-      "integrity": "sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/beasties/-/beasties-0.4.1.tgz",
+      "integrity": "sha512-2Imdcw3LznDuxAbJM26RHniOLAzE6WgrK8OuvVXCQtNBS8rsnD9zsSEa3fHl4hHpUY7BYTlrpvtPVbvu9G6neg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7982,10 +8271,11 @@
         "htmlparser2": "^10.0.0",
         "picocolors": "^1.1.1",
         "postcss": "^8.4.49",
-        "postcss-media-query-parser": "^0.2.3"
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-safe-parser": "^7.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/big.js": {
@@ -8379,16 +8669,16 @@
       "license": "MIT"
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -8431,30 +8721,47 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8892,20 +9199,20 @@
       "license": "MIT"
     },
     "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.3.tgz",
+      "integrity": "sha512-frbERmjT0UC5lMheWpJmMilnt9GEhbZJN/heUb7/zaJYeIzj5St9HvDcfshzzOqbsS+rYpMk++2SD3vGETDSyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.40",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">= 18.12.0"
@@ -9764,36 +10071,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
@@ -9810,16 +10087,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -9963,16 +10230,16 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -10649,13 +10916,13 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ip-address": {
@@ -10740,13 +11007,16 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10763,6 +11033,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-inside-container": {
@@ -11061,13 +11344,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -11601,9 +11884,9 @@
       }
     },
     "node_modules/less": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.4.0.tgz",
-      "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.4.2.tgz",
+      "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11628,9 +11911,9 @@
       }
     },
     "node_modules/less-loader": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-12.3.0.tgz",
-      "integrity": "sha512-0M6+uYulvYIWs52y0LqN4+QM9TqWAohYSNTo4htE8Z7Cn3G/qQMEmktfHmyJT23k+20kU9zHH2wrfFXkxNLtVw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-12.3.1.tgz",
+      "integrity": "sha512-JZZmG7gMzoDP3VGeEG8Sh6FW5wygB5jYL7Wp29FFihuRTsIBacqO3LbRPr2yStYD11riVf13selLm/CPFRDBRQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11641,7 +11924,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "less": "^3.5.0 || ^4.0.0",
         "webpack": "^5.0.0"
       },
@@ -11731,13 +12014,13 @@
       "license": "MIT"
     },
     "node_modules/listr2": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
-      "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^4.0.0",
+        "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
         "eventemitter3": "^5.0.1",
         "log-update": "^6.1.0",
@@ -11774,14 +12057,15 @@
       }
     },
     "node_modules/lmdb": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.4.2.tgz",
-      "integrity": "sha512-nwVGUfTBUwJKXd6lRV8pFNfnrCC1+l49ESJRM19t/tFb/97QfJEixe5DYRvug5JO7DSFKoKaVy7oGMt5rVqZvg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.1.tgz",
+      "integrity": "sha512-NYHA0MRPjvNX+vSw8Xxg6FLKxzAG+e7Pt8RqAQA/EehzHVXq9SxDqJIN3JL1hK0dweb884y8kIh6rkWvPyg9Wg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
+        "@harperfast/extended-iterable": "^1.0.3",
         "msgpackr": "^1.11.2",
         "node-addon-api": "^6.1.0",
         "node-gyp-build-optional-packages": "5.2.2",
@@ -11792,13 +12076,13 @@
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "3.4.2",
-        "@lmdb/lmdb-darwin-x64": "3.4.2",
-        "@lmdb/lmdb-linux-arm": "3.4.2",
-        "@lmdb/lmdb-linux-arm64": "3.4.2",
-        "@lmdb/lmdb-linux-x64": "3.4.2",
-        "@lmdb/lmdb-win32-arm64": "3.4.2",
-        "@lmdb/lmdb-win32-x64": "3.4.2"
+        "@lmdb/lmdb-darwin-arm64": "3.5.1",
+        "@lmdb/lmdb-darwin-x64": "3.5.1",
+        "@lmdb/lmdb-linux-arm": "3.5.1",
+        "@lmdb/lmdb-linux-arm64": "3.5.1",
+        "@lmdb/lmdb-linux-x64": "3.5.1",
+        "@lmdb/lmdb-win32-arm64": "3.5.1",
+        "@lmdb/lmdb-win32-x64": "3.5.1"
       }
     },
     "node_modules/loader-runner": {
@@ -11855,30 +12139,17 @@
       "license": "MIT"
     },
     "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11896,22 +12167,6 @@
         "slice-ansi": "^7.1.0",
         "strip-ansi": "^7.1.0",
         "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -11983,13 +12238,13 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -12040,16 +12295,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -12115,16 +12360,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -12210,9 +12445,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
+      "integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12634,16 +12869,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/node-gyp/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
@@ -12690,16 +12915,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12904,16 +13119,16 @@
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.0.tgz",
-      "integrity": "sha512-+t2etZAGcB7TbbLHfDwooV9ppB2LhhcT6A+L9cahsf9mEUAoQ6CktLEVvEnpD0N5CkX7zJqnPGaFtoQDy9EkHQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -12929,16 +13144,6 @@
         "ignore-walk": "^8.0.0",
         "proc-log": "^6.0.0"
       },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-packlist/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -12975,16 +13180,6 @@
         "npm-package-arg": "^13.0.0",
         "proc-log": "^6.0.0"
       },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -15465,24 +15660,40 @@
       }
     },
     "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
+        "chalk": "^5.6.2",
         "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
+        "cli-spinners": "^3.2.0",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15596,16 +15807,6 @@
       "bin": {
         "pacote": "bin/index.js"
       },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/pacote/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -15958,15 +16159,15 @@
       }
     },
     "node_modules/postcss-loader": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.1.1.tgz",
-      "integrity": "sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.2.0.tgz",
+      "integrity": "sha512-tHX+RkpsXVcc7st4dSdDGliI+r4aAQDuv+v3vFYHixb6YgjreG5AG4SEB0kDK8u2s6htqEEpKlkhSBUTvWKYnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^9.0.0",
-        "jiti": "^1.20.0",
-        "semver": "^7.5.4"
+        "jiti": "^2.5.1",
+        "semver": "^7.6.2"
       },
       "engines": {
         "node": ">= 18.12.0"
@@ -16059,6 +16260,33 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
@@ -16080,6 +16308,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.9.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
@@ -16097,13 +16338,13 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -16373,27 +16614,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16435,13 +16655,13 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -16553,13 +16773,14 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -16652,17 +16873,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -16687,14 +16897,46 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.4.tgz",
+      "integrity": "sha512-V2tPDUrY3WSevrvU2E41ijZlpF+5PbZu4giH+VpNraaadsJGHa4fR6IFwsocVwEXDoAdIv5qgPPxgrvKAOIPtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.113.0",
+        "@rolldown/pluginutils": "1.0.0-rc.4"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.4",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.4",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.4",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.4",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.4",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.4",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.4",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.4",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.4",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -16704,50 +16946,33 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -16788,30 +17013,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -16868,9 +17069,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
-      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16889,9 +17090,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+      "integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16905,7 +17106,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
@@ -16927,6 +17128,36 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sax": {
@@ -17330,17 +17561,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -17598,9 +17829,9 @@
       }
     },
     "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17737,14 +17968,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -17853,14 +18084,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -18002,9 +18233,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -18187,13 +18418,13 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
-      "integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/vary": {
@@ -18295,23 +18526,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/vite/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
     "node_modules/void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -18323,9 +18537,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18361,9 +18575,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
-      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "version": "5.105.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18410,15 +18624,15 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-      "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.10",
-        "memfs": "^4.6.0",
-        "mime-types": "^2.1.31",
+        "memfs": "^4.43.1",
+        "mime-types": "^3.0.1",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
@@ -18437,6 +18651,33 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/webpack-dev-server": {
@@ -18649,19 +18890,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/watchpack": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
-      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
@@ -18916,6 +19144,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -18930,9 +19171,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^21.2.18",
-        "@angular/cdk": "^20.2.14",
+        "@angular/cdk": "^21.2.14",
         "@angular/common": "^21.2.18",
         "@angular/compiler": "^21.2.18",
         "@angular/core": "^21.2.18",
@@ -25,7 +25,7 @@
         "@segment/analytics-next": "1.81.1",
         "@sentry/angular": "^10.31.0",
         "@sentry/cli": "^2.58.4",
-        "angularx-qrcode": "^20.0.0",
+        "angularx-qrcode": "^21.0.5",
         "crypto-js": "^4.2.0",
         "dexie": "^4.2.1",
         "ethers": "^6.13.5",
@@ -445,57 +445,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.2102.19",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.19.tgz",
@@ -678,41 +627,19 @@
         }
       }
     },
-    "node_modules/@angular/build/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular/build/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@angular/cdk": {
-      "version": "20.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.14.tgz",
-      "integrity": "sha512-7bZxc01URbiPiIBWThQ69XwOxVduqEKN4PhpbF2AAyfMc/W8Hcr4VoIJOwL0O1Nkq5beS8pCAqoOeIgFyXd/kg==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.14.tgz",
+      "integrity": "sha512-806REq/CLf37nEhmmd8Q+ILN8z/RVG2vk2n8YZ/4TdHpcBCi5ux4AxLbpMmduLwGPOzPagJ6ggRzE5fnX0rmcQ==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^20.0.0 || ^21.0.0",
-        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -749,19 +676,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@angular/common": {
@@ -7982,16 +7896,17 @@
       }
     },
     "node_modules/angularx-qrcode": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/angularx-qrcode/-/angularx-qrcode-20.0.0.tgz",
-      "integrity": "sha512-WZolRZztQsQxOXqodNSDicxPWNO79t/AT4wts+DxwYdtdXb1RELfZjtax9oGMQQ6mEZ6bwk5GqBGEDB3Y+cSqw==",
+      "version": "21.0.5",
+      "resolved": "https://registry.npmjs.org/angularx-qrcode/-/angularx-qrcode-21.0.5.tgz",
+      "integrity": "sha512-9Kv/Mi5tKzAkBL2xhYZyPaJEoq+b24mIpUAntp16kIBiozVnpGI6DbigTPJiSDkV7EpYHdjBJNGj8igFAHEp6g==",
       "license": "MIT",
       "dependencies": {
         "qrcode": "1.5.4",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/core": "^20.0.0"
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -8750,23 +8665,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -8790,6 +8688,24 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
@@ -12038,6 +11954,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/listr2/node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -12190,6 +12124,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/wrap-ansi": {
@@ -12867,6 +12819,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/node-gyp/node_modules/which": {
@@ -15641,19 +15603,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15674,23 +15638,6 @@
         "log-symbols": "^7.0.1",
         "stdin-discarder": "^0.3.1",
         "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/string-width": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -17231,9 +17178,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -17867,18 +17814,17 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18274,13 +18220,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -18811,6 +18757,25 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -18835,6 +18800,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpack-merge": {
@@ -19062,16 +19043,17 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19129,6 +19111,24 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^20.3.26",
+    "@angular/animations": "^21.2.18",
     "@angular/cdk": "^20.2.14",
-    "@angular/common": "^20.3.26",
-    "@angular/compiler": "^20.3.26",
-    "@angular/core": "^20.3.26",
-    "@angular/forms": "^20.3.26",
-    "@angular/platform-browser": "^20.3.26",
-    "@angular/platform-browser-dynamic": "^20.3.26",
-    "@angular/platform-server": "^20.3.26",
-    "@angular/router": "^20.3.26",
-    "@angular/ssr": "^20.3.32",
+    "@angular/common": "^21.2.18",
+    "@angular/compiler": "^21.2.18",
+    "@angular/core": "^21.2.18",
+    "@angular/forms": "^21.2.18",
+    "@angular/platform-browser": "^21.2.18",
+    "@angular/platform-browser-dynamic": "^21.2.18",
+    "@angular/platform-server": "^21.2.18",
+    "@angular/router": "^21.2.18",
+    "@angular/ssr": "^21.2.19",
     "@kaspacom/swap-sdk": "^1.1.26",
     "@kaspacom/ui": "^1.0.51",
     "@kaspacom/wallet-messages": "^1.0.35",
@@ -54,9 +54,9 @@
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^20.3.32",
-    "@angular/cli": "^20.3.32",
-    "@angular/compiler-cli": "^20.3.26",
+    "@angular-devkit/build-angular": "^21.2.19",
+    "@angular/cli": "^21.2.19",
+    "@angular/compiler-cli": "^21.2.18",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/lodash": "^4.17.13",
@@ -73,7 +73,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "npm": "^10.9.1",
     "prettier": "^3.5.3",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.3"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.45.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^21.2.18",
-    "@angular/cdk": "^20.2.14",
+    "@angular/cdk": "^21.2.14",
     "@angular/common": "^21.2.18",
     "@angular/compiler": "^21.2.18",
     "@angular/core": "^21.2.18",
@@ -40,7 +40,7 @@
     "@segment/analytics-next": "1.81.1",
     "@sentry/angular": "^10.31.0",
     "@sentry/cli": "^2.58.4",
-    "angularx-qrcode": "^20.0.0",
+    "angularx-qrcode": "^21.0.5",
     "crypto-js": "^4.2.0",
     "dexie": "^4.2.1",
     "ethers": "^6.13.5",
@@ -80,14 +80,14 @@
   },
   "overrides": {
     "@kaspacom/ui": {
-      "@angular/cdk": "20.2.14",
-      "@angular/core": "20.3.26",
-      "@angular/common": "20.3.26"
+      "@angular/cdk": "21.2.14",
+      "@angular/core": "21.2.18",
+      "@angular/common": "21.2.18"
     },
     "kaspacom-ui": {
-      "@angular/cdk": "20.2.14",
-      "@angular/core": "20.3.26",
-      "@angular/common": "20.3.26"
+      "@angular/cdk": "21.2.14",
+      "@angular/core": "21.2.18",
+      "@angular/common": "21.2.18"
     }
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,18 +1,30 @@
-<h1 class="visually-hidden">KaspaCom Web Wallet — self-custody Kaspa (KAS) wallet</h1>
+<h1 class="visually-hidden">
+  KaspaCom Web Wallet — self-custody Kaspa (KAS) wallet
+</h1>
 <app-startup-background-canvas></app-startup-background-canvas>
 <div class="application-container">
-    <ng-container *ngIf="isAllowedDomain() && !incompatibleBrowserReason(); else notSupported">
-<!--        <app-header></app-header>-->
-        <router-outlet></router-outlet>
-        <app-message-popup
-            [message]="messagePopupService.message().message"
-            [type]="messagePopupService.message().type"
-            [show]="messagePopupService.message().show"
-            (close)="messagePopupService.hideMessage()">
-        </app-message-popup>
-    </ng-container>
-    <ng-template #notSupported>
-        <p class="not-supported-url" *ngIf="!isAllowedDomain()">This URL Is not allowed to use this application, If you see this message please report to us at Kaspa.com</p>
-        <p class="not-supported-url" *ngIf="incompatibleBrowserReason()">You browser is not compatible with this application, please use a compatible browser. (Reason: {{incompatibleBrowserReason()}})</p>
-    </ng-template>
+  @if (isAllowedDomain() && !incompatibleBrowserReason()) {
+    <!--        <app-header></app-header>-->
+    <router-outlet></router-outlet>
+    <app-message-popup
+      [message]="messagePopupService.message().message"
+      [type]="messagePopupService.message().type"
+      [show]="messagePopupService.message().show"
+      (close)="messagePopupService.hideMessage()"
+    >
+    </app-message-popup>
+  } @else {
+    @if (!isAllowedDomain()) {
+      <p class="not-supported-url">
+        This URL Is not allowed to use this application, If you see this message
+        please report to us at Kaspa.com
+      </p>
+    }
+    @if (incompatibleBrowserReason()) {
+      <p class="not-supported-url">
+        You browser is not compatible with this application, please use a
+        compatible browser. (Reason: {{ incompatibleBrowserReason() }})
+      </p>
+    }
+  }
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -8,7 +7,7 @@ import {
   OnInit,
   Renderer2,
   inject,
-  DOCUMENT
+  DOCUMENT,
 } from '@angular/core';
 import { Meta } from '@angular/platform-browser';
 import { RouterOutlet } from '@angular/router';
@@ -30,7 +29,6 @@ import { WalletService } from './services/wallet.service';
   selector: 'app-root',
   imports: [
     RouterOutlet,
-    NgIf,
     MessagePopupComponent,
     StartupBackgroundCanvasComponent,
   ],

--- a/src/app/components/history-info-components/krc20-operation-history/krc20-operation-history.component.html
+++ b/src/app/components/history-info-components/krc20-operation-history/krc20-operation-history.component.html
@@ -1,98 +1,130 @@
 <div class="krc20-operations-history">
   <h2 class="title">Krc20 Operations History</h2>
 
-  <ul
-    *ngIf="operations !== undefined; else LoadingOperations"
-    class="operations-list"
-  >
-    <li *ngFor="let op of operations" class="operation-item">
-      <div [ngClass]="{
-        'operation-header': true,
-        'operation-header-deploy': op.op === KRC20OperationType.DEPLOY,
-        'operation-header-list': op.op === KRC20OperationType.LIST,
-        'operation-header-mint': op.op === KRC20OperationType.MINT,
-        'operation-header-send': op.op === KRC20OperationType.SEND,
-        'operation-header-transfer': op.op === KRC20OperationType.TRANSFER
-      }">
-        <strong>{{ getOperationTitle(op) }}</strong>
-      </div>
-      <div class="operation-details">
-        <div class="operation-detail">
-          <strong>Ticker:</strong>
-          <span>{{ op.tick }}</span>
-        </div>
-        <div class="operation-detail">
-          <strong>Balance:</strong>
-          <span
+  @if (operations !== undefined) {
+    <ul class="operations-list">
+      @for (op of operations; track op) {
+        <li class="operation-item">
+          <div
             [ngClass]="{
-              'balance-positive': getOperationWalletBalance(op).balance > 0,
-              'balance-negative': getOperationWalletBalance(op).balance < 0,
-              'balance-locked': getOperationWalletBalance(op).isLocked
+              'operation-header': true,
+              'operation-header-deploy': op.op === KRC20OperationType.DEPLOY,
+              'operation-header-list': op.op === KRC20OperationType.LIST,
+              'operation-header-mint': op.op === KRC20OperationType.MINT,
+              'operation-header-send': op.op === KRC20OperationType.SEND,
+              'operation-header-transfer':
+                op.op === KRC20OperationType.TRANSFER,
             }"
           >
-            <span>
-              {{ getOperationWalletBalance(op).balance > 0 && !getOperationWalletBalance(op).isLocked ? "+" : ""
-              }}{{ getOperationWalletBalance(op).balance | sompiToNumber }}
-            </span>
-            <span *ngIf="getOperationWalletBalance(op).isLocked">(Locked)</span>
-          </span>
-        </div>
-        <div class="operation-detail">
-          <strong>Status:</strong>
-          <span
-            [ngClass]="{
-              'confirmation-status-success':
-                op.opAccept === AcceptedStatus.Accepted &&
-                op.txAccept === AcceptedStatus.Accepted,
-              'confirmation-status-failed':
-                op.opAccept !== AcceptedStatus.Accepted ||
-                op.txAccept !== AcceptedStatus.Accepted
-            }"
-          >
-            {{
-              op.opAccept === AcceptedStatus.Accepted &&
-              op.txAccept === AcceptedStatus.Accepted
-                ? "Success"
-                : "Failed"
-            }}
-          </span>
-        </div>
-        <div class="operation-detail" *ngIf="!isNullOrEmptyString(op.max)">
-          <strong>Total Tokens:</strong>
-          <span>{{ op.max! | sompiToNumber }}</span>
-        </div>
-        <div class="operation-detail" *ngIf="!isNullOrEmptyString(op.max)">
-          <strong>Pre Allocation:</strong>
-          <span>
-            {{ op.pre || "0" | sompiToNumber }}
-            <span *ngIf="op.max"
-              >({{
-                ((Number(op.pre) / Number(op.max)) * 100).toFixed(2)
-              }}%)</span
-            >
-          </span>
-        </div>
-        <div class="operation-detail" *ngIf="!isNullOrEmptyString(op.lim)">
-          <strong>Mint Limit:</strong>
-          <span>{{ op.lim! | sompiToNumber }}</span>
-        </div>
-        <div class="operation-detail" *ngIf="op.from && (op.op == KRC20OperationType.TRANSFER || op.op == KRC20OperationType.SEND) && wallet.getAddress() != op.from">
-          <strong>From:</strong>
-          <span>{{ op.from }}</span>
-        </div>
-        <div class="operation-detail" *ngIf="op.to && (op.op == KRC20OperationType.TRANSFER || op.op == KRC20OperationType.SEND) && wallet.getAddress() != op.to">
-          <strong>To:</strong>
-          <span>{{ op.to }}</span>
-        </div>
-        <div class="operation-detail" *ngIf="!isNullOrEmptyString(op.opError)">
-          <strong>Error:</strong>
-          <span class="operation-error-message">{{ op.opError }}</span>
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ng-template #LoadingOperations>
+            <strong>{{ getOperationTitle(op) }}</strong>
+          </div>
+          <div class="operation-details">
+            <div class="operation-detail">
+              <strong>Ticker:</strong>
+              <span>{{ op.tick }}</span>
+            </div>
+            <div class="operation-detail">
+              <strong>Balance:</strong>
+              <span
+                [ngClass]="{
+                  'balance-positive': getOperationWalletBalance(op).balance > 0,
+                  'balance-negative': getOperationWalletBalance(op).balance < 0,
+                  'balance-locked': getOperationWalletBalance(op).isLocked,
+                }"
+              >
+                <span>
+                  {{
+                    getOperationWalletBalance(op).balance > 0 &&
+                    !getOperationWalletBalance(op).isLocked
+                      ? "+"
+                      : ""
+                  }}{{ getOperationWalletBalance(op).balance | sompiToNumber }}
+                </span>
+                @if (getOperationWalletBalance(op).isLocked) {
+                  <span>(Locked)</span>
+                }
+              </span>
+            </div>
+            <div class="operation-detail">
+              <strong>Status:</strong>
+              <span
+                [ngClass]="{
+                  'confirmation-status-success':
+                    op.opAccept === AcceptedStatus.Accepted &&
+                    op.txAccept === AcceptedStatus.Accepted,
+                  'confirmation-status-failed':
+                    op.opAccept !== AcceptedStatus.Accepted ||
+                    op.txAccept !== AcceptedStatus.Accepted,
+                }"
+              >
+                {{
+                  op.opAccept === AcceptedStatus.Accepted &&
+                  op.txAccept === AcceptedStatus.Accepted
+                    ? "Success"
+                    : "Failed"
+                }}
+              </span>
+            </div>
+            @if (!isNullOrEmptyString(op.max)) {
+              <div class="operation-detail">
+                <strong>Total Tokens:</strong>
+                <span>{{ op.max! | sompiToNumber }}</span>
+              </div>
+            }
+            @if (!isNullOrEmptyString(op.max)) {
+              <div class="operation-detail">
+                <strong>Pre Allocation:</strong>
+                <span>
+                  {{ op.pre || "0" | sompiToNumber }}
+                  @if (op.max) {
+                    <span
+                      >({{
+                        ((Number(op.pre) / Number(op.max)) * 100).toFixed(2)
+                      }}%)</span
+                    >
+                  }
+                </span>
+              </div>
+            }
+            @if (!isNullOrEmptyString(op.lim)) {
+              <div class="operation-detail">
+                <strong>Mint Limit:</strong>
+                <span>{{ op.lim! | sompiToNumber }}</span>
+              </div>
+            }
+            @if (
+              op.from &&
+              (op.op == KRC20OperationType.TRANSFER ||
+                op.op == KRC20OperationType.SEND) &&
+              wallet.getAddress() != op.from
+            ) {
+              <div class="operation-detail">
+                <strong>From:</strong>
+                <span>{{ op.from }}</span>
+              </div>
+            }
+            @if (
+              op.to &&
+              (op.op == KRC20OperationType.TRANSFER ||
+                op.op == KRC20OperationType.SEND) &&
+              wallet.getAddress() != op.to
+            ) {
+              <div class="operation-detail">
+                <strong>To:</strong>
+                <span>{{ op.to }}</span>
+              </div>
+            }
+            @if (!isNullOrEmptyString(op.opError)) {
+              <div class="operation-detail">
+                <strong>Error:</strong>
+                <span class="operation-error-message">{{ op.opError }}</span>
+              </div>
+            }
+          </div>
+        </li>
+      }
+    </ul>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 </div>
-

--- a/src/app/components/history-info-components/krc20-operation-history/krc20-operation-history.component.ts
+++ b/src/app/components/history-info-components/krc20-operation-history/krc20-operation-history.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { CommonModule, NgFor, NgIf } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SompiToNumberPipe } from '../../../pipes/sompi-to-number.pipe';
 import {
@@ -11,10 +11,10 @@ import { KRC20OperationType } from '../../../types/kaspa-network/krc20-operation
 import { AppWallet } from '../../../classes/AppWallet';
 
 @Component({
-    selector: 'krc20-operations-history',
-    templateUrl: './krc20-operation-history.component.html',
-    styleUrls: ['./krc20-operation-history.component.scss'],
-    imports: [NgIf, NgFor, FormsModule, SompiToNumberPipe, CommonModule]
+  selector: 'krc20-operations-history',
+  templateUrl: './krc20-operation-history.component.html',
+  styleUrls: ['./krc20-operation-history.component.scss'],
+  imports: [FormsModule, SompiToNumberPipe, CommonModule],
 })
 export class Krc20OperationHistoryComponent {
   public AcceptedStatus = AcceptedStatus;

--- a/src/app/components/history-info-components/mempool-transactions/mempool-transactions.component.html
+++ b/src/app/components/history-info-components/mempool-transactions/mempool-transactions.component.html
@@ -1,17 +1,32 @@
 <div class="mempool-transactions-component">
-  <div *ngIf="mempoolTransactions()">
-    <div
-      *ngIf="mempoolTransactions()!.receiving.length > 0 || mempoolTransactions()!.sending.length > 0; else noMempoolTransactions">
-      <div *ngIf="mempoolTransactions()!.receiving.length > 0">
-        <div>Receiving Count: {{ mempoolTransactions()!.receiving.length }}</div>
-      </div>
-      <div *ngIf="mempoolTransactions()!.sending.length > 0">
-        <div>Sending Count: {{ mempoolTransactions()!.sending.length }}</div>
-      </div>
+  @if (mempoolTransactions()) {
+    <div>
+      @if (
+        mempoolTransactions()!.receiving.length > 0 ||
+        mempoolTransactions()!.sending.length > 0
+      ) {
+        <div>
+          @if (mempoolTransactions()!.receiving.length > 0) {
+            <div>
+              <div>
+                Receiving Count: {{ mempoolTransactions()!.receiving.length }}
+              </div>
+            </div>
+          }
+          @if (mempoolTransactions()!.sending.length > 0) {
+            <div>
+              <div>
+                Sending Count: {{ mempoolTransactions()!.sending.length }}
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div>No Mempool Transactions</div>
+      }
     </div>
-    <ng-template #noMempoolTransactions>
-      <div>No Mempool Transactions</div>
-    </ng-template>
-  </div>
-  <p *ngIf="!mempoolTransactions()">Loading...</p>
+  }
+  @if (!mempoolTransactions()) {
+    <p>Loading...</p>
+  }
 </div>

--- a/src/app/components/history-info-components/mempool-transactions/mempool-transactions.component.ts
+++ b/src/app/components/history-info-components/mempool-transactions/mempool-transactions.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule, NgIf } from '@angular/common';
 import { Component, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { WalletService } from '../../../services/wallet.service';
@@ -7,7 +6,7 @@ import { WalletService } from '../../../services/wallet.service';
   selector: 'mempool-transactions',
   templateUrl: './mempool-transactions.component.html',
   styleUrls: ['./mempool-transactions.component.scss'],
-  imports: [NgIf, FormsModule, CommonModule],
+  imports: [FormsModule],
 })
 export class MempoolTransactionsComponent {
   constructor(private walletService: WalletService) {}

--- a/src/app/components/history-info-components/transaction-history/transaction-history.component.html
+++ b/src/app/components/history-info-components/transaction-history/transaction-history.component.html
@@ -1,68 +1,67 @@
 <div class="transactions-history-container">
   <h2 class="transactions-title">Kaspa Transactions History</h2>
 
-  <ul
-    *ngIf="
-      kaspaTransactionsHistoryMapped !== undefined;
-      else LoadingTransactions
-    "
-    class="transactions-list"
-  >
-    <li
-      *ngFor="let tx of kaspaTransactionsHistoryMapped"
-      class="transaction-item"
-    >
-      <div class="transaction-header">
-        <strong>Transaction ID:</strong>
-        <span class="transaction-id">{{ tx.id }}</span>
-      </div>
-      <div class="transaction-details">
-        <div class="transaction-confirmation" *ngIf="tx.confirmed">
-          <strong>Status:</strong>
-          <span class="confirmation-status">Accepted</span>
-        </div>
-        <div class="transaction-time">
-          <strong>Time:</strong>
-          <span class="transaction-date">{{
-            tx.date | date : "dd/MM/yyyy, HH:mm:ss"
-          }}</span>
-        </div>
-        <div class="transaction-amount">
-          <strong
-            >Amount:
-            <span
-              [class.plus]="tx.totalForThisWallet > 0"
-              [class.minus]="tx.totalForThisWallet < 0"
-              >{{ tx.totalForThisWallet > 0 ? "+" : ""
-              }}{{ tx.totalForThisWallet | sompiToNumber }} KAS</span
-            ></strong
-          >
-          <div class="transaction-senders">
-            <span *ngFor="let sender of tx.senders | keyvalue" class="sender">
-              -{{ sender.value | sompiToNumber }} KAS
-              <span class="sender-address">(sent from {{ sender.key }})</span>
-            </span>
+  @if (kaspaTransactionsHistoryMapped !== undefined) {
+    <ul class="transactions-list">
+      @for (tx of kaspaTransactionsHistoryMapped; track tx) {
+        <li class="transaction-item">
+          <div class="transaction-header">
+            <strong>Transaction ID:</strong>
+            <span class="transaction-id">{{ tx.id }}</span>
           </div>
-          <div class="transaction-receivers">
-            <span
-              *ngFor="let receiver of tx.receivers | keyvalue"
-              class="receiver"
-            >
-              +{{ receiver.value | sompiToNumber }} KAS
-              <span class="receiver-address"
-                >(received in {{ receiver.key }})</span
+          <div class="transaction-details">
+            @if (tx.confirmed) {
+              <div class="transaction-confirmation">
+                <strong>Status:</strong>
+                <span class="confirmation-status">Accepted</span>
+              </div>
+            }
+            <div class="transaction-time">
+              <strong>Time:</strong>
+              <span class="transaction-date">{{
+                tx.date | date: "dd/MM/yyyy, HH:mm:ss"
+              }}</span>
+            </div>
+            <div class="transaction-amount">
+              <strong
+                >Amount:
+                <span
+                  [class.plus]="tx.totalForThisWallet > 0"
+                  [class.minus]="tx.totalForThisWallet < 0"
+                  >{{ tx.totalForThisWallet > 0 ? "+" : ""
+                  }}{{ tx.totalForThisWallet | sompiToNumber }} KAS</span
+                ></strong
               >
-            </span>
+              <div class="transaction-senders">
+                @for (sender of tx.senders | keyvalue; track sender) {
+                  <span class="sender">
+                    -{{ sender.value | sompiToNumber }} KAS
+                    <span class="sender-address"
+                      >(sent from {{ sender.key }})</span
+                    >
+                  </span>
+                }
+              </div>
+              <div class="transaction-receivers">
+                @for (receiver of tx.receivers | keyvalue; track receiver) {
+                  <span class="receiver">
+                    +{{ receiver.value | sompiToNumber }} KAS
+                    <span class="receiver-address"
+                      >(received in {{ receiver.key }})</span
+                    >
+                  </span>
+                }
+              </div>
+            </div>
+            <div class="transaction-fee">
+              <strong>Fee:</strong>
+              <span>{{ tx.fee | sompiToNumber }} KAS</span>
+            </div>
           </div>
-        </div>
-        <div class="transaction-fee">
-          <strong>Fee:</strong>
-          <span>{{ tx.fee | sompiToNumber }} KAS</span>
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ng-template #LoadingTransactions>
+        </li>
+      }
+    </ul>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 </div>

--- a/src/app/components/history-info-components/transaction-history/transaction-history.component.ts
+++ b/src/app/components/history-info-components/transaction-history/transaction-history.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, Input } from '@angular/core';
-import { CommonModule, NgFor, NgIf } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SompiToNumberPipe } from '../../../pipes/sompi-to-number.pipe';
 import {
@@ -19,10 +19,10 @@ type MappedTransaction = {
 };
 
 @Component({
-    selector: 'transaction-history',
-    templateUrl: './transaction-history.component.html',
-    styleUrls: ['./transaction-history.component.scss'],
-    imports: [NgIf, NgFor, FormsModule, SompiToNumberPipe, CommonModule]
+  selector: 'transaction-history',
+  templateUrl: './transaction-history.component.html',
+  styleUrls: ['./transaction-history.component.scss'],
+  imports: [FormsModule, SompiToNumberPipe, CommonModule],
 })
 export class TransactionHistoryComponent {
   @Input() transactions: undefined | FullTransactionResponse;
@@ -35,34 +35,41 @@ export class TransactionHistoryComponent {
     effect(() => {
       if (this.transactions) {
         this.kaspaTransactionsHistoryMapped = this.transactions.map((tx) =>
-          this.transformTransactionData(tx)
+          this.transformTransactionData(tx),
         );
       }
     });
   }
 
   transformTransactionData(
-    transaction: FullTransactionResponseItem
+    transaction: FullTransactionResponseItem,
   ): MappedTransaction {
-    const senders = transaction.inputs.reduce((acc, input) => {
-      const address = input.previous_outpoint_address;
-      if (!acc[address]) {
-        acc[address] = BigInt(0);
-      }
-      acc[address] += BigInt(input.previous_outpoint_amount || 0);
-      return acc;
-    }, {} as Record<string, bigint>);
+    const senders = transaction.inputs.reduce(
+      (acc, input) => {
+        const address = input.previous_outpoint_address;
+        if (!acc[address]) {
+          acc[address] = BigInt(0);
+        }
+        acc[address] += BigInt(input.previous_outpoint_amount || 0);
+        return acc;
+      },
+      {} as Record<string, bigint>,
+    );
 
-    const receivers = transaction.outputs.reduce((acc, output) => {
-      const address = output.script_public_key_address;
-      if (!acc[address]) {
-        acc[address] = BigInt(0);
-      }
-      acc[address] += BigInt(output.amount);
-      return acc;
-    }, {} as Record<string, bigint>);
+    const receivers = transaction.outputs.reduce(
+      (acc, output) => {
+        const address = output.script_public_key_address;
+        if (!acc[address]) {
+          acc[address] = BigInt(0);
+        }
+        acc[address] += BigInt(output.amount);
+        return acc;
+      },
+      {} as Record<string, bigint>,
+    );
 
-    const fee = Object.values(senders).reduce((acc, val) => acc + val, 0n) -
+    const fee =
+      Object.values(senders).reduce((acc, val) => acc + val, 0n) -
       Object.values(receivers).reduce((acc, val) => acc + val, 0n);
 
     const totalForThisWallet =
@@ -73,7 +80,7 @@ export class TransactionHistoryComponent {
     delete receivers[this.wallet!.getAddress()];
 
     const walletsInBoth = Object.keys(senders).filter(
-      (address) => !!receivers[address]
+      (address) => !!receivers[address],
     );
 
     for (const address of walletsInBoth) {

--- a/src/app/components/history-info-components/utxos-list/utxos-list.component.html
+++ b/src/app/components/history-info-components/utxos-list/utxos-list.component.html
@@ -5,33 +5,32 @@
         wallet.getBalanceSignal()()?.utxoEntries?.length || "Loading..."
       }})
     </h2>
-    <div
-      *ngIf="(wallet.getBalanceSignal()()?.utxoEntries?.length || 0) > 1"
-      class="compound-utxos-button-container"
-    >
-      <button class="compound-utxos-button" (click)="compoundUtxos()">
-        Compound UTXOs
-      </button>
-    </div>
+    @if ((wallet.getBalanceSignal()()?.utxoEntries?.length || 0) > 1) {
+      <div class="compound-utxos-button-container">
+        <button class="compound-utxos-button" (click)="compoundUtxos()">
+          Compound UTXOs
+        </button>
+      </div>
+    }
   </div>
 
-  <ul
-    *ngIf="
-      wallet?.getBalanceSignal() !== undefined &&
-        wallet?.getBalanceSignal()!() !== undefined;
-      else noUtxos
-    "
-  >
-    <li *ngFor="let utxo of wallet.getBalanceSignal()()!.utxoEntries">
-      <div>
-        <strong> {{ utxo.amount | sompiToNumber }} KAS </strong>
-      </div>
-      <div class="utxo-transaction-id">
-        {{ utxo.outpoint.transactionId }}
-      </div>
-    </li>
-  </ul>
-  <ng-template #noUtxos>
+  @if (
+    wallet?.getBalanceSignal() !== undefined &&
+    wallet?.getBalanceSignal()!() !== undefined
+  ) {
+    <ul>
+      @for (utxo of wallet.getBalanceSignal()()!.utxoEntries; track utxo) {
+        <li>
+          <div>
+            <strong> {{ utxo.amount | sompiToNumber }} KAS </strong>
+          </div>
+          <div class="utxo-transaction-id">
+            {{ utxo.outpoint.transactionId }}
+          </div>
+        </li>
+      }
+    </ul>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 </div>

--- a/src/app/components/history-info-components/utxos-list/utxos-list.component.ts
+++ b/src/app/components/history-info-components/utxos-list/utxos-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { NgFor, NgIf } from '@angular/common';
+
 import { UtilsHelper } from '../../../services/utils.service';
 import { FormsModule } from '@angular/forms';
 import { WalletActionService } from '../../../services/wallet-action.service';
@@ -7,24 +7,21 @@ import { AppWallet } from '../../../classes/AppWallet';
 import { SompiToNumberPipe } from '../../../pipes/sompi-to-number.pipe';
 
 @Component({
-    selector: 'utxos-list',
-    templateUrl: './utxos-list.component.html',
-    styleUrls: ['./utxos-list.component.scss'],
-    imports: [NgIf, NgFor, FormsModule, SompiToNumberPipe]
+  selector: 'utxos-list',
+  templateUrl: './utxos-list.component.html',
+  styleUrls: ['./utxos-list.component.scss'],
+  imports: [FormsModule, SompiToNumberPipe],
 })
 export class UtxosListComponent {
   @Input() wallet!: AppWallet;
 
   protected selectedToken = '';
 
-  constructor(
-    private walletActionService: WalletActionService
-  ) {}
+  constructor(private walletActionService: WalletActionService) {}
 
   async compoundUtxos() {
     await this.walletActionService.validateAndDoActionAfterApproval(
-      this.walletActionService.createCompoundUtxosAction()
+      this.walletActionService.createCompoundUtxosAction(),
     );
   }
-
 }

--- a/src/app/components/message-popup/message-popup.component.html
+++ b/src/app/components/message-popup/message-popup.component.html
@@ -1,7 +1,16 @@
-<div class="message-popup" [class.show]="show" [class.success]="type === 'success'" [class.error]="type === 'error'" [class.warning]="type === 'warning'" [class.info]="type === 'info'">
+<div
+  class="message-popup"
+  [class.show]="show"
+  [class.success]="type === 'success'"
+  [class.error]="type === 'error'"
+  [class.warning]="type === 'warning'"
+  [class.info]="type === 'info'"
+>
   <div class="message-content">
-    <span class="icon" *ngIf="type !== 'error'">{{ icon }}</span>
+    @if (type !== "error") {
+      <span class="icon">{{ icon }}</span>
+    }
     <span class="message">{{ message }}</span>
     <button class="close-button" (click)="onClose()">×</button>
   </div>
-</div> 
+</div>

--- a/src/app/components/message-popup/message-popup.component.ts
+++ b/src/app/components/message-popup/message-popup.component.ts
@@ -1,13 +1,12 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 export type MessageType = 'success' | 'error' | 'warning' | 'info';
 
 @Component({
-    selector: 'app-message-popup',
-    imports: [CommonModule],
-    templateUrl: './message-popup.component.html',
-    styleUrls: ['./message-popup.component.scss']
+  selector: 'app-message-popup',
+  imports: [],
+  templateUrl: './message-popup.component.html',
+  styleUrls: ['./message-popup.component.scss'],
 })
 export class MessagePopupComponent {
   @Input() message: string = '';
@@ -33,4 +32,4 @@ export class MessagePopupComponent {
   onClose(): void {
     this.close.emit();
   }
-} 
+}

--- a/src/app/components/token-logo/token-logo.component.ts
+++ b/src/app/components/token-logo/token-logo.component.ts
@@ -1,11 +1,10 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, input, resource } from '@angular/core';
 import { UtilsService } from '../../services/utils/utils.service';
 import { ComponentSize } from '../../v2/pages/app/common/types/sizing.type';
 
 @Component({
   selector: 'kc-token-logo',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './token-logo.component.html',
   styleUrl: './token-logo.component.scss',
 })

--- a/src/app/components/wallet-actions-forms/add-l2-chain/add-l2-chain.component.ts
+++ b/src/app/components/wallet-actions-forms/add-l2-chain/add-l2-chain.component.ts
@@ -1,13 +1,19 @@
 import { Component, EventEmitter, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
 import { EIP1193ProviderChain } from '@kaspacom/wallet-messages';
 
 @Component({
-    selector: 'add-l2-chain',
-    imports: [CommonModule, FormsModule, ReactiveFormsModule],
-    templateUrl: './add-l2-chain.component.html',
-    styleUrls: ['./add-l2-chain.component.scss']
+  selector: 'add-l2-chain',
+  imports: [FormsModule, ReactiveFormsModule],
+  templateUrl: './add-l2-chain.component.html',
+  styleUrls: ['./add-l2-chain.component.scss'],
 })
 export class AddL2ChainComponent {
   @Output() chainAdded = new EventEmitter<EIP1193ProviderChain>();
@@ -22,8 +28,11 @@ export class AddL2ChainComponent {
       rpcUrls: ['', [Validators.required, this.urlListValidator()]],
       currencyName: ['', [Validators.required]],
       currencySymbol: ['', [Validators.required]],
-      currencyDecimals: [18, [Validators.required, Validators.min(0), Validators.max(36)]],
-      blockExplorerUrls: ['', [this.urlListValidator()]]
+      currencyDecimals: [
+        18,
+        [Validators.required, Validators.min(0), Validators.max(36)],
+      ],
+      blockExplorerUrls: ['', [this.urlListValidator()]],
     });
   }
 
@@ -48,12 +57,14 @@ export class AddL2ChainComponent {
         nativeCurrency: {
           name: formValue.currencyName,
           symbol: formValue.currencySymbol,
-          decimals: Number(formValue.currencyDecimals)
+          decimals: Number(formValue.currencyDecimals),
         },
         rpcUrls: formValue.rpcUrls.split(',').map((url: string) => url.trim()),
-        blockExplorerUrls: formValue.blockExplorerUrls ? 
-          formValue.blockExplorerUrls.split(',').map((url: string) => url.trim()) : 
-          []
+        blockExplorerUrls: formValue.blockExplorerUrls
+          ? formValue.blockExplorerUrls
+              .split(',')
+              .map((url: string) => url.trim())
+          : [],
       };
       this.chainAdded.emit(chain);
     }
@@ -62,4 +73,4 @@ export class AddL2ChainComponent {
   onCancel() {
     this.cancelled.emit();
   }
-} 
+}

--- a/src/app/components/wallet-actions-forms/buy-krc20-component/buy-krc20.component.html
+++ b/src/app/components/wallet-actions-forms/buy-krc20-component/buy-krc20.component.html
@@ -17,40 +17,39 @@
   <button class="buy-button" (click)="buy()">Buy</button>
   <br />
 
-  <ng-container *ngIf="listings; else loading">
+  @if (listings) {
     <ul class="asset-list">
-      <li *ngFor="let dataEntry of listings" class="asset-item">
-        <strong class="asset-label">Ticker:</strong>
-        <span class="asset-value">{{ dataEntry.tick }}</span
-        ><br />
-        <strong class="asset-label">From:</strong>
-        <span class="asset-value">{{ dataEntry.from }}</span
-        ><br />
-        <strong class="asset-label">Amount:</strong>
-        <span class="asset-value">{{ dataEntry.amount | sompiToNumber }}</span
-        ><br />
-        <strong class="asset-label">Transaction ID:</strong>
-        <span class="asset-value">{{ dataEntry.uTxid }}</span
-        ><br />
-        <strong class="asset-label">Address:</strong>
-        <span class="asset-value">{{ dataEntry.uAddr }}</span
-        ><br />
-        <strong class="asset-label">Script:</strong>
-        <span class="asset-value">{{ dataEntry.uScript }}</span
-        ><br />
-        <strong class="asset-label">Score:</strong>
-        <span class="asset-value">{{ dataEntry.opScoreAdd }}</span>
-        <button
-          class="cancel-button"
-          (click)="cancel(dataEntry)"
-          *ngIf="dataEntry.from == currentWallet()!.getAddress()"
-        >
-          Cancel
-        </button>
-      </li>
+      @for (dataEntry of listings; track dataEntry) {
+        <li class="asset-item">
+          <strong class="asset-label">Ticker:</strong>
+          <span class="asset-value">{{ dataEntry.tick }}</span
+          ><br />
+          <strong class="asset-label">From:</strong>
+          <span class="asset-value">{{ dataEntry.from }}</span
+          ><br />
+          <strong class="asset-label">Amount:</strong>
+          <span class="asset-value">{{ dataEntry.amount | sompiToNumber }}</span
+          ><br />
+          <strong class="asset-label">Transaction ID:</strong>
+          <span class="asset-value">{{ dataEntry.uTxid }}</span
+          ><br />
+          <strong class="asset-label">Address:</strong>
+          <span class="asset-value">{{ dataEntry.uAddr }}</span
+          ><br />
+          <strong class="asset-label">Script:</strong>
+          <span class="asset-value">{{ dataEntry.uScript }}</span
+          ><br />
+          <strong class="asset-label">Score:</strong>
+          <span class="asset-value">{{ dataEntry.opScoreAdd }}</span>
+          @if (dataEntry.from == currentWallet()!.getAddress()) {
+            <button class="cancel-button" (click)="cancel(dataEntry)">
+              Cancel
+            </button>
+          }
+        </li>
+      }
     </ul>
-  </ng-container>
-  <ng-template #loading>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 </div>

--- a/src/app/components/wallet-actions-forms/buy-krc20-component/buy-krc20.component.ts
+++ b/src/app/components/wallet-actions-forms/buy-krc20-component/buy-krc20.component.ts
@@ -1,7 +1,7 @@
 import { Component, effect, signal } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { WalletService } from '../../../services/wallet.service';
-import { NgFor, NgIf } from '@angular/common';
+
 import { KaspaNetworkActionsService } from '../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
 import { WalletActionService } from '../../../services/wallet-action.service';
 import { KasplexKrc20Service } from '../../../services/kasplex-api/kasplex-api.service';
@@ -11,45 +11,57 @@ import { SompiToNumberPipe } from '../../../pipes/sompi-to-number.pipe';
 import { Krc20WalletActionService } from '../../../services/protocols/krc20/krc20-wallet-actions.service';
 
 @Component({
-    selector: 'buy-krc20-token',
-    templateUrl: './buy-krc20.component.html',
-    styleUrls: ['./buy-krc20.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, NgIf, NgFor, SompiToNumberPipe]
+  selector: 'buy-krc20-token',
+  templateUrl: './buy-krc20.component.html',
+  styleUrls: ['./buy-krc20.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule, SompiToNumberPipe],
 })
 export class BuyKrc20Component {
   protected listings: ListingInfoEntry[] | undefined = undefined;
   protected selectedTicker = signal<string>('');
   protected onlyWalletListing = signal<boolean>(false);
 
-
-
-
   constructor(
     private walletService: WalletService,
     private walletActionService: WalletActionService,
     private krc20WalletActionService: Krc20WalletActionService,
-    private kasplexService: KasplexKrc20Service
+    private kasplexService: KasplexKrc20Service,
   ) {
     effect(() => {
       this.onlyWalletListing;
 
-      if (this.selectedTicker().length >= 4 && this.selectedTicker().length <= 6) {
+      if (
+        this.selectedTicker().length >= 4 &&
+        this.selectedTicker().length <= 6
+      ) {
         this.loadData();
       }
-    })
+    });
   }
 
   async loadData() {
     this.listings = undefined;
-    const kasplexResult = await firstValueFrom(this.kasplexService.getListingInfo(this.selectedTicker(), this.onlyWalletListing() ? this.walletService.getCurrentWallet()?.getAddress() : undefined));
+    const kasplexResult = await firstValueFrom(
+      this.kasplexService.getListingInfo(
+        this.selectedTicker(),
+        this.onlyWalletListing()
+          ? this.walletService.getCurrentWallet()?.getAddress()
+          : undefined,
+      ),
+    );
 
     this.listings = kasplexResult.result;
   }
 
   async buy() {
-    const action = this.walletActionService.createSignPsktAction((window as any).pskt as string, true);
+    const action = this.walletActionService.createSignPsktAction(
+      (window as any).pskt as string,
+      true,
+    );
 
-    console.log(await this.walletActionService.validateAndDoActionAfterApproval(action));
+    console.log(
+      await this.walletActionService.validateAndDoActionAfterApproval(action),
+    );
   }
 
   async cancel(data: ListingInfoEntry) {
@@ -57,8 +69,8 @@ export class BuyKrc20Component {
       this.krc20WalletActionService.createCancelListingKrc20Action(
         data.tick,
         data.uTxid,
-        BigInt(data.amount)
-      )
+        BigInt(data.amount),
+      ),
     );
   }
 

--- a/src/app/components/wallet-actions-forms/l2-transaction/l2-transaction.component.ts
+++ b/src/app/components/wallet-actions-forms/l2-transaction/l2-transaction.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -18,7 +18,7 @@ import {
 
 @Component({
   selector: 'l2-transaction',
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [FormsModule, ReactiveFormsModule],
   templateUrl: './l2-transaction.component.html',
   styleUrls: ['./l2-transaction.component.scss'],
 })
@@ -52,7 +52,8 @@ export class L2TransactionComponent implements OnInit {
 
       // Process each field and convert value to wei if present
       if (formData.value) cleanData.value = parseEther(String(formData.value));
-      if (formData.gasLimit && formData.gasLimit.length) cleanData.gasLimit = formData.gasLimit;
+      if (formData.gasLimit && formData.gasLimit.length)
+        cleanData.gasLimit = formData.gasLimit;
       if (formData.gasPrice) cleanData.gasPrice = formData.gasPrice;
       if (formData.data) cleanData.data = formData.data;
       if (formData.nonce) cleanData.nonce = formData.nonce;

--- a/src/app/components/wallet-actions-forms/list-krc20-component/list-krc20-component.component.html
+++ b/src/app/components/wallet-actions-forms/list-krc20-component/list-krc20-component.component.html
@@ -2,18 +2,20 @@
   <h2>List Asset</h2>
 
   <!-- Asset Selection -->
-   <div *ngIf="assets && assets.length > 0; else noAssetsToChoose">
-    <label for="assetInput" >Choose Asset:</label>
-    <select id="assetInput" [(ngModel)]="selectedAsset">
-      <option *ngFor="let asset of assets" [value]="getAssetId(asset)">
-        {{ asset.name }}
-      </option>
-    </select>
-  
-   </div>
-   <ng-template #noAssetsToChoose>
+  @if (assets && assets.length > 0) {
+    <div>
+      <label for="assetInput">Choose Asset:</label>
+      <select id="assetInput" [(ngModel)]="selectedAsset">
+        @for (asset of assets; track asset) {
+          <option [value]="getAssetId(asset)">
+            {{ asset.name }}
+          </option>
+        }
+      </select>
+    </div>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 
   <!-- Amount Input -->
   <label for="amount">Amount:</label>
@@ -37,5 +39,3 @@
   <!-- Send Button -->
   <button (click)="sendAsset()" [disabled]="!isFormValid()">Send</button>
 </div>
-
-  

--- a/src/app/components/wallet-actions-forms/list-krc20-component/list-krc20-component.component.ts
+++ b/src/app/components/wallet-actions-forms/list-krc20-component/list-krc20-component.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { WalletService } from '../../../services/wallet.service';
-import { NgFor, NgIf } from '@angular/common';
+
 import { TransferableAsset } from '../../../types/transferable-asset';
 import { WalletAction, WalletActionType } from '../../../types/wallet-action';
 import { KaspaNetworkActionsService } from '../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
@@ -11,10 +11,10 @@ import { Krc20WalletActionService } from '../../../services/protocols/krc20/krc2
 import { MessagePopupService } from '../../../services/message-popup.service';
 
 @Component({
-    selector: 'list-krc20-token',
-    templateUrl: './list-krc20-component.component.html',
-    styleUrls: ['./list-krc20-component.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, NgIf, NgFor]
+  selector: 'list-krc20-token',
+  templateUrl: './list-krc20-component.component.html',
+  styleUrls: ['./list-krc20-component.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule],
 })
 export class ListKrc20Component implements OnInit {
   assets: undefined | TransferableAsset[] = undefined; // Replace with your dynamic asset list
@@ -40,7 +40,14 @@ export class ListKrc20Component implements OnInit {
 
   // Validate the form
   isFormValid(): boolean {
-    return (this.selectedAsset && this.amount && this.amount > 0 && this.totalPrice && this.totalPrice > 0) || false;
+    return (
+      (this.selectedAsset &&
+        this.amount &&
+        this.amount > 0 &&
+        this.totalPrice &&
+        this.totalPrice > 0) ||
+      false
+    );
   }
 
   // Handle the send action
@@ -51,7 +58,7 @@ export class ListKrc20Component implements OnInit {
 
     if (this.isFormValid()) {
       const selectedAsset = this.assets?.find(
-        (asset) => this.selectedAsset == this.getAssetId(asset)
+        (asset) => this.selectedAsset == this.getAssetId(asset),
       );
 
       const action: WalletAction =
@@ -59,10 +66,14 @@ export class ListKrc20Component implements OnInit {
           this.walletService.getCurrentWallet()!.getAddress(),
           selectedAsset!.ticker,
           this.kaspaNetworkActionsService.kaspaToSompiFromNumber(this.amount!),
-          [{
-            address: this.walletService.getCurrentWallet()!.getAddress(),
-            amount: this.kaspaNetworkActionsService.kaspaToSompiFromNumber(this.totalPrice!),
-          }],
+          [
+            {
+              address: this.walletService.getCurrentWallet()!.getAddress(),
+              amount: this.kaspaNetworkActionsService.kaspaToSompiFromNumber(
+                this.totalPrice!,
+              ),
+            },
+          ],
         );
 
       const result =
@@ -73,14 +84,20 @@ export class ListKrc20Component implements OnInit {
         this.messagePopupService.showSuccess('Asset listed successfully!');
       } else {
         if (result.errorCode != ERROR_CODES.EIP1193.USER_REJECTED) {
-          this.messagePopupService.showError(result.errorCode ? ERROR_CODES_MESSAGES[result.errorCode] : ERROR_CODES_MESSAGES[ERROR_CODES.GENERAL.UNKNOWN_ERROR]);
+          this.messagePopupService.showError(
+            result.errorCode
+              ? ERROR_CODES_MESSAGES[result.errorCode]
+              : ERROR_CODES_MESSAGES[ERROR_CODES.GENERAL.UNKNOWN_ERROR],
+          );
           return;
         }
       }
 
       // Add your transaction logic here
     } else {
-      this.messagePopupService.showError('Please fill in all fields correctly.');
+      this.messagePopupService.showError(
+        'Please fill in all fields correctly.',
+      );
     }
   }
 

--- a/src/app/components/wallet-actions-forms/send-asset/send-asset.component.html
+++ b/src/app/components/wallet-actions-forms/send-asset/send-asset.component.html
@@ -2,33 +2,47 @@
   <h2>Send Asset</h2>
 
   <!-- Asset Selection -->
-  <div *ngIf="assets && assets.length > 0; else noAssetsToChoose">
-    <label for="assetInput">Choose Asset:</label>
-    <select id="assetInput" [(ngModel)]="selectedAsset">
-      <option *ngFor="let asset of assets" [value]="getAssetId(asset)">
-        {{ asset.name }}
-      </option>
-    </select>
-
-  </div>
-  <ng-template #noAssetsToChoose>
+  @if (assets && assets.length > 0) {
+    <div>
+      <label for="assetInput">Choose Asset:</label>
+      <select id="assetInput" [(ngModel)]="selectedAsset">
+        @for (asset of assets; track asset) {
+          <option [value]="getAssetId(asset)">
+            {{ asset.name }}
+          </option>
+        }
+      </select>
+    </div>
+  } @else {
     <p>Loading...</p>
-  </ng-template>
+  }
 
   <!-- Amount Input -->
   <label for="amount">Amount:</label>
-  <input id="amount" type="number" [(ngModel)]="amount" min="0" placeholder="Enter amount" />
+  <input
+    id="amount"
+    type="number"
+    [(ngModel)]="amount"
+    min="0"
+    placeholder="Enter amount"
+  />
 
   <!-- Address Input -->
   <label for="address">Recipient Address:</label>
-  <input id="address" type="text" [(ngModel)]="recipientAddress" placeholder="Enter recipient's address" />
+  <input
+    id="address"
+    type="text"
+    [(ngModel)]="recipientAddress"
+    placeholder="Enter recipient's address"
+  />
 
   <!-- Replace By Fee Checkbox -->
-  <div *ngIf="currentSelectedAsset()?.type == AssetType.KAS" class="rbf-checkbox">
-    <input id="rbf" type="checkbox" [(ngModel)]="rbf" />
-    <label for="rbf">Replace By Fee (RBF)</label>
-  </div>
-
+  @if (currentSelectedAsset()?.type == AssetType.KAS) {
+    <div class="rbf-checkbox">
+      <input id="rbf" type="checkbox" [(ngModel)]="rbf" />
+      <label for="rbf">Replace By Fee (RBF)</label>
+    </div>
+  }
 
   <!-- Send Button -->
   <button (click)="sendAsset()" [disabled]="!isFormValid()">Send</button>

--- a/src/app/components/wallet-actions-forms/send-asset/send-asset.component.ts
+++ b/src/app/components/wallet-actions-forms/send-asset/send-asset.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { WalletService } from '../../../services/wallet.service';
-import { NgFor, NgIf } from '@angular/common';
-import { AssetType, TransferableAsset } from '../../../types/transferable-asset';
+
+import {
+  AssetType,
+  TransferableAsset,
+} from '../../../types/transferable-asset';
 import { WalletAction, WalletActionType } from '../../../types/wallet-action';
 import { KaspaNetworkActionsService } from '../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
 import { WalletActionService } from '../../../services/wallet-action.service';
@@ -10,10 +13,10 @@ import { ERROR_CODES, ERROR_CODES_MESSAGES } from '@kaspacom/wallet-messages';
 import { MessagePopupService } from '../../../services/message-popup.service';
 
 @Component({
-    selector: 'send-asset',
-    templateUrl: './send-asset.component.html',
-    styleUrls: ['./send-asset.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, NgIf, NgFor]
+  selector: 'send-asset',
+  templateUrl: './send-asset.component.html',
+  styleUrls: ['./send-asset.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule],
 })
 export class SendAssetComponent implements OnInit {
   public AssetType = AssetType;
@@ -58,7 +61,7 @@ export class SendAssetComponent implements OnInit {
           this.recipientAddress,
           this.kaspaNetworkActionsService.kaspaToSompiFromNumber(this.amount!),
           this.walletService.getCurrentWallet()!,
-          this.rbf
+          this.rbf,
         );
 
       const result =
@@ -68,14 +71,20 @@ export class SendAssetComponent implements OnInit {
         this.amount = null;
       } else {
         if (result.errorCode != ERROR_CODES.EIP1193.USER_REJECTED) {
-          this.messagePopupService.showError(result.errorCode ? ERROR_CODES_MESSAGES[result.errorCode] : ERROR_CODES_MESSAGES[ERROR_CODES.GENERAL.UNKNOWN_ERROR]);
+          this.messagePopupService.showError(
+            result.errorCode
+              ? ERROR_CODES_MESSAGES[result.errorCode]
+              : ERROR_CODES_MESSAGES[ERROR_CODES.GENERAL.UNKNOWN_ERROR],
+          );
           return;
         }
       }
 
       // Add your transaction logic here
     } else {
-      this.messagePopupService.showError('Please fill in all fields correctly.');
+      this.messagePopupService.showError(
+        'Please fill in all fields correctly.',
+      );
     }
   }
 
@@ -85,7 +94,7 @@ export class SendAssetComponent implements OnInit {
 
   currentSelectedAsset(): undefined | TransferableAsset {
     return this.assets?.find(
-      (asset) => this.selectedAsset == this.getAssetId(asset)
+      (asset) => this.selectedAsset == this.getAssetId(asset),
     );
   }
 }

--- a/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.html
+++ b/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.html
@@ -1,153 +1,217 @@
 <!-- Loading State -->
-<div *ngIf="!feeData" class="fee-loading">
-  <div class="fee-loading-spinner"></div>
-  <p>Estimating gas &amp; fees...</p>
-</div>
+@if (!feeData) {
+  <div class="fee-loading">
+    <div class="fee-loading-spinner"></div>
+    <p>Estimating gas &amp; fees...</p>
+  </div>
+}
 
 <!-- Fee Spoiler Container -->
-<div class="fee-spoiler-container" *ngIf="feeData">
-
-  <!-- Gas Estimation Error Banner -->
-  <div class="error-banner" *ngIf="hasGasLimitError">
-    <kc-icon iconClass="icon-warning" size="sm" color="var(--orange-20)"></kc-icon>
-    <span>Gas estimation failed — the transaction may be invalid. Please verify it and adjust the gas limit manually.</span>
-  </div>
-
-  <!-- Fee Toggle Header (Spoiler) -->
-  <div class="fee-spoiler-toggle" (click)="toggleFeeSelection()">
-    <div class="fee-summary-left">
-      <kc-icon iconClass="icon-chain" size="sm" color="var(--kaspa-20)"></kc-icon>
-      <span class="fee-label">Total Fee:</span>
-      <div class="fee-value">
-        <ng-container *ngIf="totalFeeDisplay() !== undefined; else notSelected">
-          <span>{{ totalFeeDisplay() | number:'1.4-8' }}</span>
-          <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-        </ng-container>
-        <ng-template #notSelected>
-          <span class="not-selected">Not selected</span>
-        </ng-template>
+@if (feeData) {
+  <div class="fee-spoiler-container">
+    <!-- Gas Estimation Error Banner -->
+    @if (hasGasLimitError) {
+      <div class="error-banner">
+        <kc-icon
+          iconClass="icon-warning"
+          size="sm"
+          color="var(--orange-20)"
+        ></kc-icon>
+        <span
+          >Gas estimation failed — the transaction may be invalid. Please verify
+          it and adjust the gas limit manually.</span
+        >
+      </div>
+    }
+    <!-- Fee Toggle Header (Spoiler) -->
+    <div class="fee-spoiler-toggle" (click)="toggleFeeSelection()">
+      <div class="fee-summary-left">
+        <kc-icon
+          iconClass="icon-chain"
+          size="sm"
+          color="var(--kaspa-20)"
+        ></kc-icon>
+        <span class="fee-label">Total Fee:</span>
+        <div class="fee-value">
+          @if (totalFeeDisplay() !== undefined) {
+            <span>{{ totalFeeDisplay() | number: "1.4-8" }}</span>
+            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+          } @else {
+            <span class="not-selected">Not selected</span>
+          }
+        </div>
+      </div>
+      <div class="fee-spoiler-chevron">
+        <kc-icon
+          [iconClass]="
+            showFeeSelection ? 'icon-chevron-up' : 'icon-chevron-down'
+          "
+          size="sm"
+          color="var(--gray-60)"
+        >
+        </kc-icon>
       </div>
     </div>
-    <div class="fee-spoiler-chevron">
-      <kc-icon
-        [iconClass]="showFeeSelection ? 'icon-chevron-up' : 'icon-chevron-down'"
-        size="sm"
-        color="var(--gray-60)">
-      </kc-icon>
+    <!-- Fee Selection Content (Collapsible) -->
+    <div
+      class="fee-selection-content"
+      [@slideDown]="showFeeSelection ? 'open' : 'closed'"
+    >
+      <div class="fee-selection-inner">
+        <!-- Fee Options Grid -->
+        <div class="fee-options-grid">
+          <div
+            class="fee-option-card"
+            [class.selected]="selectedOption() === 'low'"
+            (click)="selectOption('low')"
+          >
+            <div class="option-title">Low</div>
+            @if (gasFeeOptionToDisplay()) {
+              <div class="option-fee">
+                <span>{{
+                  gasFeeOptionToDisplay()!["low"].display | number: "1.4-8"
+                }}</span>
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              </div>
+            }
+            @if (gasFeeOtions()) {
+              <div class="option-gwei">
+                {{ fromWeiToGwei(gasFeeOtions()!.low) }} Gwei
+              </div>
+            }
+          </div>
+          <div
+            class="fee-option-card"
+            [class.selected]="selectedOption() === 'normal'"
+            (click)="selectOption('normal')"
+          >
+            <div class="option-title">Normal</div>
+            @if (gasFeeOptionToDisplay()) {
+              <div class="option-fee">
+                <span>{{
+                  gasFeeOptionToDisplay()!["normal"].display | number: "1.4-8"
+                }}</span>
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              </div>
+            }
+            @if (gasFeeOtions()) {
+              <div class="option-gwei">
+                {{ fromWeiToGwei(gasFeeOtions()!.normal) }} Gwei
+              </div>
+            }
+          </div>
+          <div
+            class="fee-option-card"
+            [class.selected]="selectedOption() === 'priority'"
+            (click)="selectOption('priority')"
+          >
+            <div class="option-title">Priority</div>
+            @if (gasFeeOptionToDisplay()) {
+              <div class="option-fee">
+                <span>{{
+                  gasFeeOptionToDisplay()!["priority"].display | number: "1.4-8"
+                }}</span>
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              </div>
+            }
+            @if (gasFeeOtions()) {
+              <div class="option-gwei">
+                {{ fromWeiToGwei(gasFeeOtions()!.priority) }} Gwei
+              </div>
+            }
+          </div>
+        </div>
+        <!-- Custom Fee -->
+        <div class="custom-fee-section">
+          <div
+            class="custom-fee-card"
+            [class.selected]="selectedOption() === 'custom'"
+            [class.has-error]="
+              selectedOption() === 'custom' && !isCustomFeeValid()
+            "
+            (click)="selectOption('custom')"
+          >
+            <div class="custom-fee-header">
+              <span class="custom-fee-title">Custom Fee</span>
+              <span class="custom-fee-unit">in wei</span>
+            </div>
+            <div class="custom-fee-input">
+              <kc-input
+                type="number"
+                placeholder="Min 1 wei"
+                [(ngModel)]="customFee"
+                (valueChange)="selectOption('custom')"
+              >
+              </kc-input>
+            </div>
+            @if (selectedOption() === "custom" && !isCustomFeeValid()) {
+              <div class="validation-error">Minimum custom fee is 1 wei</div>
+            }
+          </div>
+        </div>
+        <!-- Gas Limit -->
+        <div class="estimated-gas-section">
+          <div class="custom-fee-card" [class.has-error]="!isGasLimitValid()">
+            <div class="custom-fee-header">
+              <span class="custom-fee-title">Gas Limit</span>
+            </div>
+            <div class="custom-fee-input">
+              <kc-input
+                type="number"
+                placeholder="Min 21,000"
+                [(ngModel)]="gasLimit"
+                (valueChange)="updateGasLimit()"
+              >
+              </kc-input>
+            </div>
+            @if (!isGasLimitValid()) {
+              <div class="validation-error">
+                Gas limit must be at least 21,000
+              </div>
+            }
+          </div>
+        </div>
+        <!-- Fee Breakdown -->
+        <div class="fee-details-section">
+          <div class="fee-detail-row">
+            <span class="detail-label">Base Fee</span>
+            <div class="detail-value">
+              <span>{{ currentBaseFee() | number: "1.4-8" }}</span>
+              <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+            </div>
+          </div>
+          @if (gasFeeOtions()) {
+            <div class="fee-detail-row">
+              <span class="detail-label">Priority Fee</span>
+              <div class="detail-value">
+                <span
+                  >{{
+                    fromWeiToGwei(gasFeeOtions()![selectedOption()])
+                  }}
+                  Gwei</span
+                >
+              </div>
+            </div>
+          }
+          @if (gasLimit()) {
+            <div class="fee-detail-row">
+              <span class="detail-label">Gas Limit</span>
+              <div class="detail-value">
+                <span>{{ gasLimit() | number }}</span>
+              </div>
+            </div>
+          }
+          @if (totalFeeDisplay() !== undefined) {
+            <div class="fee-detail-row total-row">
+              <span class="detail-label">Total Fee</span>
+              <div class="detail-value highlight">
+                <span>{{ totalFeeDisplay() | number: "1.4-8" }}</span>
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              </div>
+            </div>
+          }
+        </div>
+      </div>
     </div>
   </div>
-
-  <!-- Fee Selection Content (Collapsible) -->
-  <div class="fee-selection-content" [@slideDown]="showFeeSelection ? 'open' : 'closed'">
-    <div class="fee-selection-inner">
-
-      <!-- Fee Options Grid -->
-      <div class="fee-options-grid">
-        <div class="fee-option-card" [class.selected]="selectedOption() === 'low'" (click)="selectOption('low')">
-          <div class="option-title">Low</div>
-          <div class="option-fee" *ngIf="gasFeeOptionToDisplay()">
-            <span>{{ gasFeeOptionToDisplay()!['low'].display | number:'1.4-8' }}</span>
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-          <div class="option-gwei" *ngIf="gasFeeOtions()">{{ fromWeiToGwei(gasFeeOtions()!.low) }} Gwei</div>
-        </div>
-
-        <div class="fee-option-card" [class.selected]="selectedOption() === 'normal'" (click)="selectOption('normal')">
-          <div class="option-title">Normal</div>
-          <div class="option-fee" *ngIf="gasFeeOptionToDisplay()">
-            <span>{{ gasFeeOptionToDisplay()!['normal'].display | number:'1.4-8' }}</span>
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-          <div class="option-gwei" *ngIf="gasFeeOtions()">{{ fromWeiToGwei(gasFeeOtions()!.normal) }} Gwei</div>
-        </div>
-
-        <div class="fee-option-card" [class.selected]="selectedOption() === 'priority'" (click)="selectOption('priority')">
-          <div class="option-title">Priority</div>
-          <div class="option-fee" *ngIf="gasFeeOptionToDisplay()">
-            <span>{{ gasFeeOptionToDisplay()!['priority'].display | number:'1.4-8' }}</span>
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-          <div class="option-gwei" *ngIf="gasFeeOtions()">{{ fromWeiToGwei(gasFeeOtions()!.priority) }} Gwei</div>
-        </div>
-      </div>
-
-      <!-- Custom Fee -->
-      <div class="custom-fee-section">
-        <div class="custom-fee-card"
-             [class.selected]="selectedOption() === 'custom'"
-             [class.has-error]="selectedOption() === 'custom' && !isCustomFeeValid()"
-             (click)="selectOption('custom')">
-          <div class="custom-fee-header">
-            <span class="custom-fee-title">Custom Fee</span>
-            <span class="custom-fee-unit">in wei</span>
-          </div>
-          <div class="custom-fee-input">
-            <kc-input
-              type="number"
-              placeholder="Min 1 wei"
-              [(ngModel)]="customFee"
-              (valueChange)="selectOption('custom')">
-            </kc-input>
-          </div>
-          <div class="validation-error" *ngIf="selectedOption() === 'custom' && !isCustomFeeValid()">
-            Minimum custom fee is 1 wei
-          </div>
-        </div>
-      </div>
-
-      <!-- Gas Limit -->
-      <div class="estimated-gas-section">
-        <div class="custom-fee-card" [class.has-error]="!isGasLimitValid()">
-          <div class="custom-fee-header">
-            <span class="custom-fee-title">Gas Limit</span>
-          </div>
-          <div class="custom-fee-input">
-            <kc-input
-              type="number"
-              placeholder="Min 21,000"
-              [(ngModel)]="gasLimit"
-              (valueChange)="updateGasLimit()">
-            </kc-input>
-          </div>
-          <div class="validation-error" *ngIf="!isGasLimitValid()">
-            Gas limit must be at least 21,000
-          </div>
-        </div>
-      </div>
-
-      <!-- Fee Breakdown -->
-      <div class="fee-details-section">
-        <div class="fee-detail-row">
-          <span class="detail-label">Base Fee</span>
-          <div class="detail-value">
-            <span>{{ currentBaseFee() | number:'1.4-8' }}</span>
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-        </div>
-
-        <div class="fee-detail-row" *ngIf="gasFeeOtions()">
-          <span class="detail-label">Priority Fee</span>
-          <div class="detail-value">
-            <span>{{ fromWeiToGwei(gasFeeOtions()![selectedOption()]) }} Gwei</span>
-          </div>
-        </div>
-
-        <div class="fee-detail-row" *ngIf="gasLimit()">
-          <span class="detail-label">Gas Limit</span>
-          <div class="detail-value">
-            <span>{{ gasLimit() | number }}</span>
-          </div>
-        </div>
-
-        <div class="fee-detail-row total-row" *ngIf="totalFeeDisplay() !== undefined">
-          <span class="detail-label">Total Fee</span>
-          <div class="detail-value highlight">
-            <span>{{ totalFeeDisplay() | number:'1.4-8' }}</span>
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</div>
+}

--- a/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.ts
+++ b/src/app/components/wallet-actions-reviews/l2-priority-fee-selection/l2-priority-fee-selection.component.ts
@@ -8,47 +8,52 @@ import {
   signal,
   SimpleChanges,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import {
-  CommonModule,
-  NgIf,
-} from '@angular/common';
-import { trigger, state, style, transition, animate } from '@angular/animations';
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+} from '@angular/animations';
 import { WalletAction } from '../../../types/wallet-action';
 import { AppWallet } from '../../../classes/AppWallet';
 import { FormsModule } from '@angular/forms';
 import { KcIconComponent, KcInputComponent } from '@kaspacom/ui';
-import { EIP1193RequestPayload, EIP1193RequestType, EthTransactionParams } from '@kaspacom/wallet-messages';
+import {
+  EIP1193RequestPayload,
+  EIP1193RequestType,
+  EthTransactionParams,
+} from '@kaspacom/wallet-messages';
 import { ethers, FeeData } from 'ethers';
-
 
 type AvailableOption = 'low' | 'normal' | 'priority' | 'custom';
 const MIN_GAS_LIMIT = 21000n;
 const MIN_CUSTOM_FEE = 1;
 
-
 @Component({
   selector: 'l2-priority-fee-selection',
   templateUrl: './l2-priority-fee-selection.component.html',
   styleUrls: ['./l2-priority-fee-selection.component.scss'],
-  imports: [
-    NgIf,
-    FormsModule,
-    CommonModule,
-    KcIconComponent,
-    KcInputComponent,
-  ],
+  imports: [FormsModule, CommonModule, KcIconComponent, KcInputComponent],
   animations: [
     trigger('slideDown', [
-      state('closed', style({
-        height: '0px',
-        opacity: 0,
-        overflow: 'hidden',
-      })),
-      state('open', style({
-        height: '*',
-        opacity: 1,
-        overflow: 'visible',
-      })),
+      state(
+        'closed',
+        style({
+          height: '0px',
+          opacity: 0,
+          overflow: 'hidden',
+        }),
+      ),
+      state(
+        'open',
+        style({
+          height: '*',
+          opacity: 1,
+          overflow: 'visible',
+        }),
+      ),
       transition('closed => open', [animate('400ms ease-out')]),
       transition('open => closed', [animate('300ms ease-in')]),
     ]),
@@ -57,10 +62,13 @@ const MIN_CUSTOM_FEE = 1;
 export class L2PriorityFeeSelectionComponent implements OnChanges {
   @Input() action!: WalletAction;
   @Input() wallet!: AppWallet;
-  @Output() priorityFeeSelected = new EventEmitter<{
-    priorityFee: bigint;
-    baseFee: bigint;
-  } | undefined>();
+  @Output() priorityFeeSelected = new EventEmitter<
+    | {
+        priorityFee: bigint;
+        baseFee: bigint;
+      }
+    | undefined
+  >();
   @Output() gasLimitSelected = new EventEmitter<bigint | undefined>();
 
   protected customFee = signal<number>(0);
@@ -94,7 +102,10 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
     // EIP-1559 exposes maxPriorityFeePerGas; legacy chains only expose
     // gasPrice. Require at least one to be present so we can render a
     // sensible fee option list.
-    if (this.feeData.maxPriorityFeePerGas == null && this.feeData.gasPrice == null) {
+    if (
+      this.feeData.maxPriorityFeePerGas == null &&
+      this.feeData.gasPrice == null
+    ) {
       return undefined;
     }
 
@@ -111,13 +122,19 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
   protected gasFeeOptionToDisplay = computed(() => {
     if (!this.gasFeeOtions() || !this.gasLimitBigInt()) return undefined;
 
-    const formattedOptions: { [key: string]: { value: bigint; display: number } } = {};
-    const baseFeePerGas = (this.feeData!.gasPrice || 0n) - (this.feeData!.maxPriorityFeePerGas || 0n);
+    const formattedOptions: {
+      [key: string]: { value: bigint; display: number };
+    } = {};
+    const baseFeePerGas =
+      (this.feeData!.gasPrice || 0n) -
+      (this.feeData!.maxPriorityFeePerGas || 0n);
 
     for (const [key, value] of Object.entries(this.gasFeeOtions()!)) {
       formattedOptions[key] = {
         value,
-        display: this.fromWeiToKas((value + baseFeePerGas) * this.gasLimitBigInt()!),
+        display: this.fromWeiToKas(
+          (value + baseFeePerGas) * this.gasLimitBigInt()!,
+        ),
       };
     }
 
@@ -126,15 +143,17 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
 
   protected currentBaseFee = computed(() => {
     return this.fromWeiToKas(
-      ((this.feeData?.gasPrice || 0n) - (this.feeData?.maxPriorityFeePerGas || 0n)) *
-      (this.gasLimitBigInt() || 0n)
+      ((this.feeData?.gasPrice || 0n) -
+        (this.feeData?.maxPriorityFeePerGas || 0n)) *
+        (this.gasLimitBigInt() || 0n),
     );
   });
 
   protected totalFeeDisplay = computed(() => {
     const displayOptions = this.gasFeeOptionToDisplay();
     if (!displayOptions) return undefined;
-    if (this.selectedOption() === 'custom' && !this.isCustomFeeValid()) return undefined;
+    if (this.selectedOption() === 'custom' && !this.isCustomFeeValid())
+      return undefined;
     if (!this.isGasLimitValid()) return undefined;
     return displayOptions[this.selectedOption()]?.display;
   });
@@ -151,7 +170,9 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
 
     this.priorityFeeSelected.emit({
       priorityFee: amount,
-      baseFee: (this.feeData?.gasPrice || 0n) - (this.feeData?.maxPriorityFeePerGas || 0n),
+      baseFee:
+        (this.feeData?.gasPrice || 0n) -
+        (this.feeData?.maxPriorityFeePerGas || 0n),
     });
   }
 
@@ -166,8 +187,15 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
   selectOption(option: AvailableOption | string) {
     this.selectedOption.set(option as AvailableOption);
 
-    if (option !== 'custom' && this.gasFeeOtions() && option in this.gasFeeOtions()!) {
-      const fee = this.gasFeeOtions()![option as 'low' | 'normal' | 'priority' | 'custom'];
+    if (
+      option !== 'custom' &&
+      this.gasFeeOtions() &&
+      option in this.gasFeeOtions()!
+    ) {
+      const fee =
+        this.gasFeeOtions()![
+          option as 'low' | 'normal' | 'priority' | 'custom'
+        ];
       this.feeSelected(fee);
     } else if (option === 'custom') {
       if (!this.isCustomFeeValid()) {
@@ -187,23 +215,28 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
 
   async loadPriorityFeeDataAndEmit(action: WalletAction): Promise<void> {
     this.hasGasLimitError = false;
-    const actionData: EIP1193RequestPayload<EIP1193RequestType> = action.data as EIP1193RequestPayload<EIP1193RequestType>;
-    const transaction: EthTransactionParams = actionData.params[0] as EthTransactionParams;
+    const actionData: EIP1193RequestPayload<EIP1193RequestType> =
+      action.data as EIP1193RequestPayload<EIP1193RequestType>;
+    const transaction: EthTransactionParams = actionData
+      .params[0] as EthTransactionParams;
 
     const provider = this.wallet.getL2Provider();
     if (!provider) throw new Error('No provider found');
 
     try {
-      let gasForTransaction = await provider.estimateGas((await this.wallet.getL2Wallet())!, {
-        from: transaction.from,
-        to: transaction.to,
-        value: transaction.value,
-        data: transaction.data,
-        nonce: transaction.nonce ? parseInt(transaction.nonce) : undefined,
-      });
+      let gasForTransaction = await provider.estimateGas(
+        (await this.wallet.getL2Wallet())!,
+        {
+          from: transaction.from,
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          nonce: transaction.nonce ? parseInt(transaction.nonce) : undefined,
+        },
+      );
 
       if (gasForTransaction !== MIN_GAS_LIMIT) {
-        gasForTransaction = gasForTransaction * 125n / 100n;
+        gasForTransaction = (gasForTransaction * 125n) / 100n;
       }
 
       this.gasLimit.set(Number(gasForTransaction));
@@ -219,7 +252,12 @@ export class L2PriorityFeeSelectionComponent implements OnChanges {
   }
 
   fromWeiToKas(number: bigint): number {
-    return Number(ethers.formatUnits(number, this.wallet.getL2Provider()?.getConfig().nativeCurrency.decimals));
+    return Number(
+      ethers.formatUnits(
+        number,
+        this.wallet.getL2Provider()?.getConfig().nativeCurrency.decimals,
+      ),
+    );
   }
 
   fromWeiToGwei(number: bigint): string {

--- a/src/app/components/wallet-actions-reviews/priority-fee-selection/priority-fee-selection.component.html
+++ b/src/app/components/wallet-actions-reviews/priority-fee-selection/priority-fee-selection.component.html
@@ -1,134 +1,156 @@
-<div class="fee-spoiler-container" *ngIf="currentOptions">
-  <!-- Fee Toggle Header -->
-  <div class="fee-spoiler-toggle" (click)="toggleFeeSelection()">
-    <div class="fee-summary-left">
-      <kc-icon iconClass="icon-chain" size="sm" color="var(--kaspa-20)"></kc-icon>
-      <span class="fee-label">
-        <ng-container *ngIf="totalTransactionsMass && totalTransactionsMass.length > 1">
-          Estimated Total Fees: 
-        </ng-container>
-        <ng-container *ngIf="totalTransactionsMass && totalTransactionsMass.length == 1">
-          Total Fee: 
-        </ng-container>
-      </span>
-      <div class="fee-value">
-        <ng-container *ngIf="totalTransactionsMass && totalTransactionsMass.length > 1">
-          <span>≈{{ getEstimatedTotalFees() | sompiToNumber }}</span>
-          <!-- Always show kaspa icon for fees -->
-          <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-        </ng-container>
-        <ng-container *ngIf="totalTransactionsMass && totalTransactionsMass.length == 1">
-          <ng-container *ngIf="additionalPriorityFee === undefined">
-            <span>Not selected</span>
-          </ng-container>
-          <ng-container *ngIf="additionalPriorityFee !== undefined">
-            <span>{{ getEstimatedTotalFees() | sompiToNumber }}</span>
+@if (currentOptions) {
+  <div class="fee-spoiler-container">
+    <!-- Fee Toggle Header -->
+    <div class="fee-spoiler-toggle" (click)="toggleFeeSelection()">
+      <div class="fee-summary-left">
+        <kc-icon
+          iconClass="icon-chain"
+          size="sm"
+          color="var(--kaspa-20)"
+        ></kc-icon>
+        <span class="fee-label">
+          @if (totalTransactionsMass && totalTransactionsMass.length > 1) {
+            Estimated Total Fees:
+          }
+          @if (totalTransactionsMass && totalTransactionsMass.length == 1) {
+            Total Fee:
+          }
+        </span>
+        <div class="fee-value">
+          @if (totalTransactionsMass && totalTransactionsMass.length > 1) {
+            <span>≈{{ getEstimatedTotalFees() | sompiToNumber }}</span>
             <!-- Always show kaspa icon for fees -->
             <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </ng-container>
-        </ng-container>
-      </div>
-    </div>
-    <div class="fee-spoiler-chevron">
-      <kc-icon 
-        [iconClass]="showPriorityFeeSelection ? 'icon-chevron-up' : 'icon-chevron-down'" 
-        size="sm" 
-        color="var(--gray-60)">
-      </kc-icon>
-    </div>
-  </div>
-
-  <!-- Fee Selection Content (Collapsible) -->
-  <div class="fee-selection-content" [@slideDown]="showPriorityFeeSelection ? 'open' : 'closed'">
-    <div class="fee-selection-inner">
-      
-      <!-- Fee Options -->
-      <div class="fee-options-grid">
-        <div *ngFor="let option of currentOptions | keyvalue" 
-             class="fee-option-card"
-             [class.selected]="selectedOption === option.key" 
-             (click)="selectOption(option.key)">
-          <div class="option-title">{{ option.key | titlecase }}</div>
-          <div class="option-fee">
-            <span>{{ option.value.priorityFee | sompiToNumber }}</span>
-            <!-- Always show kaspa icon for fees -->
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-          <div class="option-time">~{{ option.value.estimatedSeconds.toFixed(1) }}s</div>
+          }
+          @if (totalTransactionsMass && totalTransactionsMass.length == 1) {
+            @if (additionalPriorityFee === undefined) {
+              <span>Not selected</span>
+            }
+            @if (additionalPriorityFee !== undefined) {
+              <span>{{ getEstimatedTotalFees() | sompiToNumber }}</span>
+              <!-- Always show kaspa icon for fees -->
+              <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+            }
+          }
         </div>
       </div>
-
-      <!-- Custom Fee -->
-      <div class="custom-fee-section">
-        <div class="custom-fee-card" 
-             [class.selected]="selectedOption === 'custom'" 
-             (click)="selectOption('custom')">
-          <div class="custom-fee-header">
-            <span class="custom-fee-title">Custom Fee</span>
-          </div>
-          <div class="custom-fee-input">
-            <kc-input 
-              type="number"
-              placeholder="Enter amount"
-              [(ngModel)]="customFee"
-              (valueChange)="selectOption('custom')">
-              <div rightSideSlot class="input-icon">
+      <div class="fee-spoiler-chevron">
+        <kc-icon
+          [iconClass]="
+            showPriorityFeeSelection ? 'icon-chevron-up' : 'icon-chevron-down'
+          "
+          size="sm"
+          color="var(--gray-60)"
+        >
+        </kc-icon>
+      </div>
+    </div>
+    <!-- Fee Selection Content (Collapsible) -->
+    <div
+      class="fee-selection-content"
+      [@slideDown]="showPriorityFeeSelection ? 'open' : 'closed'"
+    >
+      <div class="fee-selection-inner">
+        <!-- Fee Options -->
+        <div class="fee-options-grid">
+          @for (option of currentOptions | keyvalue; track option) {
+            <div
+              class="fee-option-card"
+              [class.selected]="selectedOption === option.key"
+              (click)="selectOption(option.key)"
+            >
+              <div class="option-title">{{ option.key | titlecase }}</div>
+              <div class="option-fee">
+                <span>{{ option.value.priorityFee | sompiToNumber }}</span>
                 <!-- Always show kaspa icon for fees -->
                 <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
               </div>
-            </kc-input>
+              <div class="option-time">
+                ~{{ option.value.estimatedSeconds.toFixed(1) }}s
+              </div>
+            </div>
+          }
+        </div>
+        <!-- Custom Fee -->
+        <div class="custom-fee-section">
+          <div
+            class="custom-fee-card"
+            [class.selected]="selectedOption === 'custom'"
+            (click)="selectOption('custom')"
+          >
+            <div class="custom-fee-header">
+              <span class="custom-fee-title">Custom Fee</span>
+            </div>
+            <div class="custom-fee-input">
+              <kc-input
+                type="number"
+                placeholder="Enter amount"
+                [(ngModel)]="customFee"
+                (valueChange)="selectOption('custom')"
+              >
+                <div rightSideSlot class="input-icon">
+                  <!-- Always show kaspa icon for fees -->
+                  <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+                </div>
+              </kc-input>
+            </div>
           </div>
         </div>
-      </div>
-
-      <!-- Fee Details -->
-      <div class="fee-details-section">
-        <div class="fee-detail-row">
-          <span class="detail-label">Minimum transaction fee:</span>
-          <div class="detail-value">
-            <span>{{ transactionMass! * minimumFeeMultiplier | sompiToNumber }}</span>
-            <!-- Always show kaspa icon for fees -->
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-          </div>
-        </div>
-        
-        <div class="fee-detail-row">
-          <span class="detail-label">Additional Priority fee:</span>
-          <div class="detail-value">
-            <ng-container *ngIf="additionalPriorityFee === undefined">
-              <span>Not selected</span>
-            </ng-container>
-            <ng-container *ngIf="additionalPriorityFee !== undefined">
-              <span>{{ additionalPriorityFee | sompiToNumber }}</span>
+        <!-- Fee Details -->
+        <div class="fee-details-section">
+          <div class="fee-detail-row">
+            <span class="detail-label">Minimum transaction fee:</span>
+            <div class="detail-value">
+              <span>{{
+                transactionMass! * minimumFeeMultiplier | sompiToNumber
+              }}</span>
               <!-- Always show kaspa icon for fees -->
               <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
-            </ng-container>
+            </div>
           </div>
-        </div>
-
-        <div *ngIf="getAdditionalCommitActionPrice() > 0" class="fee-detail-row">
-          <span class="detail-label">Protocol Action Fee:</span>
-          <div class="detail-value">
-            <span>{{ getAdditionalCommitActionPrice() | sompiToNumber }}</span>
-            <!-- Always show kaspa icon for fees -->
-            <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+          <div class="fee-detail-row">
+            <span class="detail-label">Additional Priority fee:</span>
+            <div class="detail-value">
+              @if (additionalPriorityFee === undefined) {
+                <span>Not selected</span>
+              }
+              @if (additionalPriorityFee !== undefined) {
+                <span>{{ additionalPriorityFee | sompiToNumber }}</span>
+                <!-- Always show kaspa icon for fees -->
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              }
+            </div>
           </div>
-        </div>
-
-        <div *ngIf="totalTransactionsMass && totalTransactionsMass.length > 1" class="fee-detail-row">
-          <span class="detail-label">Number Of Transactions:</span>
-          <div class="detail-value">
-            <span>{{ totalTransactionsMass!.length }}</span>
-            <!-- No icon needed for transaction count -->
-          </div>
+          @if (getAdditionalCommitActionPrice() > 0) {
+            <div class="fee-detail-row">
+              <span class="detail-label">Protocol Action Fee:</span>
+              <div class="detail-value">
+                <span>{{
+                  getAdditionalCommitActionPrice() | sompiToNumber
+                }}</span>
+                <!-- Always show kaspa icon for fees -->
+                <kc-icon iconClass="icon-kaspa-coin" size="sm"></kc-icon>
+              </div>
+            </div>
+          }
+          @if (totalTransactionsMass && totalTransactionsMass.length > 1) {
+            <div class="fee-detail-row">
+              <span class="detail-label">Number Of Transactions:</span>
+              <div class="detail-value">
+                <span>{{ totalTransactionsMass!.length }}</span>
+                <!-- No icon needed for transaction count -->
+              </div>
+            </div>
+          }
         </div>
       </div>
-
     </div>
   </div>
-</div>
+}
 
 <!-- Loading State -->
-<div *ngIf="!currentOptions" class="fee-loading">
-  <p>Loading Priority Fees...</p>
-</div>
+@if (!currentOptions) {
+  <div class="fee-loading">
+    <p>Loading Priority Fees...</p>
+  </div>
+}

--- a/src/app/components/wallet-actions-reviews/priority-fee-selection/priority-fee-selection.component.ts
+++ b/src/app/components/wallet-actions-reviews/priority-fee-selection/priority-fee-selection.component.ts
@@ -6,13 +6,14 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 import {
-  CommonModule,
-  NgFor,
-  NgIf,
-  TitleCasePipe,
-} from '@angular/common';
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+} from '@angular/animations';
+import { CommonModule, TitleCasePipe } from '@angular/common';
 import { SompiToNumberPipe } from '../../../pipes/sompi-to-number.pipe';
 import { WalletAction, WalletActionType } from '../../../types/wallet-action';
 import { KaspaNetworkActionsService } from '../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
@@ -36,8 +37,6 @@ const MINIMUM_FEE_MULTIPLIER = 100n;
   templateUrl: './priority-fee-selection.component.html',
   styleUrls: ['./priority-fee-selection.component.scss'],
   imports: [
-    NgIf,
-    NgFor,
     SompiToNumberPipe,
     FormsModule,
     TitleCasePipe,
@@ -47,24 +46,26 @@ const MINIMUM_FEE_MULTIPLIER = 100n;
   ],
   animations: [
     trigger('slideDown', [
-      state('closed', style({
-        height: '0px',
-        opacity: 0,
-        overflow: 'hidden'
-      })),
-      state('open', style({
-        height: '*',
-        opacity: 1,
-        overflow: 'visible'
-      })),
-      transition('closed => open', [
-        animate('400ms ease-out')
-      ]),
-      transition('open => closed', [
-        animate('300ms ease-in')
-      ])
-    ])
-  ]
+      state(
+        'closed',
+        style({
+          height: '0px',
+          opacity: 0,
+          overflow: 'hidden',
+        }),
+      ),
+      state(
+        'open',
+        style({
+          height: '*',
+          opacity: 1,
+          overflow: 'visible',
+        }),
+      ),
+      transition('closed => open', [animate('400ms ease-out')]),
+      transition('open => closed', [animate('300ms ease-in')]),
+    ]),
+  ],
 })
 export class PriorityFeeSelectionComponent implements OnChanges {
   @Input() action!: WalletAction;
@@ -78,10 +79,10 @@ export class PriorityFeeSelectionComponent implements OnChanges {
   protected currentOptions:
     | undefined
     | {
-      low: BucketFeeRate;
-      normal: BucketFeeRate;
-      priority: BucketFeeRate;
-    } = undefined;
+        low: BucketFeeRate;
+        normal: BucketFeeRate;
+        priority: BucketFeeRate;
+      } = undefined;
 
   protected customFee: number = 0;
   protected selectedOption: AvailableOption = 'normal';
@@ -91,10 +92,14 @@ export class PriorityFeeSelectionComponent implements OnChanges {
   constructor(
     protected kaspaNetworkActionsService: KaspaNetworkActionsService,
     protected krc20OperationsDataService: Krc20OperationDataService,
-  ) { }
+  ) {}
 
   // Methods to determine transaction type and asset info
-  getTransactionAssetInfo(): { type: 'kaspa' | 'krc20' | 'krc721' | 'kns', ticker?: string, imageUrl?: string } {
+  getTransactionAssetInfo(): {
+    type: 'kaspa' | 'krc20' | 'krc721' | 'kns';
+    ticker?: string;
+    imageUrl?: string;
+  } {
     if (this.action.type === WalletActionType.TRANSFER_KAS) {
       return { type: 'kaspa' };
     }
@@ -147,7 +152,7 @@ export class PriorityFeeSelectionComponent implements OnChanges {
     ]);
 
     const maxTransactionMass = Math.max(
-      ...this.totalTransactionsMass!.map((m) => Number(m))
+      ...this.totalTransactionsMass!.map((m) => Number(m)),
     );
 
     this.transactionMass = BigInt(maxTransactionMass);
@@ -157,22 +162,28 @@ export class PriorityFeeSelectionComponent implements OnChanges {
 
     this.currentOptions = {
       low: {
-        priorityFee: BigInt(Math.round(
-          this.currentFeeRates!.lowBuckets[0].feerate * maxTransactionMass)
+        priorityFee: BigInt(
+          Math.round(
+            this.currentFeeRates!.lowBuckets[0].feerate * maxTransactionMass,
+          ),
         ),
 
         estimatedSeconds: this.currentFeeRates!.lowBuckets[0].estimatedSeconds,
       },
       normal: {
-        priorityFee: BigInt(Math.round(
-          this.currentFeeRates!.normalBuckets[0].feerate * maxTransactionMass)
+        priorityFee: BigInt(
+          Math.round(
+            this.currentFeeRates!.normalBuckets[0].feerate * maxTransactionMass,
+          ),
         ),
         estimatedSeconds:
           this.currentFeeRates!.normalBuckets[0].estimatedSeconds,
       },
       priority: {
-        priorityFee: BigInt(Math.round(
-          this.currentFeeRates!.priorityBucket.feerate * maxTransactionMass)
+        priorityFee: BigInt(
+          Math.round(
+            this.currentFeeRates!.priorityBucket.feerate * maxTransactionMass,
+          ),
         ),
         estimatedSeconds: this.currentFeeRates!.priorityBucket.estimatedSeconds,
       },
@@ -184,9 +195,9 @@ export class PriorityFeeSelectionComponent implements OnChanges {
   feeSelected(amount: bigint | undefined) {
     this.additionalPriorityFee =
       amount !== undefined
-        ? amount - (this.transactionMass! * MINIMUM_FEE_MULTIPLIER) < 0n
+        ? amount - this.transactionMass! * MINIMUM_FEE_MULTIPLIER < 0n
           ? 0n
-          : amount - (this.transactionMass! * MINIMUM_FEE_MULTIPLIER)
+          : amount - this.transactionMass! * MINIMUM_FEE_MULTIPLIER
         : undefined;
 
     this.priorityFeeSelected.emit(this.additionalPriorityFee);
@@ -206,7 +217,7 @@ export class PriorityFeeSelectionComponent implements OnChanges {
       this.feeSelected(fee);
     } else if (option == 'custom') {
       this.feeSelected(
-        this.kaspaNetworkActionsService.kaspaToSompiFromNumber(this.customFee!)
+        this.kaspaNetworkActionsService.kaspaToSompiFromNumber(this.customFee!),
       );
     }
   }
@@ -220,7 +231,8 @@ export class PriorityFeeSelectionComponent implements OnChanges {
     }
 
     return (
-      (this.totalTransactionsMass.reduce((a, b) => a + b, 0n) * MINIMUM_FEE_MULTIPLIER) +
+      this.totalTransactionsMass.reduce((a, b) => a + b, 0n) *
+        MINIMUM_FEE_MULTIPLIER +
       this.additionalPriorityFee * BigInt(this.totalTransactionsMass.length) +
       this.getAdditionalCommitActionPrice()
     );

--- a/src/app/components/wallet-actions-reviews/review-action/review-action.component.html
+++ b/src/app/components/wallet-actions-reviews/review-action/review-action.component.html
@@ -1,87 +1,113 @@
-<div class="modal-overlay" *ngIf="currentActionSignal()">
-  <div class="transaction-review-container">
-    <div class="transaction-header">
-      <h2 class="typo-title-4" *ngIf="isActionHasPriorityFee">Transaction Review</h2>
-      <h2 class="typo-title-4" *ngIf="!isActionHasPriorityFee">Action Review</h2>
-      <p class="typo-text-3">Please review the details below before proceeding.</p>
-    </div>
-
-    <div class="transaction-content">
-      <ng-container *ngIf="currentActionDisplay(); else unknownAction">
-        <h3 class="typo-title-3">{{ currentActionDisplay()!.title }}</h3>
-        <h4 class="typo-text-3" *ngIf="currentActionDisplay()!.subtitle">{{ currentActionDisplay()!.subtitle }}</h4>
-
-        <div class="details-list">
-          <div *ngFor="let row of currentActionDisplay()!.rows">
-            <div *ngIf="row.inputField; else noInputField">
-              <div *ngIf="row.inputField.fieldType == InputFieldType.CHECKBOX">
-                <div class="checkbox-container">
-                  <kc-checkbox
-                    [label]="row.fieldName"
-                    [isChecked]="row.fieldValue === 'true'"
-                    (checkedChange)="additionalParams[row.inputField.fieldParam] = $event"
-                    size="md">
-                  </kc-checkbox>
-                </div>
+@if (currentActionSignal()) {
+  <div class="modal-overlay">
+    <div class="transaction-review-container">
+      <div class="transaction-header">
+        @if (isActionHasPriorityFee) {
+          <h2 class="typo-title-4">Transaction Review</h2>
+        }
+        @if (!isActionHasPriorityFee) {
+          <h2 class="typo-title-4">Action Review</h2>
+        }
+        <p class="typo-text-3">
+          Please review the details below before proceeding.
+        </p>
+      </div>
+      <div class="transaction-content">
+        @if (currentActionDisplay()) {
+          <h3 class="typo-title-3">{{ currentActionDisplay()!.title }}</h3>
+          @if (currentActionDisplay()!.subtitle) {
+            <h4 class="typo-text-3">{{ currentActionDisplay()!.subtitle }}</h4>
+          }
+          <div class="details-list">
+            @for (row of currentActionDisplay()!.rows; track row) {
+              <div>
+                @if (row.inputField) {
+                  <div>
+                    @if (row.inputField.fieldType == InputFieldType.CHECKBOX) {
+                      <div>
+                        <div class="checkbox-container">
+                          <kc-checkbox
+                            [label]="row.fieldName"
+                            [isChecked]="row.fieldValue === 'true'"
+                            (checkedChange)="
+                              additionalParams[row.inputField.fieldParam] =
+                                $event
+                            "
+                            size="md"
+                          >
+                          </kc-checkbox>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                } @else {
+                  <div
+                    [ngClass]="{
+                      detail: !row.isCodeBlock,
+                      'detail-signing-message': row.isCodeBlock,
+                    }"
+                  >
+                    <div class="label typo-caption-semibold">
+                      {{ row.fieldName }}
+                    </div>
+                    <div class="value typo-text-2">{{ row.fieldValue }}</div>
+                  </div>
+                }
               </div>
-            </div>
-            <ng-template #noInputField>
-              <div [ngClass]="{'detail': !row.isCodeBlock, 'detail-signing-message': row.isCodeBlock}">
-                <div class="label typo-caption-semibold">{{ row.fieldName }}</div>
-                <div class="value typo-text-2">{{ row.fieldValue }}</div>
-              </div>
-            </ng-template>
+            }
           </div>
-        </div>
-      </ng-container>
-
-      <ng-template #unknownAction>
-        <p class="typo-text-3">Unknown Action Type ({{ currentActionSignal()?.action?.type }})</p>
-      </ng-template>
-
-      <!-- Priority fee -->
-      <priority-fee-selection *ngIf="isActionHasPriorityFee && currentActionSignal()"
-        [action]="currentActionSignal()!.action" [wallet]="wallet"
-        (priorityFeeSelected)="setCurrentPriorityFee($event)"></priority-fee-selection>
-    </div>
-
-    <!-- Actions buttons -->
-    <div class="transaction-actions">
-      <kc-button
-        text="Approve"
-        variant="primary"
-        size="lg"
-        [isFullWidth]="true"
-        [isDisabled]="!isAvailableForApproval()"
-        (buttonClick)="acceptTransaction()">
-      </kc-button>
-      <kc-button
-        text="Reject"
-        variant="tertiary"
-        size="lg"
-        [isFullWidth]="true"
-        (buttonClick)="rejectTransaction()">
-      </kc-button>
+        } @else {
+          <p class="typo-text-3">
+            Unknown Action Type ({{ currentActionSignal()?.action?.type }})
+          </p>
+        }
+        <!-- Priority fee -->
+        @if (isActionHasPriorityFee && currentActionSignal()) {
+          <priority-fee-selection
+            [action]="currentActionSignal()!.action"
+            [wallet]="wallet"
+            (priorityFeeSelected)="setCurrentPriorityFee($event)"
+          ></priority-fee-selection>
+        }
+      </div>
+      <!-- Actions buttons -->
+      <div class="transaction-actions">
+        <kc-button
+          text="Approve"
+          variant="primary"
+          size="lg"
+          [isFullWidth]="true"
+          [isDisabled]="!isAvailableForApproval()"
+          (buttonClick)="acceptTransaction()"
+        >
+        </kc-button>
+        <kc-button
+          text="Reject"
+          variant="tertiary"
+          size="lg"
+          [isFullWidth]="true"
+          (buttonClick)="rejectTransaction()"
+        >
+        </kc-button>
+      </div>
     </div>
   </div>
-</div>
+}
 
 <!-- Progress and result handling - shown without modal overlay -->
-<ng-container *ngIf="!currentActionSignal()">
-  <ng-container *ngIf="currentProgressSignal() !== undefined || actionResultSignal(); else noActionToShow">
+@if (!currentActionSignal()) {
+  @if (currentProgressSignal() !== undefined || actionResultSignal()) {
     <div class="modal-overlay">
       <div class="transaction-review-container">
-        <ng-container *ngIf="currentProgressSignal() !== undefined">
+        @if (currentProgressSignal() !== undefined) {
           <div class="progress-container">
             <h3 class="typo-title-4">Processing Action...</h3>
             <div class="progress-bar">
               <div class="progress-fill"></div>
             </div>
           </div>
-        </ng-container>
+        }
       </div>
     </div>
-  </ng-container>
-
-  <ng-template #noActionToShow></ng-template>
-</ng-container>
+  } @else {}
+}

--- a/src/app/components/wallet-actions-reviews/review-action/review-action.component.ts
+++ b/src/app/components/wallet-actions-reviews/review-action/review-action.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed } from '@angular/core';
-import { NgClass, NgFor, NgIf } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   SignPsktTransactionAction,
@@ -12,17 +12,26 @@ import { PriorityFeeSelectionComponent } from '../priority-fee-selection/priorit
 import { AppWallet } from '../../../classes/AppWallet';
 import { ReviewActionDataService } from '../../../services/action-info-services/review-action-data.service';
 import { WalletActionService } from '../../../services/wallet-action.service';
-import { EIP1193RequestPayload, EIP1193RequestType } from '@kaspacom/wallet-messages';
+import {
+  EIP1193RequestPayload,
+  EIP1193RequestType,
+} from '@kaspacom/wallet-messages';
 import { InputFieldType } from '../../../types/action-display.type';
 import { KcButtonComponent, KcCheckboxComponent } from 'kaspacom-ui';
 
 const TIMEOUT = 2 * 60 * 1000;
 
 @Component({
-    selector: 'review-action',
-    templateUrl: './review-action.component.html',
-    styleUrls: ['./review-action.component.scss'],
-    imports: [NgIf, NgFor, NgClass, PriorityFeeSelectionComponent, FormsModule, KcButtonComponent, KcCheckboxComponent]
+  selector: 'review-action',
+  templateUrl: './review-action.component.html',
+  styleUrls: ['./review-action.component.scss'],
+  imports: [
+    NgClass,
+    PriorityFeeSelectionComponent,
+    FormsModule,
+    KcButtonComponent,
+    KcCheckboxComponent,
+  ],
 })
 export class ReviewActionComponent {
   public WalletActionType = WalletActionType;
@@ -30,11 +39,23 @@ export class ReviewActionComponent {
   public InputFieldType = InputFieldType;
   public Number = Number;
 
-  currentActionDisplay = computed(() => this.currentActionSignal ? this.reviewActionDataService.getActionDisplay(this.currentActionSignal()?.action, this.wallet) : undefined);
-  currentActionSignal = computed(() => this.walletActionService.getActionToApproveSignal()());
-  currentProgressSignal = computed(() => this.walletActionService.getCurrentProgressSignal()());
-  actionResultSignal = computed(() => this.walletActionService.getActionResultSignal()());
-
+  currentActionDisplay = computed(() =>
+    this.currentActionSignal
+      ? this.reviewActionDataService.getActionDisplay(
+          this.currentActionSignal()?.action,
+          this.wallet,
+        )
+      : undefined,
+  );
+  currentActionSignal = computed(() =>
+    this.walletActionService.getActionToApproveSignal()(),
+  );
+  currentProgressSignal = computed(() =>
+    this.walletActionService.getCurrentProgressSignal()(),
+  );
+  actionResultSignal = computed(() =>
+    this.walletActionService.getActionResultSignal()(),
+  );
 
   private resolve:
     | ((result: { isApproved: boolean; priorityFee?: bigint }) => void)
@@ -46,7 +67,11 @@ export class ReviewActionComponent {
   protected currentPriorityFee: bigint | undefined = undefined;
   protected additionalParams: { [key: string]: any } = {};
 
-  constructor(private walletService: WalletService, private walletActionService: WalletActionService, private readonly reviewActionDataService: ReviewActionDataService) { }
+  constructor(
+    private walletService: WalletService,
+    private walletActionService: WalletActionService,
+    private readonly reviewActionDataService: ReviewActionDataService,
+  ) {}
 
   requestUserConfirmation(action: WalletAction): Promise<{
     isApproved: boolean;
@@ -58,8 +83,6 @@ export class ReviewActionComponent {
     return this.initAction(action);
   }
 
-
-
   // COMPONENT MANAGEMENT
   private clearData() {
     clearTimeout(this.timeout!);
@@ -68,7 +91,11 @@ export class ReviewActionComponent {
   }
 
   private resolveActionAndClear(isApproved: boolean) {
-    this.walletActionService.resolveCurrentWaitingForApproveAction(isApproved, isApproved ? this.currentPriorityFee! : undefined, isApproved ? this.additionalParams : undefined);
+    this.walletActionService.resolveCurrentWaitingForApproveAction(
+      isApproved,
+      isApproved ? this.currentPriorityFee! : undefined,
+      isApproved ? this.additionalParams : undefined,
+    );
     this.clearData();
   }
 
@@ -114,7 +141,9 @@ export class ReviewActionComponent {
   }
 
   isAvailableForApproval(): boolean {
-    return this.currentPriorityFee !== undefined || !this.isActionHasPriorityFee;
+    return (
+      this.currentPriorityFee !== undefined || !this.isActionHasPriorityFee
+    );
   }
 
   protected get isActionHasPriorityFee() {
@@ -122,12 +151,21 @@ export class ReviewActionComponent {
       return false;
     }
 
-    if ([WalletActionType.SIGN_MESSAGE, WalletActionType.APPROVE_COMMUNICATION_APP].includes(this.currentActionSignal()!.action.type)) {
+    if (
+      [
+        WalletActionType.SIGN_MESSAGE,
+        WalletActionType.APPROVE_COMMUNICATION_APP,
+      ].includes(this.currentActionSignal()!.action.type)
+    ) {
       return false;
     }
 
-    if (this.currentActionSignal()!.action.type === WalletActionType.EIP1193_PROVIDER_REQUEST) {
-      const actionData = this.currentActionSignal()!.action.data as EIP1193RequestPayload<EIP1193RequestType>;
+    if (
+      this.currentActionSignal()!.action.type ===
+      WalletActionType.EIP1193_PROVIDER_REQUEST
+    ) {
+      const actionData = this.currentActionSignal()!.action
+        .data as EIP1193RequestPayload<EIP1193RequestType>;
 
       if (actionData.method != EIP1193RequestType.KAS_SEND_TRANSACTION) {
         return false;
@@ -135,8 +173,10 @@ export class ReviewActionComponent {
     }
 
     if (
-      this.currentActionSignal()!.action.type === WalletActionType.SIGN_PSKT_TRANSACTION &&
-      (this.currentActionSignal()!.action.data as SignPsktTransactionAction).signOnly
+      this.currentActionSignal()!.action.type ===
+        WalletActionType.SIGN_PSKT_TRANSACTION &&
+      (this.currentActionSignal()!.action.data as SignPsktTransactionAction)
+        .signOnly
     ) {
       return false;
     }

--- a/src/app/components/wallet-management/export-wallets-qr/export-wallets-qr.component.html
+++ b/src/app/components/wallet-management/export-wallets-qr/export-wallets-qr.component.html
@@ -1,44 +1,48 @@
 <div class="container">
-  <button class="action-button" (click)="handleButtonClick()" *ngIf="!passwordFilled">Sync With Other Device</button>
+  @if (!passwordFilled) {
+    <button class="action-button" (click)="handleButtonClick()">
+      Sync With Other Device
+    </button>
+  }
 
   <!-- Password Prompt -->
-  <div *ngIf="showPasswordPrompt">
-    <div class="password-prompt">
-      <label for="password">Enter Your Password:</label>
-      <input id="password" type="password" #passwordInput />
-      <button class="verify-button" (click)="verifyPassword(passwordInput.value)">
-        Submit
-      </button>
+  @if (showPasswordPrompt) {
+    <div>
+      <div class="password-prompt">
+        <label for="password">Enter Your Password:</label>
+        <input id="password" type="password" #passwordInput />
+        <button
+          class="verify-button"
+          (click)="verifyPassword(passwordInput.value)"
+        >
+          Submit
+        </button>
+      </div>
     </div>
-  </div>
+  }
 
   <!-- QR Code and Warning -->
-  <div *ngIf="passwordFilled && encryptedUserData" class="qr-display">
-
-    <div *ngIf="encryptedUserData!.length >= maxDataLength" class="error-message">
-      There are too many wallets to show qr code. Please download key file.
+  @if (passwordFilled && encryptedUserData) {
+    <div class="qr-display">
+      @if (encryptedUserData!.length >= maxDataLength) {
+        <div class="error-message">
+          There are too many wallets to show qr code. Please download key file.
+        </div>
+      }
+      @if (encryptedUserData!.length < maxDataLength) {
+        <div class="qr-code">
+          <button class="action-button" (click)="hideKeyInfo()">
+            Hide Key Info
+          </button>
+          <p>Scan this QR code with your mobile wallet to sync your wallet.</p>
+          <qrcode [qrdata]="encryptedUserData!" [width]="qrCodeSize"></qrcode>
+          <p class="warning">Warning: Do not share this QR code with anyone.</p>
+        </div>
+      }
+      <button class="action-button" (click)="downloadKeyFile()">
+        Download Key File
+      </button>
+      <p class="warning">Warning: Do not share this key file with anyone.</p>
     </div>
-
-    <div *ngIf="encryptedUserData!.length < maxDataLength" class="qr-code">
-
-      <button class="action-button" (click)="hideKeyInfo()">Hide Key Info</button>
-
-      <p>
-        Scan this QR code with your mobile wallet to sync your wallet.
-      </p>
-
-      <qrcode [qrdata]="encryptedUserData!" [width]="qrCodeSize"></qrcode>
-
-      <p class="warning">
-        Warning: Do not share this QR code with anyone.
-      </p>
-    </div>
-
-      <button class="action-button" (click)="downloadKeyFile()">Download Key File</button>
-
-      <p class="warning">
-        Warning: Do not share this key file with anyone.
-      </p>
-
-  </div>
+  }
 </div>

--- a/src/app/components/wallet-management/export-wallets-qr/export-wallets-qr.component.ts
+++ b/src/app/components/wallet-management/export-wallets-qr/export-wallets-qr.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import { Component, HostListener } from '@angular/core';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { PasswordManagerService } from '../../../services/password-manager.service';
@@ -9,7 +8,7 @@ import { MessagePopupService } from '../../../services/message-popup.service';
   selector: 'export-wallets-qr',
   templateUrl: './export-wallets-qr.component.html',
   styleUrls: ['./export-wallets-qr.component.scss'],
-  imports: [NgIf, QRCodeComponent],
+  imports: [QRCodeComponent],
 })
 export class ExportWalletsQrComponent {
   showPasswordPrompt: boolean = false; // Signal to display the password prompt
@@ -20,7 +19,7 @@ export class ExportWalletsQrComponent {
 
   constructor(
     private passwordManagerService: PasswordManagerService,
-    private messagePopupService: MessagePopupService
+    private messagePopupService: MessagePopupService,
   ) {
     this.updateQrCodeSize();
   }
@@ -44,7 +43,7 @@ export class ExportWalletsQrComponent {
       this.showPasswordPrompt = false;
 
       const encryptedUserData = localStorage.getItem(
-        LOCAL_STORAGE_KEYS.USER_DATA
+        LOCAL_STORAGE_KEYS.USER_DATA,
       );
 
       if (encryptedUserData) {
@@ -52,7 +51,7 @@ export class ExportWalletsQrComponent {
       }
     } else {
       this.messagePopupService.showError(
-        'Incorrect password. Please try again.'
+        'Incorrect password. Please try again.',
       );
     }
   }
@@ -67,8 +66,8 @@ export class ExportWalletsQrComponent {
     link.setAttribute(
       'href',
       `data:text/plain;charset=utf-8,${encodeURIComponent(
-        this.encryptedUserData!
-      )}`
+        this.encryptedUserData!,
+      )}`,
     );
     link.setAttribute('download', 'kaspacom-wallets.key');
 

--- a/src/app/pages/clear-data/clear-data.component.html
+++ b/src/app/pages/clear-data/clear-data.component.html
@@ -21,18 +21,33 @@
         autocomplete="off"
         required
       />
-      <div *ngIf="clearDataForm.get('confirmation')?.invalid && clearDataForm.get('confirmation')?.touched" class="error-message">
-        Please type "DELETE ALL DATA" exactly to confirm
-      </div>
+      @if (
+        clearDataForm.get("confirmation")?.invalid &&
+        clearDataForm.get("confirmation")?.touched
+      ) {
+        <div class="error-message">
+          Please type "DELETE ALL DATA" exactly to confirm
+        </div>
+      }
     </div>
 
     <div class="button-group">
-      <button type="button" (click)="cancel()" class="cancel-button">Cancel</button>
-      <button type="submit" [disabled]="clearDataForm.invalid" class="delete-button">Clear All Data</button>
+      <button type="button" (click)="cancel()" class="cancel-button">
+        Cancel
+      </button>
+      <button
+        type="submit"
+        [disabled]="clearDataForm.invalid"
+        class="delete-button"
+      >
+        Clear All Data
+      </button>
     </div>
   </form>
 
-  <div *ngIf="error" class="error-message">
-    {{ error }}
-  </div>
-</div> 
+  @if (error) {
+    <div class="error-message">
+      {{ error }}
+    </div>
+  }
+</div>

--- a/src/app/pages/clear-data/clear-data.component.ts
+++ b/src/app/pages/clear-data/clear-data.component.ts
@@ -1,27 +1,36 @@
 import { Component } from '@angular/core';
-import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { Router } from '@angular/router';
-import { NgIf } from '@angular/common';
+
 import { WalletService } from '../../services/wallet.service';
 import { PasswordManagerService } from '../../services/password-manager.service';
 import { LOCAL_STORAGE_KEYS } from '../../config/consts';
 
 @Component({
-    selector: 'app-clear-data',
-    templateUrl: './clear-data.component.html',
-    styleUrls: ['./clear-data.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, NgIf]
+  selector: 'app-clear-data',
+  templateUrl: './clear-data.component.html',
+  styleUrls: ['./clear-data.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule],
 })
 export class ClearDataComponent {
   clearDataForm: FormGroup = this.fb.group({
-    confirmation: ['', [Validators.required, Validators.pattern('DELETE ALL DATA')]]
+    confirmation: [
+      '',
+      [Validators.required, Validators.pattern('DELETE ALL DATA')],
+    ],
   });
   error: string = '';
 
   constructor(
     private fb: FormBuilder,
     private router: Router,
-    private passwordManagerService: PasswordManagerService
+    private passwordManagerService: PasswordManagerService,
   ) {}
 
   async onSubmit() {
@@ -32,7 +41,6 @@ export class ClearDataComponent {
 
         // Refresh the page
         window.location.reload();
-
       } catch (error: unknown) {
         this.error = 'Failed to clear data. Please try again.';
         console.error('Error clearing data:', error);
@@ -43,4 +51,4 @@ export class ClearDataComponent {
   cancel() {
     this.router.navigate(['/login']);
   }
-} 
+}

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -10,17 +10,21 @@
         placeholder="Enter your password"
         required
       />
-      <div *ngIf="password?.invalid && password?.touched" class="error-message">
-        Password is required.
-      </div>
+      @if (password?.invalid && password?.touched) {
+        <div class="error-message">Password is required.</div>
+      }
     </div>
     <button type="submit" [disabled]="loginForm.invalid">Login</button>
   </form>
-  <div *ngIf="loginError" class="error-message">
-    Incorrect password. Please try again.
-  </div>
+  @if (loginError) {
+    <div class="error-message">Incorrect password. Please try again.</div>
+  }
   <div class="clear-data-section">
-    <button type="button" (click)="navigateToClearData()" class="clear-data-button">
+    <button
+      type="button"
+      (click)="navigateToClearData()"
+      class="clear-data-button"
+    >
       Clear All Data
     </button>
   </div>

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -7,16 +7,16 @@ import {
   Validators,
 } from '@angular/forms';
 import { PasswordManagerService } from '../../services/password-manager.service';
-import { NgIf } from '@angular/common';
+
 import { Router } from '@angular/router';
 import { WalletService } from '../../services/wallet.service';
 import { IFrameCommunicationApp } from '../../services/communication-service/communication-app/iframe-communication.service';
 
 @Component({
-    selector: 'app-login',
-    templateUrl: './login.component.html',
-    styleUrls: ['./login.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, NgIf]
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule],
 })
 export class LoginComponent implements OnInit {
   loginForm: FormGroup = new FormGroup({});
@@ -57,18 +57,16 @@ export class LoginComponent implements OnInit {
 
         await this.walletService.loadWallets();
 
-
         if (this.walletService.getWalletsCount() === 0) {
           this.router.navigate(['/add-wallet']);
         } else {
           if (IFrameCommunicationApp.isIframe()) {
-            this.router.navigate(['/wallet-selection']);  
+            this.router.navigate(['/wallet-selection']);
           } else {
             await this.walletService.selectCurrentWalletFromLocalStorage();
-            this.router.navigate(['/wallet-info']);  
+            this.router.navigate(['/wallet-info']);
           }
         }
-        
       } else {
         this.loginError = true;
       }

--- a/src/app/pages/wallet-info/wallet-info.component.html
+++ b/src/app/pages/wallet-info/wallet-info.component.html
@@ -1,223 +1,273 @@
-<div class="wallet-info-container" *ngIf="wallet">
-  <div class="wallet-info-section">
-    <div *ngIf="wallet; else loadingMessage">
-      <div class="wallet-info-header">
-        <h2>Wallet Information</h2>
-        <button (click)="goToSelectWallet()" class="change-wallet-button">
-          Change Wallet
-        </button>
-      </div>
-
-      <div class="unfinished-action" *ngIf="unfinishedAction">
-        <p class="unfinished-action-message">
-          You have unfinished commit reveal action.
-        </p>
-        <button class="finish-action-button" (click)="finishUnfinishedAction(false)">
-          Retreive Kas
-        </button>
-        <button class="finish-action-button" (click)="finishUnfinishedAction(true)" *ngIf="canCompleteUnfinishedAction">
-          Finish Action
-        </button>
-      </div>
-
-      <!-- Wallet Balance -->
-      <div class="wallet-balance">
-        <h3>Wallet Name:</h3>
-        <p>{{ wallet.getDisplayName() }}</p>
-        <h3>Wallet Address:</h3>
-        <p>{{ wallet.getAddress() }}</p>
-        <h3>Balance:</h3>
-        <div *ngIf="
-            walletUtxoStateBalanceSignal() !== undefined;
-            else loadingData
-          ">
-          <p>
-            Current:
-            {{
-            walletUtxoStateBalanceSignal()!.mature | sompiToNumber
-            }}
-            KAS
-          </p>
-          <p>
-            Pending:
-            {{
-            walletUtxoStateBalanceSignal()!.pending
-            | sompiToNumber
-            }}
-            KAS
-          </p>
-          <p>
-            Outgoing:
-            {{
-            walletUtxoStateBalanceSignal()!.outgoing
-            | sompiToNumber
-            }}
-            KAS
-          </p>
-        </div>
-        <ng-template #loadingData>
-          <p>Loading...</p>
-        </ng-template>
-
-
-
+@if (wallet) {
+  <div class="wallet-info-container">
+    <div class="wallet-info-section">
+      @if (wallet) {
         <div>
-          <h3>L2:</h3>
-
-          <div class="network-selector">
-            <select [(ngModel)]="selectedChain" (change)="onChainChange()" class="network-select">
-              <option [value]="undefined">Select network</option>
-              <option *ngFor="let chain of availableChains" [value]="chain.chainId">
-                {{ chain.chainName }}
-              </option>
-            </select>
-            <button class="add-chain-button" (click)="showAddChainForm()">Add Chain</button>
+          <div class="wallet-info-header">
+            <h2>Wallet Information</h2>
+            <button (click)="goToSelectWallet()" class="change-wallet-button">
+              Change Wallet
+            </button>
           </div>
-
-          <div *ngIf="l2WalletInfoFormatted(); else loadingL2">
-            <p>
-              <strong>Address:</strong>
-              {{ l2WalletInfoFormatted()?.address }}
-            </p>
-            <p>
-              <strong>Balance:</strong>
-              {{ l2WalletInfoFormatted()?.balance }}
-            </p>
-          </div>
-          <ng-template #loadingL2>
-            <div *ngIf="currentL2Chain(); else loadingL2Chain">
-              <p>Loading...</p>
+          @if (unfinishedAction) {
+            <div class="unfinished-action">
+              <p class="unfinished-action-message">
+                You have unfinished commit reveal action.
+              </p>
+              <button
+                class="finish-action-button"
+                (click)="finishUnfinishedAction(false)"
+              >
+                Retreive Kas
+              </button>
+              @if (canCompleteUnfinishedAction) {
+                <button
+                  class="finish-action-button"
+                  (click)="finishUnfinishedAction(true)"
+                >
+                  Finish Action
+                </button>
+              }
             </div>
-            <ng-template #loadingL2Chain>
-              <p>Please select a network</p>
-            </ng-template>
-          </ng-template>
+          }
+          <!-- Wallet Balance -->
+          <div class="wallet-balance">
+            <h3>Wallet Name:</h3>
+            <p>{{ wallet.getDisplayName() }}</p>
+            <h3>Wallet Address:</h3>
+            <p>{{ wallet.getAddress() }}</p>
+            <h3>Balance:</h3>
+            @if (walletUtxoStateBalanceSignal() !== undefined) {
+              <div>
+                <p>
+                  Current:
+                  {{ walletUtxoStateBalanceSignal()!.mature | sompiToNumber }}
+                  KAS
+                </p>
+                <p>
+                  Pending:
+                  {{ walletUtxoStateBalanceSignal()!.pending | sompiToNumber }}
+                  KAS
+                </p>
+                <p>
+                  Outgoing:
+                  {{ walletUtxoStateBalanceSignal()!.outgoing | sompiToNumber }}
+                  KAS
+                </p>
+              </div>
+            } @else {
+              <p>Loading...</p>
+            }
+            <div>
+              <h3>L2:</h3>
+              <div class="network-selector">
+                <select
+                  [(ngModel)]="selectedChain"
+                  (change)="onChainChange()"
+                  class="network-select"
+                >
+                  <option [value]="undefined">Select network</option>
+                  @for (chain of availableChains; track chain) {
+                    <option [value]="chain.chainId">
+                      {{ chain.chainName }}
+                    </option>
+                  }
+                </select>
+                <button class="add-chain-button" (click)="showAddChainForm()">
+                  Add Chain
+                </button>
+              </div>
+              @if (l2WalletInfoFormatted()) {
+                <div>
+                  <p>
+                    <strong>Address:</strong>
+                    {{ l2WalletInfoFormatted()?.address }}
+                  </p>
+                  <p>
+                    <strong>Balance:</strong>
+                    {{ l2WalletInfoFormatted()?.balance }}
+                  </p>
+                </div>
+              } @else {
+                @if (currentL2Chain()) {
+                  <div>
+                    <p>Loading...</p>
+                  </div>
+                } @else {
+                  <p>Please select a network</p>
+                }
+              }
+            </div>
+          </div>
+          <div class="mempoll-transactions">
+            <h3>Pending Transactions:</h3>
+            <mempool-transactions></mempool-transactions>
+          </div>
+          <!-- KRC20 Tokens -->
+          <div class="krc20-tokens">
+            <h3>KRC20 Tokens:</h3>
+            @if (tokens) {
+              <ul class="krc20-token-list">
+                @for (token of tokens; track token) {
+                  <li>
+                    <strong>{{ token.ticker }}</strong> {{ token.balance }}
+                  </li>
+                }
+              </ul>
+            } @else {
+              <p>Loading tokens...</p>
+            }
+          </div>
         </div>
-
-      </div>
-
-      <div class="mempoll-transactions">
-        <h3>Pending Transactions:</h3>
-        <mempool-transactions></mempool-transactions>
-      </div>
-
-      <!-- KRC20 Tokens -->
-      <div class="krc20-tokens">
-        <h3>KRC20 Tokens:</h3>
-        <ng-container *ngIf="tokens; else loadingTokens">
-          <ul class="krc20-token-list">
-            <li *ngFor="let token of tokens">
-              <strong>{{ token.ticker }}</strong> {{ token.balance }}
-            </li>
-          </ul>
-        </ng-container>
-        <ng-template #loadingTokens>
-          <p>Loading tokens...</p>
-        </ng-template>
-      </div>
-    </div>
-    <div class="secondary-component">
-      <div>
-        <review-action #reviewActionComponent></review-action>
-      </div>
-      <!-- Tabs -->
-      <div class="tabs-container">
-        <div class="tabs">
-          <button class="tab-button" [class.active]="activeTab === 'send'" (click)="switchTab('send')">
-            Send Asset
-          </button>
-          <button class="tab-button" [class.active]="activeTab === 'mint'" (click)="switchTab('mint')">
-            Mint
-          </button>
-          <button class="tab-button" [class.active]="activeTab === 'deploy'" (click)="switchTab('deploy')">
-            Deploy
-          </button>
-          <button class="tab-button" [class.active]="activeTab === 'kasplex-l2'" (click)="switchTab('kasplex-l2')">
-            L2 Transaction
-          </button>
-          <!-- This is for development -->
-          <!-- <button
+      } @else {
+        <p>Loading...</p>
+      }
+      <div class="secondary-component">
+        <div>
+          <review-action #reviewActionComponent></review-action>
+        </div>
+        <!-- Tabs -->
+        <div class="tabs-container">
+          <div class="tabs">
+            <button
+              class="tab-button"
+              [class.active]="activeTab === 'send'"
+              (click)="switchTab('send')"
+            >
+              Send Asset
+            </button>
+            <button
+              class="tab-button"
+              [class.active]="activeTab === 'mint'"
+              (click)="switchTab('mint')"
+            >
+              Mint
+            </button>
+            <button
+              class="tab-button"
+              [class.active]="activeTab === 'deploy'"
+              (click)="switchTab('deploy')"
+            >
+              Deploy
+            </button>
+            <button
+              class="tab-button"
+              [class.active]="activeTab === 'kasplex-l2'"
+              (click)="switchTab('kasplex-l2')"
+            >
+              L2 Transaction
+            </button>
+            <!-- This is for development -->
+            <!-- <button
             class="tab-button"
             [class.active]="activeTab === 'list'"
             (click)="switchTab('list')"
-          >
+            >
             List
           </button>
           <button
             class="tab-button"
             [class.active]="activeTab === 'buy'"
             (click)="switchTab('buy')"
-          >
+            >
             Buy
           </button> -->
+          </div>
+          <!-- Tab Content -->
+          <div class="tab-content">
+            @if (activeTab === "send") {
+              <div class="send-assets-container">
+                <send-asset></send-asset>
+              </div>
+            }
+            @if (activeTab === "mint") {
+              <div class="mint-container">
+                <mint></mint>
+              </div>
+            }
+            @if (activeTab === "deploy") {
+              <div class="deploy-container">
+                <deploy></deploy>
+              </div>
+            }
+            @if (activeTab === "kasplex-l2") {
+              <div class="kasplex-l2-container">
+                <l2-transaction></l2-transaction>
+              </div>
+            }
+            <!-- This is for development -->
+            <!-- <div *ngIf="activeTab === 'list'" class="list-container">
+          <list-krc20-token></list-krc20-token>
         </div>
-
+        <div *ngIf="activeTab === 'buy'" class="list-container">
+          <buy-krc20-token></buy-krc20-token>
+        </div> -->
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="transactions-info-section">
+      <div class="tabs-container">
+        <div class="tabs">
+          <button
+            class="tab-button"
+            [class.active]="infoActiveTab === 'utxos'"
+            (click)="switchInfoTab('utxos')"
+          >
+            UTXOs
+          </button>
+          <button
+            class="tab-button"
+            [class.active]="infoActiveTab === 'kaspa-transactions'"
+            (click)="switchInfoTab('kaspa-transactions')"
+          >
+            Kaspa Transactions History
+          </button>
+          <button
+            class="tab-button"
+            [class.active]="infoActiveTab === 'krc20-actions'"
+            (click)="switchInfoTab('krc20-actions')"
+          >
+            Krc20 Actions History
+          </button>
+        </div>
         <!-- Tab Content -->
         <div class="tab-content">
-          <div *ngIf="activeTab === 'send'" class="send-assets-container">
-            <send-asset></send-asset>
-          </div>
-          <div *ngIf="activeTab === 'mint'" class="mint-container">
-            <mint></mint>
-          </div>
-          <div *ngIf="activeTab === 'deploy'" class="deploy-container">
-            <deploy></deploy>
-          </div>
-          <div *ngIf="activeTab === 'kasplex-l2'" class="kasplex-l2-container">
-            <l2-transaction></l2-transaction>
-          </div>
-          <!-- This is for development -->
-          <!-- <div *ngIf="activeTab === 'list'" class="list-container">
-            <list-krc20-token></list-krc20-token>
-          </div>
-          <div *ngIf="activeTab === 'buy'" class="list-container">
-            <buy-krc20-token></buy-krc20-token>
-          </div> -->
+          @if (infoActiveTab === "utxos") {
+            <div>
+              <utxos-list [wallet]="wallet"></utxos-list>
+            </div>
+          }
+          @if (infoActiveTab === "kaspa-transactions") {
+            <div>
+              <transaction-history
+                [transactions]="kaspaTransactionsHistory"
+                [wallet]="wallet"
+              ></transaction-history>
+            </div>
+          }
+          @if (infoActiveTab === "krc20-actions") {
+            <div>
+              <krc20-operations-history
+                [operations]="krc20OperationHistory"
+                [wallet]="wallet"
+              ></krc20-operations-history>
+            </div>
+          }
         </div>
       </div>
     </div>
   </div>
-  <div class="transactions-info-section">
-    <div class="tabs-container">
-      <div class="tabs">
-        <button class="tab-button" [class.active]="infoActiveTab === 'utxos'" (click)="switchInfoTab('utxos')">
-          UTXOs
-        </button>
-        <button class="tab-button" [class.active]="infoActiveTab === 'kaspa-transactions'"
-          (click)="switchInfoTab('kaspa-transactions')">
-          Kaspa Transactions History
-        </button>
-        <button class="tab-button" [class.active]="infoActiveTab === 'krc20-actions'"
-          (click)="switchInfoTab('krc20-actions')">
-          Krc20 Actions History
-        </button>
-      </div>
-
-      <!-- Tab Content -->
-      <div class="tab-content">
-        <div *ngIf="infoActiveTab === 'utxos'">
-          <utxos-list [wallet]="wallet"></utxos-list>
-        </div>
-
-        <div *ngIf="infoActiveTab === 'kaspa-transactions'">
-          <transaction-history [transactions]="kaspaTransactionsHistory" [wallet]="wallet"></transaction-history>
-        </div>
-
-        <div *ngIf="infoActiveTab === 'krc20-actions'">
-          <krc20-operations-history [operations]="krc20OperationHistory" [wallet]="wallet"></krc20-operations-history>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<ng-template #loadingMessage>
-  <p>Loading...</p>
-</ng-template>
+}
 
 <!-- Add Chain Form Modal -->
-<div class="modal" *ngIf="isAddChainFormVisible">
-  <div class="modal-content">
-    <add-l2-chain (chainAdded)="onChainAdded($event)" (cancelled)="hideAddChainForm()"></add-l2-chain>
+@if (isAddChainFormVisible) {
+  <div class="modal">
+    <div class="modal-content">
+      <add-l2-chain
+        (chainAdded)="onChainAdded($event)"
+        (cancelled)="hideAddChainForm()"
+      ></add-l2-chain>
+    </div>
   </div>
-</div>
+}

--- a/src/app/pages/wallet-info/wallet-info.component.ts
+++ b/src/app/pages/wallet-info/wallet-info.component.ts
@@ -8,7 +8,7 @@ import {
 import { Router } from '@angular/router';
 import { WalletService } from '../../services/wallet.service'; // Assume you have a service to fetch wallets
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { CommonModule, NgFor, NgIf, Time } from '@angular/common';
+import { Time } from '@angular/common';
 import { AppWallet } from '../../classes/AppWallet';
 import { catchError, firstValueFrom, map, of, tap } from 'rxjs';
 import { KasplexKrc20Service } from '../../services/kasplex-api/kasplex-api.service';
@@ -40,27 +40,24 @@ type ActionTabs = 'send' | 'mint' | 'deploy' | 'list' | 'buy' | 'kasplex-l2';
 type InfoTabs = 'utxos' | 'kaspa-transactions' | 'krc20-actions';
 
 @Component({
-    selector: 'wallet-info',
-    templateUrl: './wallet-info.component.html',
-    styleUrls: ['./wallet-info.component.scss'],
-    imports: [
-        FormsModule,
-        ReactiveFormsModule,
-        NgIf,
-        NgFor,
-        SompiToNumberPipe,
-        SendAssetComponent,
-        MintComponent,
-        ReviewActionComponent,
-        CommonModule,
-        DeployComponent,
-        UtxosListComponent,
-        TransactionHistoryComponent,
-        Krc20OperationHistoryComponent,
-        MempoolTransactionsComponent,
-        AddL2ChainComponent,
-        L2TransactionComponent,
-    ]
+  selector: 'wallet-info',
+  templateUrl: './wallet-info.component.html',
+  styleUrls: ['./wallet-info.component.scss'],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    SompiToNumberPipe,
+    SendAssetComponent,
+    MintComponent,
+    ReviewActionComponent,
+    DeployComponent,
+    UtxosListComponent,
+    TransactionHistoryComponent,
+    Krc20OperationHistoryComponent,
+    MempoolTransactionsComponent,
+    AddL2ChainComponent,
+    L2TransactionComponent,
+  ],
 })
 export class WalletInfoComponent implements OnInit, OnDestroy {
   @ViewChild('reviewActionComponent')
@@ -70,7 +67,8 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
   protected tokens: undefined | { ticker: string; balance: number }[] =
     undefined;
 
-  protected unfinishedAction: undefined | UnfinishedCommitRevealAction = undefined;
+  protected unfinishedAction: undefined | UnfinishedCommitRevealAction =
+    undefined;
   protected canCompleteUnfinishedAction: boolean = false;
 
   protected kaspaTransactionsHistory: undefined | FullTransactionResponse =
@@ -105,20 +103,31 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
     private kaspaApiService: KaspaApiService,
     private ethereumWalletChainManager: EthereumWalletChainManager,
   ) {
-    toObservable(this.ethereumWalletChainManager.getCurrentChainSignal()).subscribe((chain) => {
+    toObservable(
+      this.ethereumWalletChainManager.getCurrentChainSignal(),
+    ).subscribe((chain) => {
       this.selectedChain = chain;
     });
   }
 
-  walletUtxoStateBalanceSignal = computed(() => this.wallet?.getCurrentWalletStateBalanceSignalValue());
-  currentL2Chain = computed(() => this.ethereumWalletChainManager.getCurrentChainSignal()());
+  walletUtxoStateBalanceSignal = computed(() =>
+    this.wallet?.getCurrentWalletStateBalanceSignalValue(),
+  );
+  currentL2Chain = computed(() =>
+    this.ethereumWalletChainManager.getCurrentChainSignal()(),
+  );
 
   l2WalletInfo = computed(() => this.wallet?.getL2WalletStateSignal()());
   l2WalletInfoFormatted = computed(() => {
-    return this.l2WalletInfo() ? {
-      address: this.l2WalletInfo()?.address,
-      balance: this.l2WalletInfo()?.balanceFormatted + ' ' + this.wallet?.getL2Provider()?.getConfig().nativeCurrency.symbol,
-    } : undefined;
+    return this.l2WalletInfo()
+      ? {
+          address: this.l2WalletInfo()?.address,
+          balance:
+            this.l2WalletInfo()?.balanceFormatted +
+            ' ' +
+            this.wallet?.getL2Provider()?.getConfig().nativeCurrency.symbol,
+        }
+      : undefined;
   });
 
   ngOnInit(): void {
@@ -142,7 +151,8 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
   }
 
   private initializeL2Networks() {
-    const chainsByChainId = this.ethereumWalletChainManager.getAllChainsByChainId();
+    const chainsByChainId =
+      this.ethereumWalletChainManager.getAllChainsByChainId();
     this.availableChains = Object.values(chainsByChainId);
 
     // Set initial selected chain
@@ -151,7 +161,9 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
   }
 
   protected onChainChange() {
-    this.ethereumWalletChainManager.setCurrentChain(this.selectedChain == 'undefined' ? undefined : this.selectedChain);
+    this.ethereumWalletChainManager.setCurrentChain(
+      this.selectedChain == 'undefined' ? undefined : this.selectedChain,
+    );
   }
 
   async loadKrc20Tokens() {
@@ -165,7 +177,7 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
         .getWalletTokenList(
           this.wallet!.getAddress(),
           paginationKey,
-          this.paginationDirection
+          this.paginationDirection,
         )
         .pipe(
           tap((response) => {
@@ -176,28 +188,26 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
             return response.result.map((token) => ({
               ticker: token.tick,
               balance: this.kaspaNetworkActionsService.sompiToNumber(
-                BigInt(+token.balance)
+                BigInt(+token.balance),
               ),
             }));
           }),
           catchError((err) => {
             console.error(
               `Error fetching token list for address ${this.wallet!.getAddress()}:`,
-              err
+              err,
             );
 
             return of(undefined);
-          })
-        )
+          }),
+        ),
     );
   }
 
   async loadKrc20Operations() {
     this.krc20OperationHistory = await firstValueFrom(
       this.kasplexService
-        .getWalletOperationHistory(
-          this.wallet!.getAddress(),
-        )
+        .getWalletOperationHistory(this.wallet!.getAddress())
         .pipe(
           map((response) => {
             return response.result;
@@ -205,12 +215,12 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
           catchError((err) => {
             console.error(
               `Error fetching krc20 operation list for address ${this.wallet!.getAddress()}:`,
-              err
+              err,
             );
 
             return of(undefined);
-          })
-        )
+          }),
+        ),
     );
   }
 
@@ -220,12 +230,12 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
         catchError((err) => {
           console.error(
             `Error fetching transactions list for address ${this.wallet!.getAddress()}:`,
-            err
+            err,
           );
 
           return of(undefined);
-        })
-      )
+        }),
+      ),
     );
   }
 
@@ -267,15 +277,16 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
 
   async checkForUnfinishedActions() {
     try {
-      const unfinishedAction = await this.kaspaNetworkActionsService.getWalletUnfinishedActions(
-        this.wallet!
-      );
+      const unfinishedAction =
+        await this.kaspaNetworkActionsService.getWalletUnfinishedActions(
+          this.wallet!,
+        );
 
       if (unfinishedAction) {
-        this.canCompleteUnfinishedAction = await this.checkIfCanFinishUnfinishedAction(unfinishedAction);
+        this.canCompleteUnfinishedAction =
+          await this.checkIfCanFinishUnfinishedAction(unfinishedAction);
       }
       this.unfinishedAction = unfinishedAction;
-
     } catch (error) {
       console.error(error);
     }
@@ -285,7 +296,9 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
     }, 60 * 1000);
   }
 
-  async checkIfCanFinishUnfinishedAction(unfinishedAction: UnfinishedCommitRevealAction): Promise<boolean> {
+  async checkIfCanFinishUnfinishedAction(
+    unfinishedAction: UnfinishedCommitRevealAction,
+  ): Promise<boolean> {
     const result = await this.walletActionService.validateAction(
       this.walletActionService.createUnfinishedCommitRevealAction(
         unfinishedAction.operationData,
@@ -293,7 +306,7 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
       ),
       this.walletService.getCurrentWallet()!,
       true,
-    )
+    );
 
     return result.isValidated;
   }
@@ -306,8 +319,8 @@ export class WalletInfoComponent implements OnInit, OnDestroy {
     await this.walletActionService.validateAndDoActionAfterApproval(
       this.walletActionService.createUnfinishedCommitRevealAction(
         this.unfinishedAction!.operationData,
-        shouldFinish
-      )
+        shouldFinish,
+      ),
     );
 
     this.checkForUnfinishedActions();

--- a/src/app/services/encryption.service.ts
+++ b/src/app/services/encryption.service.ts
@@ -17,7 +17,7 @@ export class EncryptionService {
    * @param password The password to derive the key from.
    * @param salt The salt used to add randomness to the key derivation.
    */
-  private async deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  private async deriveKey(password: string, salt: Uint8Array<ArrayBuffer>): Promise<CryptoKey> {
     const keyMaterial = await crypto.subtle.importKey(
       'raw',
       new TextEncoder().encode(password),

--- a/src/app/v2/pages/app/activity/activity.component.ts
+++ b/src/app/v2/pages/app/activity/activity.component.ts
@@ -8,7 +8,7 @@ import {
   effect,
 } from '@angular/core';
 import { BaseActivityComponent } from './base-activity.component';
-import { CommonModule } from '@angular/common';
+
 import { Router } from '@angular/router';
 import { KcIconComponent } from 'kaspacom-ui';
 import {
@@ -73,12 +73,7 @@ type ActivityItem = KaspaActivityItem | Krc20ActivityItem | Erc20ActivityItem;
 
 @Component({
   selector: 'app-activity',
-  imports: [
-    CommonModule,
-    KcIconComponent,
-    KcLabeledTabsComponent,
-    SkeletonComponent,
-  ],
+  imports: [KcIconComponent, KcLabeledTabsComponent, SkeletonComponent],
   templateUrl: './activity.component.html',
   styleUrl: './activity.component.scss',
 })

--- a/src/app/v2/pages/app/app-wrapper.component.html
+++ b/src/app/v2/pages/app/app-wrapper.component.html
@@ -12,11 +12,13 @@
     }
 
     <!-- Iframe loading spinner - shows during initial load -->
-    <div class="iframe-overlay-cover" *ngIf="shouldEnforceAccountSelection() && showIframeLoader()">
-      <div class="iframe-loader">
-        <kc-spinner size="lg"></kc-spinner>
+    @if (shouldEnforceAccountSelection() && showIframeLoader()) {
+      <div class="iframe-overlay-cover">
+        <div class="iframe-loader">
+          <kc-spinner size="lg"></kc-spinner>
+        </div>
       </div>
-    </div>
+    }
 
     @if (isExpandedLayout()) {
       <!-- ── EXPANDED MODE: two-column layout ── -->
@@ -38,7 +40,10 @@
       <div class="wrapper__right">
         <!-- Right-panel header (title + navigation controls) -->
         <div class="wrapper__right-header">
-          @if (flowPagesService.isAnyPageOpen() && (flowPagesService.activePage()?.showTitle ?? true)) {
+          @if (
+            flowPagesService.isAnyPageOpen() &&
+            (flowPagesService.activePage()?.showTitle ?? true)
+          ) {
             <div class="wrapper__right-nav">
               @if (flowPagesService.canNavigateBack()) {
                 <kc-icon
@@ -73,21 +78,29 @@
             <!-- Placeholder shown when no action is active -->
             <div class="wrapper__right-placeholder">
               <div class="wrapper__right-placeholder-icon">
-                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="3" y="3" width="7" height="7" rx="1"/>
-                  <rect x="14" y="3" width="7" height="7" rx="1"/>
-                  <rect x="3" y="14" width="7" height="7" rx="1"/>
-                  <path d="M14 14h7v7h-7z" opacity="0.35"/>
+                <svg
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="3" y="3" width="7" height="7" rx="1" />
+                  <rect x="14" y="3" width="7" height="7" rx="1" />
+                  <rect x="3" y="14" width="7" height="7" rx="1" />
+                  <path d="M14 14h7v7h-7z" opacity="0.35" />
                 </svg>
               </div>
               <p class="wrapper__right-placeholder-text">
-                Open Swap or another action<br>to see it here
+                Open Swap or another action<br />to see it here
               </p>
             </div>
           }
         </div>
       </div>
-
     } @else {
       <!-- ── NORMAL MODE: existing single-column layout ── -->
       <div

--- a/src/app/v2/pages/app/app-wrapper.component.ts
+++ b/src/app/v2/pages/app/app-wrapper.component.ts
@@ -1,5 +1,16 @@
-import { Component, inject, signal, computed, ViewChild, ElementRef, AfterViewInit, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser, CommonModule } from '@angular/common';
+import {
+  Component,
+  inject,
+  signal,
+  computed,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+  OnDestroy,
+  OnInit,
+  PLATFORM_ID,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { Router, RouterOutlet, ChildrenOutletContexts } from '@angular/router';
 import { navAnimation } from './common/animation/nav.animation';
 import { WrapperHeaderComponent } from './common/wrapper-header/wrapper-header.component';
@@ -13,16 +24,22 @@ import { DynamicFlowPageOutletComponent } from './common/flow-page/dynamic-flow-
 import { DynamicQuickActionDialogOutletComponent } from './common/quick-action-dialog/dynamic-quick-action-dialog-outlet.component';
 import { IframeAccountSelectionComponent } from './iframe-account-selection/iframe-account-selection.component';
 import { IframeAccountSelectionService } from '../../services/iframe-account-selection.service';
-import { DesktopViewService, MOBILE_BREAKPOINT } from '../../services/desktop-view.service';
+import {
+  DesktopViewService,
+  MOBILE_BREAKPOINT,
+} from '../../services/desktop-view.service';
 
-import { KcSnackbarComponent, KcSpinnerComponent, KcIconComponent } from 'kaspacom-ui';
+import {
+  KcSnackbarComponent,
+  KcSpinnerComponent,
+  KcIconComponent,
+} from 'kaspacom-ui';
 import { WalletService } from '../../../services/wallet.service';
 import { AssetsManagerService } from '../../../services/assets-manager/assets-manager.service';
 
 @Component({
   selector: 'app-app-wrapper',
   imports: [
-    CommonModule,
     RouterOutlet,
     WrapperHeaderComponent,
     WrapperNavComponent,
@@ -54,13 +71,17 @@ export class AppWrapperComponent implements OnInit, AfterViewInit, OnDestroy {
   protected assetsManager = inject(AssetsManagerService);
   iframeAccountSelectionService = inject(IframeAccountSelectionService);
   desktopViewService = inject(DesktopViewService);
-  shouldEnforceAccountSelection = signal(this.iframeAccountSelectionService.shouldEnforceAccountSelection());
+  shouldEnforceAccountSelection = signal(
+    this.iframeAccountSelectionService.shouldEnforceAccountSelection(),
+  );
 
   // Detect if running in iframe mode
   showIframeLoader = signal(false);
 
   // Track viewport width for responsive expanded layout
-  private windowWidth = signal(this.isBrowser ? window.innerWidth : MOBILE_BREAKPOINT);
+  private windowWidth = signal(
+    this.isBrowser ? window.innerWidth : MOBILE_BREAKPOINT,
+  );
   private readonly onResize = () => this.windowWidth.set(window.innerWidth);
 
   /** True only when the user opted in AND the viewport is wide enough. */

--- a/src/app/v2/pages/app/common/components/kaspa-nodes-background/kaspa-nodes-background.component.ts
+++ b/src/app/v2/pages/app/common/components/kaspa-nodes-background/kaspa-nodes-background.component.ts
@@ -1,5 +1,11 @@
-import { Component, ElementRef, ViewChild, AfterViewInit, OnDestroy, Input } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  AfterViewInit,
+  OnDestroy,
+  Input,
+} from '@angular/core';
 
 class GraphNode {
   x: number;
@@ -14,12 +20,19 @@ class GraphNode {
   fadeInDuration: number;
   isVisible: boolean;
 
-  constructor(canvasWidth: number, canvasHeight: number, config: any, delayMs: number = 0) {
+  constructor(
+    canvasWidth: number,
+    canvasHeight: number,
+    config: any,
+    delayMs: number = 0,
+  ) {
     this.x = Math.random() * canvasWidth;
     this.y = Math.random() * canvasHeight;
     this.vx = (Math.random() - 0.5) * config.speed;
     this.vy = (Math.random() - 0.5) * config.speed;
-    this.radius = Math.random() * (config.nodeMaxSize - config.nodeMinSize) + config.nodeMinSize;
+    this.radius =
+      Math.random() * (config.nodeMaxSize - config.nodeMinSize) +
+      config.nodeMinSize;
     this.hasConnections = Math.random() < config.connectionProbability;
     // Random target opacity between 0.3 and 1.0 for variety
     this.targetOpacity = Math.random() * 0.7 + 0.3;
@@ -35,17 +48,20 @@ class GraphNode {
     if (!this.isVisible && currentTime >= this.fadeInStartTime) {
       this.isVisible = true;
     }
-    
+
     if (this.isVisible) {
-      const fadeProgress = Math.min(1, (currentTime - this.fadeInStartTime) / this.fadeInDuration);
+      const fadeProgress = Math.min(
+        1,
+        (currentTime - this.fadeInStartTime) / this.fadeInDuration,
+      );
       this.opacity = this.targetOpacity * fadeProgress;
     }
-    
+
     // Only move if visible
     if (this.isVisible) {
       this.x += this.vx;
       this.y += this.vy;
-      
+
       // Bounce off edges
       if (this.x <= this.radius || this.x >= canvasWidth - this.radius) {
         this.vx = -this.vx;
@@ -53,16 +69,22 @@ class GraphNode {
       if (this.y <= this.radius || this.y >= canvasHeight - this.radius) {
         this.vy = -this.vy;
       }
-      
+
       // Keep within bounds
-      this.x = Math.max(this.radius, Math.min(canvasWidth - this.radius, this.x));
-      this.y = Math.max(this.radius, Math.min(canvasHeight - this.radius, this.y));
+      this.x = Math.max(
+        this.radius,
+        Math.min(canvasWidth - this.radius, this.x),
+      );
+      this.y = Math.max(
+        this.radius,
+        Math.min(canvasHeight - this.radius, this.y),
+      );
     }
   }
 
   draw(ctx: CanvasRenderingContext2D, nodeColor: string) {
     if (this.opacity <= 0) return; // Don't draw invisible nodes
-    
+
     ctx.globalAlpha = this.opacity;
     ctx.beginPath();
     ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
@@ -87,26 +109,22 @@ export interface KaspaNodesConfig {
 @Component({
   selector: 'kaspa-nodes-background',
   standalone: true,
-  imports: [CommonModule],
-  template: `
-    <canvas 
-      #backgroundCanvas 
-      class="kaspa-nodes-canvas">
-    </canvas>
-  `,
-  styleUrls: ['./kaspa-nodes-background.component.scss']
+  imports: [],
+  template: ` <canvas #backgroundCanvas class="kaspa-nodes-canvas"> </canvas> `,
+  styleUrls: ['./kaspa-nodes-background.component.scss'],
 })
 export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('backgroundCanvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
+  @ViewChild('backgroundCanvas', { static: true })
+  canvasRef!: ElementRef<HTMLCanvasElement>;
   @Input() config: KaspaNodesConfig = {};
-  
+
   private animationId: number | null = null;
   private canvas!: HTMLCanvasElement;
   private ctx!: CanvasRenderingContext2D;
   private nodes: GraphNode[] = [];
   private resizeListener?: () => void;
   private resizeObserver?: ResizeObserver;
-  
+
   private readonly defaultConfig: Required<KaspaNodesConfig> = {
     nodeColor: '#6FC7BA', // Kaspa teal color for nodes
     lineColor: '#6e6e6e', // Gray color for connection lines
@@ -116,7 +134,7 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
     nodeMinSize: 3,
     nodeMaxSize: 8,
     speed: 0.8,
-    fadeInSequenceDelay: 25 // 25ms delay between each node appearing for faster sequence
+    fadeInSequenceDelay: 25, // 25ms delay between each node appearing for faster sequence
   };
 
   private get mergedConfig(): Required<KaspaNodesConfig> {
@@ -135,7 +153,7 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
     if (this.animationId) {
       cancelAnimationFrame(this.animationId);
     }
-    
+
     if (this.resizeListener) {
       window.removeEventListener('resize', this.resizeListener);
     }
@@ -148,16 +166,16 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
   private initCanvas() {
     this.canvas = this.canvasRef.nativeElement;
     this.ctx = this.canvas.getContext('2d')!;
-    
+
     // Set initial canvas size
     this.resizeCanvas();
-    
+
     // Use ResizeObserver to watch for container size changes
     this.resizeObserver = new ResizeObserver(() => {
       this.resizeCanvas();
     });
     this.resizeObserver.observe(this.canvas.parentElement!);
-    
+
     // Fallback to window resize listener
     this.resizeListener = () => this.resizeCanvas();
     window.addEventListener('resize', this.resizeListener);
@@ -170,15 +188,15 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
     // Use the container's client dimensions (content area without padding/borders)
     const width = container.clientWidth;
     const height = container.clientHeight;
-    
+
     // Set canvas dimensions to match container exactly
     this.canvas.width = width;
     this.canvas.height = height;
-    
+
     // Also set CSS dimensions to prevent scaling issues
     this.canvas.style.width = `${width}px`;
     this.canvas.style.height = `${height}px`;
-    
+
     // Recreate nodes with new canvas dimensions if nodes exist
     if (this.nodes.length > 0) {
       this.createNodes();
@@ -188,11 +206,13 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
   private createNodes() {
     this.nodes = [];
     const config = this.mergedConfig;
-    
+
     // Create exactly 24 nodes with sequential fade-in animation
     for (let i = 0; i < config.nodeCount; i++) {
       const delayMs = i * config.fadeInSequenceDelay;
-      this.nodes.push(new GraphNode(this.canvas.width, this.canvas.height, config, delayMs));
+      this.nodes.push(
+        new GraphNode(this.canvas.width, this.canvas.height, config, delayMs),
+      );
     }
   }
 
@@ -200,22 +220,24 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
     const config = this.mergedConfig;
     this.ctx.strokeStyle = config.lineColor;
     this.ctx.lineWidth = 1.5;
-    
+
     for (let i = 0; i < this.nodes.length; i++) {
       if (!this.nodes[i].hasConnections || this.nodes[i].opacity <= 0) continue;
-      
+
       for (let j = i + 1; j < this.nodes.length; j++) {
-        if (!this.nodes[j].hasConnections || this.nodes[j].opacity <= 0) continue;
-        
+        if (!this.nodes[j].hasConnections || this.nodes[j].opacity <= 0)
+          continue;
+
         const dx = this.nodes[i].x - this.nodes[j].x;
         const dy = this.nodes[i].y - this.nodes[j].y;
         const distance = Math.sqrt(dx * dx + dy * dy);
-        
+
         if (distance < config.maxDistance) {
-          const distanceOpacity = 1 - (distance / config.maxDistance);
-          const averageNodeOpacity = (this.nodes[i].opacity + this.nodes[j].opacity) / 2;
+          const distanceOpacity = 1 - distance / config.maxDistance;
+          const averageNodeOpacity =
+            (this.nodes[i].opacity + this.nodes[j].opacity) / 2;
           this.ctx.globalAlpha = distanceOpacity * averageNodeOpacity * 0.7; // Increased opacity for better visibility
-          
+
           this.ctx.beginPath();
           this.ctx.moveTo(this.nodes[i].x, this.nodes[i].y);
           this.ctx.lineTo(this.nodes[j].x, this.nodes[j].y);
@@ -226,24 +248,22 @@ export class KaspaNodesBackgroundComponent implements AfterViewInit, OnDestroy {
     this.ctx.globalAlpha = 1;
   }
 
-
-
   private animate = () => {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    
+
     // Draw connections first (so they appear behind nodes)
     this.drawConnections();
-    
+
     // Update and draw nodes
-    this.nodes.forEach(node => {
+    this.nodes.forEach((node) => {
       node.update(this.canvas.width, this.canvas.height);
       node.draw(this.ctx, this.mergedConfig.nodeColor);
     });
-    
+
     this.animationId = requestAnimationFrame(this.animate);
-  }
+  };
 
   private startAnimation() {
     this.animate();
   }
-} 
+}

--- a/src/app/v2/pages/app/common/flow-page/dynamic-flow-page-outlet.component.ts
+++ b/src/app/v2/pages/app/common/flow-page/dynamic-flow-page-outlet.component.ts
@@ -13,11 +13,11 @@ import { IFlowPageConfig } from './interfaces/flow-page.interface';
   standalone: true,
   imports: [CommonModule, NgComponentOutlet],
   template: `
-    <ng-container *ngIf="componentToRender() as comp">
+    @if (componentToRender(); as comp) {
       <ng-container
         *ngComponentOutlet="comp; inputs: componentInputs()"
       ></ng-container>
-    </ng-container>
+    }
   `,
 })
 export class DynamicFlowPageOutletComponent {

--- a/src/app/v2/pages/app/common/flow-page/flow-page.component.ts
+++ b/src/app/v2/pages/app/common/flow-page/flow-page.component.ts
@@ -1,45 +1,63 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcIconComponent, KcTooltipDirective } from 'kaspacom-ui';
-import { trigger, state, style, transition, animate } from '@angular/animations';
+import {
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+} from '@angular/animations';
 
 @Component({
   selector: 'app-flow-page',
   standalone: true,
-  imports: [CommonModule, KcIconComponent, KcTooltipDirective],
+  imports: [KcIconComponent, KcTooltipDirective],
   templateUrl: './flow-page.component.html',
   styleUrl: './flow-page.component.scss',
   animations: [
     trigger('slideDown', [
-      state('closed', style({
-        transform: 'translateY(-100%)',
-        opacity: 0,
-        visibility: 'hidden'
-      })),
-      state('open', style({
-        transform: 'translateY(0)',
-        opacity: 1,
-        visibility: 'visible'
-      })),
+      state(
+        'closed',
+        style({
+          transform: 'translateY(-100%)',
+          opacity: 0,
+          visibility: 'hidden',
+        }),
+      ),
+      state(
+        'open',
+        style({
+          transform: 'translateY(0)',
+          opacity: 1,
+          visibility: 'visible',
+        }),
+      ),
       transition('closed => open', [
         style({
           visibility: 'visible',
           transform: 'translateY(-100%)',
-          opacity: 0
+          opacity: 0,
         }),
-        animate('300ms ease-out', style({
-          transform: 'translateY(0)',
-          opacity: 1
-        }))
+        animate(
+          '300ms ease-out',
+          style({
+            transform: 'translateY(0)',
+            opacity: 1,
+          }),
+        ),
       ]),
       transition('open => closed', [
-        animate('200ms ease-in', style({
-          transform: 'translateY(100%)', // Slide down off-screen instead of up
-          opacity: 0
-        }))
-      ])
-    ])
-  ]
+        animate(
+          '200ms ease-in',
+          style({
+            transform: 'translateY(100%)', // Slide down off-screen instead of up
+            opacity: 0,
+          }),
+        ),
+      ]),
+    ]),
+  ],
 })
 export class FlowPageComponent {
   @Input() isOpen = false;

--- a/src/app/v2/pages/app/common/flow-page/placeholder-flow-page.component.ts
+++ b/src/app/v2/pages/app/common/flow-page/placeholder-flow-page.component.ts
@@ -1,10 +1,9 @@
 import { Component, Input } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-placeholder-flow-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: `
     <div class="placeholder-page">
       <p class="text-gray-60 typo-text-2">{{ text }}</p>

--- a/src/app/v2/pages/app/common/quick-action-dialog/dynamic-quick-action-dialog-outlet.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/dynamic-quick-action-dialog-outlet.component.ts
@@ -8,7 +8,7 @@ import {
   ComponentRef,
   Type,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { QuickActionDialogService } from '../../../../services/quick-action-dialog.service';
 import {
   IQuickActionDialogComponent,
@@ -19,7 +19,7 @@ import {
 @Component({
   selector: 'app-dynamic-quick-action-dialog-outlet',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: ` <ng-template #host></ng-template> `,
 })
 export class DynamicQuickActionDialogOutletComponent {

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/create-wallet-account/create-wallet-account-quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/create-wallet-account/create-wallet-account-quick-action-dialog.component.ts
@@ -1,7 +1,19 @@
-import { Component, Input, Output, EventEmitter, inject, ChangeDetectorRef, AfterViewInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  inject,
+  ChangeDetectorRef,
+  AfterViewInit,
+} from '@angular/core';
+
 import { FormsModule } from '@angular/forms';
-import { KcInputComponent, KcButtonComponent, NotificationService } from 'kaspacom-ui';
+import {
+  KcInputComponent,
+  KcButtonComponent,
+  NotificationService,
+} from 'kaspacom-ui';
 import { QuickActionDialogComponent } from '../../quick-action-dialog.component';
 import { WalletService } from '../../../../../../../services/wallet.service';
 import { AppWallet } from '../../../../../../../classes/AppWallet';
@@ -9,9 +21,14 @@ import { AppWallet } from '../../../../../../../classes/AppWallet';
 @Component({
   selector: 'app-create-wallet-account-quick-action-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule, KcInputComponent, KcButtonComponent, QuickActionDialogComponent],
+  imports: [
+    FormsModule,
+    KcInputComponent,
+    KcButtonComponent,
+    QuickActionDialogComponent,
+  ],
   templateUrl: './create-wallet-account-quick-action-dialog.component.html',
-  styleUrl: './create-wallet-account-quick-action-dialog.component.scss'
+  styleUrl: './create-wallet-account-quick-action-dialog.component.scss',
 })
 export class CreateWalletAccountQuickActionDialogComponent implements AfterViewInit {
   @Input() isOpen = false;
@@ -85,27 +102,42 @@ export class CreateWalletAccountQuickActionDialogComponent implements AfterViewI
               this.accountName,
             );
             if (success) {
-              this.notificationService.success('Success', `Account name updated successfully!`);
+              this.notificationService.success(
+                'Success',
+                `Account name updated successfully!`,
+              );
               // Account name is already updated in storage, no need to reload
               // Call the success callback to refresh the parent component
               if (this.data?.onSuccess) {
                 this.data.onSuccess();
               }
             } else {
-              this.notificationService.error('Error', 'Failed to update account name');
+              this.notificationService.error(
+                'Error',
+                'Failed to update account name',
+              );
             }
           } else {
             // This is a wallet without accounts, update wallet name
-            const success = await this.walletService.updateWalletName(wallet, this.accountName);
+            const success = await this.walletService.updateWalletName(
+              wallet,
+              this.accountName,
+            );
             if (success) {
-              this.notificationService.success('Success', `Wallet name updated successfully!`);
+              this.notificationService.success(
+                'Success',
+                `Wallet name updated successfully!`,
+              );
               // The updateWalletName method already updates the wallet signal
               // Call the success callback to refresh the parent component
               if (this.data?.onSuccess) {
                 this.data.onSuccess();
               }
             } else {
-              this.notificationService.error('Error', 'Failed to update wallet name');
+              this.notificationService.error(
+                'Error',
+                'Failed to update wallet name',
+              );
             }
           }
         } else {
@@ -118,7 +150,9 @@ export class CreateWalletAccountQuickActionDialogComponent implements AfterViewI
 
           // Get all wallets for this wallet ID
           const allWallets = this.walletService.getAllWallets(false)() || [];
-          const walletGroup = allWallets.filter(w => w.getId() === currentWallet.getId());
+          const walletGroup = allWallets.filter(
+            (w) => w.getId() === currentWallet.getId(),
+          );
 
           if (walletGroup.length === 0) {
             this.notificationService.error('Error', 'Wallet not found');
@@ -127,7 +161,9 @@ export class CreateWalletAccountQuickActionDialogComponent implements AfterViewI
 
           // Calculate next account number
           const accounts = walletGroup.map((wallet) =>
-            this.walletService.getWalletAccountNumberFromDerivedPath(wallet.getDerivedPath()!)
+            this.walletService.getWalletAccountNumberFromDerivedPath(
+              wallet.getDerivedPath()!,
+            ),
           );
           const maxAccount = Math.max(...accounts);
           const newAccountNumber = maxAccount + 1;
@@ -137,14 +173,17 @@ export class CreateWalletAccountQuickActionDialogComponent implements AfterViewI
             walletGroup[0].getId(),
             this.walletService.replaceWalletAccountNumberFromDerivedPath(
               walletGroup[0].getDerivedPath()!,
-              newAccountNumber
+              newAccountNumber,
             ),
-            this.accountName
+            this.accountName,
           );
 
           if (result.success) {
             // Show success notification
-            this.notificationService.success('Success', `Account "${this.accountName}" added successfully!`);
+            this.notificationService.success(
+              'Success',
+              `Account "${this.accountName}" added successfully!`,
+            );
             // Note: addWalletAccount already updates the wallet service's signal,
             // so we don't need to call loadWallets() here
             // Call the success callback to refresh the parent component
@@ -152,7 +191,10 @@ export class CreateWalletAccountQuickActionDialogComponent implements AfterViewI
               this.data.onSuccess();
             }
           } else {
-            this.notificationService.error('Error', result.error || 'Failed to add account');
+            this.notificationService.error(
+              'Error',
+              result.error || 'Failed to add account',
+            );
           }
         }
 

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet-account/delete-wallet-account-quick-action-dialog.component.html
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet-account/delete-wallet-account-quick-action-dialog.component.html
@@ -7,15 +7,22 @@
 >
   <!-- Content slot for confirmation message -->
   <div slot="content" class="delete-confirmation">
-    <p *ngIf="!isLastWalletAccount()">
-      Are you sure you want to delete the account <strong>{{ accountName }}</strong>?
-      This action cannot be undone and you will lose access to this account permanently.
-    </p>
-    <p *ngIf="isLastWalletAccount()">
-      You can't delete the last wallet. You can remove only all wallets info from the settings menu.
-    </p>
+    @if (!isLastWalletAccount()) {
+      <p>
+        Are you sure you want to delete the account
+        <strong>{{ accountName }}</strong
+        >? This action cannot be undone and you will lose access to this account
+        permanently.
+      </p>
+    }
+    @if (isLastWalletAccount()) {
+      <p>
+        You can't delete the last wallet. You can remove only all wallets info
+        from the settings menu.
+      </p>
+    }
   </div>
-  
+
   <!-- Footer slot for action buttons -->
   <div slot="footer" class="button-row">
     <kc-button
@@ -36,5 +43,3 @@
     ></kc-button>
   </div>
 </app-quick-action-dialog>
-
-

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet-account/delete-wallet-account-quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet-account/delete-wallet-account-quick-action-dialog.component.ts
@@ -8,7 +8,7 @@ import {
   AfterViewInit,
   computed,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcButtonComponent, NotificationService } from 'kaspacom-ui';
 import { QuickActionDialogComponent } from '../../quick-action-dialog.component';
 import { WalletService } from '../../../../../../../services/wallet.service';
@@ -24,12 +24,11 @@ interface DeleteAccountDialogData {
 @Component({
   selector: 'app-delete-wallet-account-quick-action-dialog',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, QuickActionDialogComponent],
+  imports: [KcButtonComponent, QuickActionDialogComponent],
   templateUrl: './delete-wallet-account-quick-action-dialog.component.html',
   styleUrl: './delete-wallet-account-quick-action-dialog.component.scss',
 })
-export class DeleteWalletAccountQuickActionDialogComponent
-  implements AfterViewInit {
+export class DeleteWalletAccountQuickActionDialogComponent implements AfterViewInit {
   @Input() isOpen = false;
   @Input() data: DeleteAccountDialogData | undefined;
   @Output() backdropClick = new EventEmitter<void>();
@@ -51,11 +50,13 @@ export class DeleteWalletAccountQuickActionDialogComponent
       return true;
     }
 
-    const allWalletsByWalletId = _.groupBy(this.walletService.getAllWallets()()!, 'id');
-
+    const allWalletsByWalletId = _.groupBy(
+      this.walletService.getAllWallets()()!,
+      'id',
+    );
 
     return allWalletsByWalletId[this.data?.wallet.getId()].length <= 1;
-  })
+  });
 
   ngAfterViewInit(): void {
     // Start with dialog closed, then open it to trigger animation

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet/delete-wallet-quick-action-dialog.component.html
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet/delete-wallet-quick-action-dialog.component.html
@@ -6,13 +6,20 @@
   (close)="onClose()"
 >
   <div slot="content" class="delete-confirmation">
-    <p *ngIf="!isLastWallet()">
-      Are you sure you want to delete the wallet <strong>{{ walletName }}</strong>?
-      This will remove all accounts associated with this wallet from this device.
-    </p>
-    <p *ngIf="isLastWallet()">
-      You can't delete the last wallet. You can remove only all wallets info from the settings menu.
-    </p>
+    @if (!isLastWallet()) {
+      <p>
+        Are you sure you want to delete the wallet
+        <strong>{{ walletName }}</strong
+        >? This will remove all accounts associated with this wallet from this
+        device.
+      </p>
+    }
+    @if (isLastWallet()) {
+      <p>
+        You can't delete the last wallet. You can remove only all wallets info
+        from the settings menu.
+      </p>
+    }
   </div>
 
   <div slot="footer" class="button-row">
@@ -33,4 +40,4 @@
       (buttonClick)="onDelete()"
     ></kc-button>
   </div>
-</app-quick-action-dialog> 
+</app-quick-action-dialog>

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet/delete-wallet-quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/delete-wallet/delete-wallet-quick-action-dialog.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectorRef,
@@ -25,12 +24,7 @@ interface DeleteWalletDialogData {
 @Component({
   selector: 'app-delete-wallet-quick-action-dialog',
   standalone: true,
-  imports: [
-    CommonModule,
-    FormsModule,
-    KcButtonComponent,
-    QuickActionDialogComponent,
-  ],
+  imports: [FormsModule, KcButtonComponent, QuickActionDialogComponent],
   templateUrl: './delete-wallet-quick-action-dialog.component.html',
   styleUrl: './delete-wallet-quick-action-dialog.component.scss',
 })

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/edit-wallet/edit-wallet-quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/edit-wallet/edit-wallet-quick-action-dialog.component.ts
@@ -8,7 +8,7 @@ import {
   inject,
   ChangeDetectorRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FormsModule } from '@angular/forms';
 import { KcInputComponent, KcButtonComponent } from 'kaspacom-ui';
 import { QuickActionDialogComponent } from '../../quick-action-dialog.component';
@@ -19,7 +19,6 @@ import { MessagePopupService } from '../../../../../../../services/message-popup
   selector: 'app-edit-wallet-quick-action-dialog',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     KcInputComponent,
     KcButtonComponent,

--- a/src/app/v2/pages/app/common/quick-action-dialog/implementations/wallet-options/wallet-options-quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/implementations/wallet-options/wallet-options-quick-action-dialog.component.ts
@@ -7,7 +7,7 @@ import {
   ChangeDetectorRef,
   AfterViewInit,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcIconComponent } from 'kaspacom-ui';
 import { QuickActionDialogComponent } from '../../quick-action-dialog.component';
 import { FlowPagesService } from '../../../../../../services/flow-pages.service';
@@ -15,7 +15,7 @@ import { FlowPagesService } from '../../../../../../services/flow-pages.service'
 @Component({
   selector: 'app-wallet-options-quick-action-dialog',
   standalone: true,
-  imports: [CommonModule, KcIconComponent, QuickActionDialogComponent],
+  imports: [KcIconComponent, QuickActionDialogComponent],
   templateUrl: './wallet-options-quick-action-dialog.component.html',
   styleUrl: './wallet-options-quick-action-dialog.component.scss',
 })
@@ -66,7 +66,7 @@ export class WalletOptionsQuickActionDialogComponent implements AfterViewInit {
     this.closeDialog();
   }
 
-    onChangeWallet(): void {
+  onChangeWallet(): void {
     this.flowPagesService.navigateToPage({
       id: 'wallet-selection',
       title: 'Select wallet',
@@ -89,5 +89,3 @@ export class WalletOptionsQuickActionDialogComponent implements AfterViewInit {
     this.closeDialog();
   }
 }
-
-

--- a/src/app/v2/pages/app/common/quick-action-dialog/quick-action-dialog.component.ts
+++ b/src/app/v2/pages/app/common/quick-action-dialog/quick-action-dialog.component.ts
@@ -1,42 +1,67 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
+
 import { KcIconComponent, KcTooltipDirective } from 'kaspacom-ui';
-import { trigger, state, style, transition, animate } from '@angular/animations';
+import {
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+} from '@angular/animations';
 
 @Component({
   selector: 'app-quick-action-dialog',
   standalone: true,
-  imports: [CommonModule, KcIconComponent, KcTooltipDirective],
+  imports: [KcIconComponent, KcTooltipDirective],
   templateUrl: './quick-action-dialog.component.html',
   styleUrl: './quick-action-dialog.component.scss',
   animations: [
     trigger('slideUp', [
-      state('closed', style({
-        transform: 'translateY(600px)',
-        opacity: 0
-      })),
-      state('open', style({
-        transform: 'translateY(0)',
-        opacity: 1
-      })),
+      state(
+        'closed',
+        style({
+          transform: 'translateY(600px)',
+          opacity: 0,
+        }),
+      ),
+      state(
+        'open',
+        style({
+          transform: 'translateY(0)',
+          opacity: 1,
+        }),
+      ),
       transition('closed => open', [
         style({
           transform: 'translateY(600px)',
-          opacity: 0
+          opacity: 0,
         }),
-        animate('300ms ease-out', style({
-          transform: 'translateY(0)',
-          opacity: 1
-        }))
+        animate(
+          '300ms ease-out',
+          style({
+            transform: 'translateY(0)',
+            opacity: 1,
+          }),
+        ),
       ]),
       transition('open => closed', [
-        animate('300ms ease-in', style({
-          transform: 'translateY(600px)',
-          opacity: 0
-        }))
-      ])
-    ])
-  ]
+        animate(
+          '300ms ease-in',
+          style({
+            transform: 'translateY(600px)',
+            opacity: 0,
+          }),
+        ),
+      ]),
+    ]),
+  ],
 })
 export class QuickActionDialogComponent implements OnChanges {
   @Input() isOpen = false;

--- a/src/app/v2/pages/app/common/wrapper-nav/wrapper-nav.component.ts
+++ b/src/app/v2/pages/app/common/wrapper-nav/wrapper-nav.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -22,7 +22,7 @@ export interface INavRoute {
 }
 @Component({
   selector: 'app-wrapper-nav',
-  imports: [CommonModule, RouterModule, KcTooltipDirective],
+  imports: [RouterModule, KcTooltipDirective],
   templateUrl: './wrapper-nav.component.html',
   styleUrl: './wrapper-nav.component.scss',
 })

--- a/src/app/v2/pages/app/flows/add-custom-network/add-custom-network-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/add-custom-network/add-custom-network-flow-page.component.ts
@@ -1,8 +1,17 @@
 import { Component, computed, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FormsModule } from '@angular/forms';
-import { DropdownOption, KcButtonComponent, KcDropdownSelectComponent, KcInputComponent, NotificationService } from 'kaspacom-ui';
-import { EthereumWalletChainManager, ExtendedEIP1193ProviderChain } from '../../../../../services/etherium-services/etherium-wallet-chain.manager';
+import {
+  DropdownOption,
+  KcButtonComponent,
+  KcDropdownSelectComponent,
+  KcInputComponent,
+  NotificationService,
+} from 'kaspacom-ui';
+import {
+  EthereumWalletChainManager,
+  ExtendedEIP1193ProviderChain,
+} from '../../../../../services/etherium-services/etherium-wallet-chain.manager';
 import { FlowPagesService } from '../../../../services/flow-pages.service';
 import { CHAIN_ID_LOGOS } from '../../../../shared/network-selection-modal/chain-id-logos';
 
@@ -16,27 +25,137 @@ interface WellKnownNetwork {
 }
 
 const WELL_KNOWN_NETWORKS: WellKnownNetwork[] = [
-  { name: 'Ethereum Mainnet',   chainId: 1,      rpcUrl: 'https://eth.llamarpc.com',                         symbol: 'ETH',   decimals: 18, explorerUrl: 'https://etherscan.io' },
-  { name: 'Base',               chainId: 8453,   rpcUrl: 'https://mainnet.base.org',                         symbol: 'ETH',   decimals: 18, explorerUrl: 'https://basescan.org' },
-  { name: 'Arbitrum One',       chainId: 42161,  rpcUrl: 'https://arb1.arbitrum.io/rpc',                     symbol: 'ETH',   decimals: 18, explorerUrl: 'https://arbiscan.io' },
-  { name: 'Optimism',           chainId: 10,     rpcUrl: 'https://mainnet.optimism.io',                      symbol: 'ETH',   decimals: 18, explorerUrl: 'https://optimistic.etherscan.io' },
-  { name: 'Polygon',            chainId: 137,    rpcUrl: 'https://polygon-rpc.com',                          symbol: 'POL',   decimals: 18, explorerUrl: 'https://polygonscan.com' },
-  { name: 'BNB Smart Chain',    chainId: 56,     rpcUrl: 'https://bsc-dataseed.binance.org',                 symbol: 'BNB',   decimals: 18, explorerUrl: 'https://bscscan.com' },
-  { name: 'Avalanche C-Chain',  chainId: 43114,  rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',            symbol: 'AVAX',  decimals: 18, explorerUrl: 'https://snowtrace.io' },
-  { name: 'zkSync Era',         chainId: 324,    rpcUrl: 'https://mainnet.era.zksync.io',                    symbol: 'ETH',   decimals: 18, explorerUrl: 'https://explorer.zksync.io' },
-  { name: 'Linea',              chainId: 59144,  rpcUrl: 'https://rpc.linea.build',                          symbol: 'ETH',   decimals: 18, explorerUrl: 'https://lineascan.build' },
-  { name: 'Fantom',             chainId: 250,    rpcUrl: 'https://rpc.ftm.tools',                            symbol: 'FTM',   decimals: 18, explorerUrl: 'https://ftmscan.com' },
-  { name: 'Celo',               chainId: 42220,  rpcUrl: 'https://forno.celo.org',                           symbol: 'CELO',  decimals: 18, explorerUrl: 'https://celoscan.io' },
-  { name: 'Moonbeam',           chainId: 1284,   rpcUrl: 'https://rpc.api.moonbeam.network',                 symbol: 'GLMR',  decimals: 18, explorerUrl: 'https://moonscan.io' },
-  { name: 'Moonriver',          chainId: 1285,   rpcUrl: 'https://rpc.api.moonriver.moonbeam.network',       symbol: 'MOVR',  decimals: 18, explorerUrl: 'https://moonriver.moonscan.io' },
-  { name: 'Cronos',             chainId: 25,     rpcUrl: 'https://evm.cronos.org',                           symbol: 'CRO',   decimals: 18, explorerUrl: 'https://cronoscan.com' },
-  { name: 'Metis',              chainId: 1088,   rpcUrl: 'https://andromeda.metis.io/?owner=1088',           symbol: 'METIS', decimals: 18, explorerUrl: 'https://andromeda-explorer.metis.io' },
+  {
+    name: 'Ethereum Mainnet',
+    chainId: 1,
+    rpcUrl: 'https://eth.llamarpc.com',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://etherscan.io',
+  },
+  {
+    name: 'Base',
+    chainId: 8453,
+    rpcUrl: 'https://mainnet.base.org',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://basescan.org',
+  },
+  {
+    name: 'Arbitrum One',
+    chainId: 42161,
+    rpcUrl: 'https://arb1.arbitrum.io/rpc',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://arbiscan.io',
+  },
+  {
+    name: 'Optimism',
+    chainId: 10,
+    rpcUrl: 'https://mainnet.optimism.io',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://optimistic.etherscan.io',
+  },
+  {
+    name: 'Polygon',
+    chainId: 137,
+    rpcUrl: 'https://polygon-rpc.com',
+    symbol: 'POL',
+    decimals: 18,
+    explorerUrl: 'https://polygonscan.com',
+  },
+  {
+    name: 'BNB Smart Chain',
+    chainId: 56,
+    rpcUrl: 'https://bsc-dataseed.binance.org',
+    symbol: 'BNB',
+    decimals: 18,
+    explorerUrl: 'https://bscscan.com',
+  },
+  {
+    name: 'Avalanche C-Chain',
+    chainId: 43114,
+    rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    symbol: 'AVAX',
+    decimals: 18,
+    explorerUrl: 'https://snowtrace.io',
+  },
+  {
+    name: 'zkSync Era',
+    chainId: 324,
+    rpcUrl: 'https://mainnet.era.zksync.io',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://explorer.zksync.io',
+  },
+  {
+    name: 'Linea',
+    chainId: 59144,
+    rpcUrl: 'https://rpc.linea.build',
+    symbol: 'ETH',
+    decimals: 18,
+    explorerUrl: 'https://lineascan.build',
+  },
+  {
+    name: 'Fantom',
+    chainId: 250,
+    rpcUrl: 'https://rpc.ftm.tools',
+    symbol: 'FTM',
+    decimals: 18,
+    explorerUrl: 'https://ftmscan.com',
+  },
+  {
+    name: 'Celo',
+    chainId: 42220,
+    rpcUrl: 'https://forno.celo.org',
+    symbol: 'CELO',
+    decimals: 18,
+    explorerUrl: 'https://celoscan.io',
+  },
+  {
+    name: 'Moonbeam',
+    chainId: 1284,
+    rpcUrl: 'https://rpc.api.moonbeam.network',
+    symbol: 'GLMR',
+    decimals: 18,
+    explorerUrl: 'https://moonscan.io',
+  },
+  {
+    name: 'Moonriver',
+    chainId: 1285,
+    rpcUrl: 'https://rpc.api.moonriver.moonbeam.network',
+    symbol: 'MOVR',
+    decimals: 18,
+    explorerUrl: 'https://moonriver.moonscan.io',
+  },
+  {
+    name: 'Cronos',
+    chainId: 25,
+    rpcUrl: 'https://evm.cronos.org',
+    symbol: 'CRO',
+    decimals: 18,
+    explorerUrl: 'https://cronoscan.com',
+  },
+  {
+    name: 'Metis',
+    chainId: 1088,
+    rpcUrl: 'https://andromeda.metis.io/?owner=1088',
+    symbol: 'METIS',
+    decimals: 18,
+    explorerUrl: 'https://andromeda-explorer.metis.io',
+  },
 ];
 
 @Component({
   selector: 'app-add-custom-network-flow-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, KcButtonComponent, KcInputComponent, KcDropdownSelectComponent],
+  imports: [
+    FormsModule,
+    KcButtonComponent,
+    KcInputComponent,
+    KcDropdownSelectComponent,
+  ],
   templateUrl: './add-custom-network-flow-page.component.html',
   styleUrl: './add-custom-network-flow-page.component.scss',
   host: {
@@ -64,10 +183,12 @@ export class AddCustomNetworkFlowPageComponent {
   submitted = signal(false);
   selectedPresetChainId = signal<number | null>(null);
 
-  protected readonly presetOptions: DropdownOption[] = WELL_KNOWN_NETWORKS.map(n => ({
-    value: n.chainId,
-    label: n.name,
-  }));
+  protected readonly presetOptions: DropdownOption[] = WELL_KNOWN_NETWORKS.map(
+    (n) => ({
+      value: n.chainId,
+      label: n.name,
+    }),
+  );
 
   private urlPattern = /^https?:\/\/.+/;
 
@@ -90,13 +211,14 @@ export class AddCustomNetworkFlowPageComponent {
     return Number.isInteger(val) && val >= 0 && val <= 36;
   });
 
-  isFormValid = computed(() =>
-    !!this.networkName().trim() &&
-    this.isChainIdValid() &&
-    this.isRpcUrlValid() &&
-    !!this.currencySymbol().trim() &&
-    this.isDecimalsValid() &&
-    this.isExplorerUrlValid()
+  isFormValid = computed(
+    () =>
+      !!this.networkName().trim() &&
+      this.isChainIdValid() &&
+      this.isRpcUrlValid() &&
+      !!this.currencySymbol().trim() &&
+      this.isDecimalsValid() &&
+      this.isExplorerUrlValid(),
   );
 
   chainIdError = computed(() => {
@@ -108,12 +230,16 @@ export class AddCustomNetworkFlowPageComponent {
   rpcUrlError = computed(() => {
     if (!this.submitted()) return '';
     if (!this.rpcUrl().trim()) return 'RPC URL is required';
-    return this.isRpcUrlValid() ? '' : 'Must be a valid URL (http:// or https://)';
+    return this.isRpcUrlValid()
+      ? ''
+      : 'Must be a valid URL (http:// or https://)';
   });
 
   explorerUrlError = computed(() => {
     if (!this.submitted() || !this.explorerUrl().trim()) return '';
-    return this.isExplorerUrlValid() ? '' : 'Must be a valid URL (http:// or https://)';
+    return this.isExplorerUrlValid()
+      ? ''
+      : 'Must be a valid URL (http:// or https://)';
   });
 
   decimalsError = computed(() => {
@@ -127,7 +253,7 @@ export class AddCustomNetworkFlowPageComponent {
   }
 
   onPresetSelected(chainId: number): void {
-    const preset = WELL_KNOWN_NETWORKS.find(n => n.chainId === chainId);
+    const preset = WELL_KNOWN_NETWORKS.find((n) => n.chainId === chainId);
     if (!preset) return;
     this.selectedPresetChainId.set(chainId);
     this.networkName.set(preset.name);
@@ -146,7 +272,10 @@ export class AddCustomNetworkFlowPageComponent {
 
     const allChains = this.chainManager.getAllChainsByChainId();
     if (allChains[hexChainId]) {
-      this.notificationService.error('Network Exists', 'A network with this Chain ID is already added.');
+      this.notificationService.error(
+        'Network Exists',
+        'A network with this Chain ID is already added.',
+      );
       return;
     }
 
@@ -160,16 +289,24 @@ export class AddCustomNetworkFlowPageComponent {
         decimals: Number(this.currencyDecimals()),
       },
       rpcUrls: [this.rpcUrl().trim()],
-      blockExplorerUrls: this.explorerUrl().trim() ? [this.explorerUrl().trim()] : [],
+      blockExplorerUrls: this.explorerUrl().trim()
+        ? [this.explorerUrl().trim()]
+        : [],
     };
 
     this.isSaving.set(true);
     try {
       this.chainManager.addChain(chain);
-      this.notificationService.success('Network Added', `${chain.chainName} has been added.`);
+      this.notificationService.success(
+        'Network Added',
+        `${chain.chainName} has been added.`,
+      );
       this.flowPagesService.navigateBack();
     } catch {
-      this.notificationService.error('Error', 'Failed to add network. Please try again.');
+      this.notificationService.error(
+        'Error',
+        'Failed to add network. Please try again.',
+      );
     } finally {
       this.isSaving.set(false);
     }

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.html
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.html
@@ -1,164 +1,193 @@
-<div *ngIf="approvalConfig()" [ngSwitch]="currentState()" class="approval-flow-root">
-
-  <!-- Approval State -->
-  <div *ngSwitchCase="ApprovalFlowState.APPROVAL" class="approval-flow-container">
-    <!-- Swap Approval (custom UI for swap transactions) -->
-    <ng-container *ngIf="isSwapTransaction() && swapContext(); else regularApproval">
-      <app-swap-approval
-        [swapContext]="swapContext()!"
-        [isLoading]="isLoading()"
-        [canApprove]="isAvailableForApproval()"
-        (approve)="onAccept()"
-        (reject)="onReject()">
-        <ng-container *ngIf="isActionHasL2PriorityFee()">
-          <l2-priority-fee-selection
-            [action]="approvalConfig()!.action"
-            [wallet]="wallet()"
-            (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
-            (gasLimitSelected)="setL2GasLimit($event)">
-          </l2-priority-fee-selection>
-        </ng-container>
-      </app-swap-approval>
-    </ng-container>
-
-    <!-- Regular Approval -->
-    <ng-template #regularApproval>
-      <div class="approval-flow-content">
-
-        <!-- Transaction Header -->
-        <div class="transaction-header">
-          <h2 *ngIf="isActionHasPriorityFee()">Transaction Review</h2>
-          <h2 *ngIf="!isActionHasPriorityFee()">Action Review</h2>
-          <p>Please review the details below before proceeding.</p>
-        </div>
-
-        <!-- Action Details Section -->
-        <ng-container *ngIf="actionDisplay(); else unknownAction">
-          <div class="action-overview-card">
-            <div class="action-header">
-              <h3 class="action-title">{{ actionDisplay()!.title }}</h3>
-              <h4 class="action-subtitle" *ngIf="actionDisplay()!.subtitle">{{ actionDisplay()!.subtitle }}</h4>
-            </div>
-
-            <!-- Action Detail Rows -->
-            <div class="action-details-grid">
-              <ng-container *ngFor="let row of actionDisplay()!.rows">
-
-                <!-- Input Fields (checkboxes) -->
-                <div *ngIf="row.inputField; else noInputField" class="detail-card checkbox-container">
-                  <div *ngIf="row.inputField.fieldType === InputFieldType.CHECKBOX">
-                    <label class="checkbox-label">
-                      <input
-                        type="checkbox"
-                        [(ngModel)]="additionalParams[row.inputField.fieldParam]"
-                        [checked]="row.fieldValue === 'true'">
-                      <span>{{ row.fieldName }}</span>
-                    </label>
+@if (approvalConfig()) {
+  <div class="approval-flow-root">
+    @switch (currentState()) {
+      <!-- Approval State -->
+      @case (ApprovalFlowState.APPROVAL) {
+        <div class="approval-flow-container">
+          <!-- Swap Approval (custom UI for swap transactions) -->
+          @if (isSwapTransaction() && swapContext()) {
+            <app-swap-approval
+              [swapContext]="swapContext()!"
+              [isLoading]="isLoading()"
+              [canApprove]="isAvailableForApproval()"
+              (approve)="onAccept()"
+              (reject)="onReject()"
+            >
+              @if (isActionHasL2PriorityFee()) {
+                <l2-priority-fee-selection
+                  [action]="approvalConfig()!.action"
+                  [wallet]="wallet()"
+                  (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
+                  (gasLimitSelected)="setL2GasLimit($event)"
+                >
+                </l2-priority-fee-selection>
+              }
+            </app-swap-approval>
+          } @else {
+            <div class="approval-flow-content">
+              <!-- Transaction Header -->
+              <div class="transaction-header">
+                @if (isActionHasPriorityFee()) {
+                  <h2>Transaction Review</h2>
+                }
+                @if (!isActionHasPriorityFee()) {
+                  <h2>Action Review</h2>
+                }
+                <p>Please review the details below before proceeding.</p>
+              </div>
+              <!-- Action Details Section -->
+              @if (actionDisplay()) {
+                <div class="action-overview-card">
+                  <div class="action-header">
+                    <h3 class="action-title">{{ actionDisplay()!.title }}</h3>
+                    @if (actionDisplay()!.subtitle) {
+                      <h4 class="action-subtitle">
+                        {{ actionDisplay()!.subtitle }}
+                      </h4>
+                    }
+                  </div>
+                  <!-- Action Detail Rows -->
+                  <div class="action-details-grid">
+                    @for (row of actionDisplay()!.rows; track row) {
+                      <!-- Input Fields (checkboxes) -->
+                      @if (row.inputField) {
+                        <div class="detail-card checkbox-container">
+                          @if (
+                            row.inputField.fieldType === InputFieldType.CHECKBOX
+                          ) {
+                            <div>
+                              <label class="checkbox-label">
+                                <input
+                                  type="checkbox"
+                                  [(ngModel)]="
+                                    additionalParams[row.inputField.fieldParam]
+                                  "
+                                  [checked]="row.fieldValue === 'true'"
+                                />
+                                <span>{{ row.fieldName }}</span>
+                              </label>
+                            </div>
+                          }
+                        </div>
+                      } @else {
+                        <!-- Signing Message Detail -->
+                        @if (row.isCodeBlock) {
+                          <div class="detail-card detail-signing-message">
+                            <div class="detail-label">{{ row.fieldName }}</div>
+                            <div class="detail-value">{{ row.fieldValue }}</div>
+                          </div>
+                        }
+                        <!-- Regular Detail -->
+                        @if (!row.isCodeBlock) {
+                          <div class="detail-card">
+                            <div class="detail-label">{{ row.fieldName }}</div>
+                            <div class="detail-value">{{ row.fieldValue }}</div>
+                          </div>
+                        }
+                      }
+                      <!-- Regular Detail Rows -->
+                    }
                   </div>
                 </div>
-
-                <!-- Regular Detail Rows -->
-                <ng-template #noInputField>
-                  <!-- Signing Message Detail -->
-                  <div *ngIf="row.isCodeBlock" class="detail-card detail-signing-message">
-                    <div class="detail-label">{{ row.fieldName }}</div>
-                    <div class="detail-value">{{ row.fieldValue }}</div>
-                  </div>
-
-                  <!-- Regular Detail -->
-                  <div *ngIf="!row.isCodeBlock" class="detail-card">
-                    <div class="detail-label">{{ row.fieldName }}</div>
-                    <div class="detail-value">{{ row.fieldValue }}</div>
-                  </div>
-                </ng-template>
-
-              </ng-container>
+              } @else {
+                <div class="unknown-action-card">
+                  <kc-icon
+                    iconClass="icon-warning"
+                    size="lg"
+                    color="var(--orange-20)"
+                  ></kc-icon>
+                  <h3>Unknown Action</h3>
+                  <p>
+                    This action type is not recognized. Please proceed with
+                    caution.
+                  </p>
+                </div>
+              }
+              <!-- Priority Fee Selection -->
+              @if (isActionHasPriorityFee()) {
+                <priority-fee-selection
+                  [action]="approvalConfig()!.action"
+                  [wallet]="wallet()"
+                  (priorityFeeSelected)="setCurrentPriorityFee($event)"
+                >
+                </priority-fee-selection>
+              }
+              <!-- Priority Fee Selection -->
+              @if (isActionHasL2PriorityFee()) {
+                <l2-priority-fee-selection
+                  [action]="approvalConfig()!.action"
+                  [wallet]="wallet()"
+                  (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
+                  (gasLimitSelected)="setL2GasLimit($event)"
+                >
+                </l2-priority-fee-selection>
+              }
+              <!-- Action Buttons - Last element that gets pushed to bottom -->
+              <div class="action-buttons-section">
+                <div class="action-buttons">
+                  <kc-button
+                    [text]="isLoading() ? 'Processing...' : 'Approve'"
+                    variant="primary"
+                    size="lg"
+                    [isFullWidth]="true"
+                    [isDisabled]="!isAvailableForApproval()"
+                    [isLoading]="isLoading()"
+                    (buttonClick)="onAccept()"
+                    class="accept-button"
+                  >
+                  </kc-button>
+                  <kc-button
+                    [text]="'Reject'"
+                    variant="tertiary"
+                    size="lg"
+                    [isFullWidth]="true"
+                    [isDisabled]="isLoading()"
+                    (buttonClick)="onReject()"
+                    class="reject-button"
+                  >
+                  </kc-button>
+                </div>
+              </div>
             </div>
-          </div>
-        </ng-container>
-
-        <ng-template #unknownAction>
-          <div class="unknown-action-card">
-            <kc-icon iconClass="icon-warning" size="lg" color="var(--orange-20)"></kc-icon>
-            <h3>Unknown Action</h3>
-            <p>This action type is not recognized. Please proceed with caution.</p>
-          </div>
-        </ng-template>
-
-      <!-- Priority Fee Selection -->
-      <ng-container *ngIf="isActionHasPriorityFee()">
-        <priority-fee-selection
-          [action]="approvalConfig()!.action"
-          [wallet]="wallet()"
-          (priorityFeeSelected)="setCurrentPriorityFee($event)">
-        </priority-fee-selection>
-      </ng-container>
-
-            <!-- Priority Fee Selection -->
-      <ng-container *ngIf="isActionHasL2PriorityFee()">
-        <l2-priority-fee-selection
-          [action]="approvalConfig()!.action"
-          [wallet]="wallet()"
-          (priorityFeeSelected)="setL2CurrentPriorityFee($event)"
-          (gasLimitSelected)="setL2GasLimit($event)">
-        </l2-priority-fee-selection>
-      </ng-container>
-
-        <!-- Action Buttons - Last element that gets pushed to bottom -->
-        <div class="action-buttons-section">
-          <div class="action-buttons">
+          }
+          <!-- Regular Approval -->
+        </div>
+      }
+      <!-- Processing/Loading State -->
+      @case (ApprovalFlowState.PROCESSING) {
+        <app-approval-loading-page> </app-approval-loading-page>
+      }
+      <!-- Success State -->
+      @case (ApprovalFlowState.SUCCESS) {
+        <app-approval-success-page [actionResult]="approvalConfig()!.result!">
+        </app-approval-success-page>
+      }
+      <!-- Error State -->
+      @case (ApprovalFlowState.ERROR) {
+        <div class="error-container">
+          <div class="error-content">
+            <div class="error-icon-wrapper">
+              <kc-icon
+                iconClass="icon-warning"
+                size="lg"
+                color="#f87171"
+              ></kc-icon>
+            </div>
+            <h2>Transaction Failed</h2>
+            <div class="error-message">
+              {{ approvalConfig()?.error || "An unexpected error occurred" }}
+            </div>
             <kc-button
-              [text]="isLoading() ? 'Processing...' : 'Approve'"
-              variant="primary"
+              [text]="'Close'"
+              variant="secondary"
               size="lg"
               [isFullWidth]="true"
-              [isDisabled]="!isAvailableForApproval()"
-              [isLoading]="isLoading()"
-              (buttonClick)="onAccept()"
-              class="accept-button">
-            </kc-button>
-
-            <kc-button
-              [text]="'Reject'"
-              variant="tertiary"
-              size="lg"
-              [isFullWidth]="true"
-              [isDisabled]="isLoading()"
-              (buttonClick)="onReject()"
-              class="reject-button">
+              (buttonClick)="approvalFlowService.closeApproval()"
+            >
             </kc-button>
           </div>
         </div>
-      </div>
-    </ng-template>
+      }
+    }
   </div>
-
-  <!-- Processing/Loading State -->
-  <app-approval-loading-page *ngSwitchCase="ApprovalFlowState.PROCESSING">
-  </app-approval-loading-page>
-
-  <!-- Success State -->
-  <app-approval-success-page
-    *ngSwitchCase="ApprovalFlowState.SUCCESS"
-    [actionResult]="approvalConfig()!.result!">
-  </app-approval-success-page>
-
-  <!-- Error State -->
-  <div *ngSwitchCase="ApprovalFlowState.ERROR" class="error-container">
-    <div class="error-content">
-      <div class="error-icon-wrapper">
-        <kc-icon iconClass="icon-warning" size="lg" color="#f87171"></kc-icon>
-      </div>
-      <h2>Transaction Failed</h2>
-      <div class="error-message">{{ approvalConfig()?.error || 'An unexpected error occurred' }}</div>
-      <kc-button
-        [text]="'Close'"
-        variant="secondary"
-        size="lg"
-        [isFullWidth]="true"
-        (buttonClick)="approvalFlowService.closeApproval()">
-      </kc-button>
-    </div>
-  </div>
-
-</div>
+}

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/approval-flow-page.component.ts
@@ -6,7 +6,7 @@ import {
   WritableSignal,
   OnDestroy,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FormsModule } from '@angular/forms';
 import { KcButtonComponent } from 'kaspacom-ui';
 import { KcIconComponent } from 'kaspacom-ui';
@@ -33,7 +33,6 @@ import { SwapContextService } from '../../../../../services/swap-context.service
 @Component({
   selector: 'app-approval-flow-page',
   imports: [
-    CommonModule,
     FormsModule,
     KcButtonComponent,
     KcIconComponent,
@@ -126,7 +125,8 @@ export class ApprovalFlowPageComponent implements OnDestroy {
   });
 
   // Form state
-  protected currentPriorityFee: WritableSignal<bigint | undefined> = signal(undefined);
+  protected currentPriorityFee: WritableSignal<bigint | undefined> =
+    signal(undefined);
   protected currentL2PriorityFee: WritableSignal<
     Partial<L2PriorityInfo> | undefined
   > = signal(undefined);
@@ -197,9 +197,9 @@ export class ApprovalFlowPageComponent implements OnDestroy {
   setL2CurrentPriorityFee(
     info:
       | {
-        priorityFee: bigint;
-        baseFee: bigint;
-      }
+          priorityFee: bigint;
+          baseFee: bigint;
+        }
       | undefined,
   ) {
     if (info == undefined) {

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-loading-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-loading-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ApprovalFlowService } from '../../../../../../services/approval-flow.service';
 import { KcIconComponent } from 'kaspacom-ui';
 import { KaspaNodesBackgroundComponent } from '../../../../common/components/kaspa-nodes-background/kaspa-nodes-background.component';
@@ -7,15 +7,13 @@ import { KaspaNodesBackgroundComponent } from '../../../../common/components/kas
 @Component({
   selector: 'app-approval-loading-page',
   standalone: true,
-  imports: [
-    CommonModule,
-    KcIconComponent,
-    KaspaNodesBackgroundComponent
-  ],
+  imports: [KcIconComponent, KaspaNodesBackgroundComponent],
   template: `
     <div class="loading-container">
       <!-- Background Canvas -->
-      <kaspa-nodes-background class="background-canvas"></kaspa-nodes-background>
+      <kaspa-nodes-background
+        class="background-canvas"
+      ></kaspa-nodes-background>
 
       <!-- Loading Header -->
       <div class="loading-header">
@@ -24,27 +22,26 @@ import { KaspaNodesBackgroundComponent } from '../../../../common/components/kas
             <kc-icon
               [iconClass]="'icon-refresh'"
               [size]="'xlg'"
-              class="spinner-icon">
+              class="spinner-icon"
+            >
             </kc-icon>
           </div>
         </div>
         <h2 class="loading-title">Processing Transaction</h2>
-        <p class="loading-subtitle">Please wait while your transaction is being processed...</p>
+        <p class="loading-subtitle">
+          Please wait while your transaction is being processed...
+        </p>
       </div>
 
       <!-- Progress Bar -->
       <div class="progress-section">
         <div class="progress-bar">
-          <div
-            class="progress-fill"
-            [style.width.%]="currentProgress()">
-          </div>
+          <div class="progress-fill" [style.width.%]="currentProgress()"></div>
         </div>
       </div>
-
     </div>
   `,
-  styleUrl: './approval-loading-page.component.scss'
+  styleUrl: './approval-loading-page.component.scss',
 })
 export class ApprovalLoadingPageComponent {
   private approvalFlowService = inject(ApprovalFlowService);

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -1,21 +1,28 @@
 import { Component, computed, inject, Input, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { Router } from '@angular/router';
-import { WalletActionResult, WalletActionResultType, CommitRevealActionResult, ProtocolType } from '@kaspacom/wallet-messages';
+import {
+  WalletActionResult,
+  WalletActionResultType,
+  CommitRevealActionResult,
+  ProtocolType,
+} from '@kaspacom/wallet-messages';
 import { CompletedActionOverviewService } from '../../../../../../../services/action-info-services/completed-action-overview.service';
 import { KcButtonComponent, KcIconComponent } from 'kaspacom-ui';
 import { ApprovalFlowService } from '../../../../../../services/approval-flow.service';
-import { trigger, state, style, transition, animate } from '@angular/animations';
+import {
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+} from '@angular/animations';
 import { WalletActionService } from '../../../../../../../services/wallet-action.service';
 
 @Component({
   selector: 'app-approval-success-page',
   standalone: true,
-  imports: [
-    CommonModule,
-    KcButtonComponent,
-    KcIconComponent
-  ],
+  imports: [KcButtonComponent, KcIconComponent],
   template: `
     <div class="success-container">
       <!-- Success Header -->
@@ -24,43 +31,61 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
 
         <!-- Success Icon -->
         <div class="success-icon-wrapper">
-          <img src="/svgs/success.svg" alt="Success" class="success-icon" width="334" height="226" />
+          <img
+            src="/svgs/success.svg"
+            alt="Success"
+            class="success-icon"
+            width="334"
+            height="226"
+          />
         </div>
       </div>
 
       <!-- Transaction Details Spoiler -->
-      <div class="details-spoiler-container" *ngIf="actionDisplay()">
-        <!-- Details Toggle Header -->
-        <div class="details-spoiler-toggle" (click)="toggleDetails()">
-          <div class="spoiler-left">
-            <kc-icon iconClass="icon-info" size="sm" color="#6fc7ba"></kc-icon>
-            <span class="spoiler-label">Transaction Details</span>
+      @if (actionDisplay()) {
+        <div class="details-spoiler-container">
+          <!-- Details Toggle Header -->
+          <div class="details-spoiler-toggle" (click)="toggleDetails()">
+            <div class="spoiler-left">
+              <kc-icon
+                iconClass="icon-info"
+                size="sm"
+                color="#6fc7ba"
+              ></kc-icon>
+              <span class="spoiler-label">Transaction Details</span>
+            </div>
+            <div class="spoiler-chevron">
+              <kc-icon
+                [iconClass]="
+                  showDetails ? 'icon-chevron-up' : 'icon-chevron-down'
+                "
+                size="sm"
+                color="var(--gray-60, #9E9E9E)"
+              >
+              </kc-icon>
+            </div>
           </div>
-          <div class="spoiler-chevron">
-            <kc-icon
-              [iconClass]="showDetails ? 'icon-chevron-up' : 'icon-chevron-down'"
-              size="sm"
-              color="var(--gray-60, #9E9E9E)">
-            </kc-icon>
-          </div>
-        </div>
-
-        <!-- Details Content (Collapsible) -->
-        <div class="details-content" [@slideDown]="showDetails ? 'open' : 'closed'">
-          <div class="details-inner">
-            <h3 class="details-title">{{ actionDisplay()!.title }}</h3>
-
-            <div class="details-grid">
-              <div class="detail-item" *ngFor="let row of actionDisplay()!.rows">
-                <div class="detail-label">{{ row.fieldName }}</div>
-                <div class="detail-value">
-                  {{ row.fieldValue }}
-                </div>
+          <!-- Details Content (Collapsible) -->
+          <div
+            class="details-content"
+            [@slideDown]="showDetails ? 'open' : 'closed'"
+          >
+            <div class="details-inner">
+              <h3 class="details-title">{{ actionDisplay()!.title }}</h3>
+              <div class="details-grid">
+                @for (row of actionDisplay()!.rows; track row) {
+                  <div class="detail-item">
+                    <div class="detail-label">{{ row.fieldName }}</div>
+                    <div class="detail-value">
+                      {{ row.fieldValue }}
+                    </div>
+                  </div>
+                }
               </div>
             </div>
           </div>
         </div>
-      </div>
+      }
 
       <!-- Action Button -->
       <div class="action-button">
@@ -70,7 +95,8 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
           size="lg"
           [isFullWidth]="true"
           (buttonClick)="onDone()"
-          class="done-button">
+          class="done-button"
+        >
         </kc-button>
       </div>
     </div>
@@ -78,27 +104,31 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
   styleUrl: './approval-success-page.component.scss',
   animations: [
     trigger('slideDown', [
-      state('closed', style({
-        height: '0px',
-        opacity: 0,
-        overflow: 'hidden'
-      })),
-      state('open', style({
-        height: '*',
-        opacity: 1,
-        overflow: 'visible'
-      })),
-      transition('closed => open', [
-        animate('400ms ease-out')
-      ]),
-      transition('open => closed', [
-        animate('300ms ease-in')
-      ])
-    ])
-  ]
+      state(
+        'closed',
+        style({
+          height: '0px',
+          opacity: 0,
+          overflow: 'hidden',
+        }),
+      ),
+      state(
+        'open',
+        style({
+          height: '*',
+          opacity: 1,
+          overflow: 'visible',
+        }),
+      ),
+      transition('closed => open', [animate('400ms ease-out')]),
+      transition('open => closed', [animate('300ms ease-in')]),
+    ]),
+  ],
 })
 export class ApprovalSuccessPageComponent {
-  private completedActionOverviewService = inject(CompletedActionOverviewService);
+  private completedActionOverviewService = inject(
+    CompletedActionOverviewService,
+  );
   private approvalFlowService = inject(ApprovalFlowService);
   private router = inject(Router);
   private walletActionService = inject(WalletActionService);
@@ -122,7 +152,7 @@ export class ApprovalSuccessPageComponent {
   }
 
   actionDisplay = computed(() =>
-    this.completedActionOverviewService.getActionDisplay(this.actionResult)
+    this.completedActionOverviewService.getActionDisplay(this.actionResult),
   );
 
   toggleDetails() {
@@ -141,7 +171,6 @@ export class ApprovalSuccessPageComponent {
 
     // Clear the action result to dismiss the modal
     this.walletActionService.clearActionResult();
-
   }
 
   /**

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/swap-approval.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, input, output } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcButtonComponent, KcIconComponent } from 'kaspacom-ui';
 import { TokenLogoComponent } from '../../../../../../../components/token-logo/token-logo.component';
 import { SwapContext } from '../../../../../../services/swap-context.service';
@@ -9,7 +9,6 @@ import { CommaFormatterPipe } from '../../../../../../../pipes/comma-formatter.p
   selector: 'app-swap-approval',
   standalone: true,
   imports: [
-    CommonModule,
     KcButtonComponent,
     KcIconComponent,
     TokenLogoComponent,
@@ -34,7 +33,9 @@ export class SwapApprovalComponent {
   minReceived = computed(() => this.swapContext().minReceived || '0');
   route = computed(() => this.swapContext().route || '-');
   slippage = computed(() => this.swapContext().settings?.maxSlippage || '0.5');
-  deadline = computed(() => this.swapContext().settings?.swapDeadline?.toString() || '20');
+  deadline = computed(
+    () => this.swapContext().settings?.swapDeadline?.toString() || '20',
+  );
   networkName = computed(() => this.swapContext().networkName || 'Unknown');
   priceImpact = computed(() => this.swapContext().priceImpact || '0');
   estimatedGas = computed(() => this.swapContext().estimatedGas || '0');

--- a/src/app/v2/pages/app/flows/export-account/export-account.component.ts
+++ b/src/app/v2/pages/app/flows/export-account/export-account.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcButtonComponent, NotificationService } from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../common/flow-page/interfaces/flow-page.interface';
@@ -14,7 +14,7 @@ interface ExportAccountFlowData {
 @Component({
   selector: 'app-export-account',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, FormsModule],
+  imports: [KcButtonComponent, FormsModule],
   templateUrl: './export-account.component.html',
   styleUrl: './export-account.component.scss',
 })
@@ -68,9 +68,8 @@ export class ExportAccountComponent extends FlowPageBaseComponent {
     this.isVerifying.set(true);
 
     try {
-      const isValid = await this.passwordManagerService.checkAndLoadPassword(
-        passwordValue,
-      );
+      const isValid =
+        await this.passwordManagerService.checkAndLoadPassword(passwordValue);
 
       if (!isValid) {
         this.passwordError.set('Incorrect password. Please try again.');
@@ -173,9 +172,8 @@ export class ExportAccountComponent extends FlowPageBaseComponent {
       return false;
     }
 
-    const wallet = this.walletService.getWalletByIdAndAccount(
-      walletIdWithAccount,
-    );
+    const wallet =
+      this.walletService.getWalletByIdAndAccount(walletIdWithAccount);
 
     if (!wallet) {
       this.loadError.set(true);
@@ -229,5 +227,3 @@ export class ExportAccountComponent extends FlowPageBaseComponent {
     return `${normalized || 'account'}-private-key.txt`;
   }
 }
-
-

--- a/src/app/v2/pages/app/flows/export-kaspacom-wallet/export-kaspacom-wallet-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/export-kaspacom-wallet/export-kaspacom-wallet-flow-page.component.ts
@@ -1,7 +1,17 @@
-import { Component, computed, inject, signal, HostListener } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  HostListener,
+} from '@angular/core';
+
 import { QRCodeComponent } from 'angularx-qrcode';
-import { KcButtonComponent, KcIconComponent, NotificationService } from 'kaspacom-ui';
+import {
+  KcButtonComponent,
+  KcIconComponent,
+  NotificationService,
+} from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../common/flow-page/interfaces/flow-page.interface';
 import { PasswordManagerService } from '../../../../../services/password-manager.service';
@@ -11,13 +21,7 @@ import { FormsModule } from '@angular/forms';
 @Component({
   selector: 'app-export-kaspacom-wallet-flow-page',
   standalone: true,
-  imports: [
-    CommonModule, 
-    QRCodeComponent, 
-    KcButtonComponent, 
-    KcIconComponent,
-    FormsModule
-  ],
+  imports: [QRCodeComponent, KcButtonComponent, KcIconComponent, FormsModule],
   templateUrl: './export-kaspacom-wallet-flow-page.component.html',
   styleUrl: './export-kaspacom-wallet-flow-page.component.scss',
 })
@@ -42,7 +46,7 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
   isLoading = signal<boolean>(false);
   encryptedUserData = signal<string | null>(null);
   passwordError = signal<string | null>(null);
-  
+
   // QR Code settings
   maxDataLength = 2331;
   qrCodeSize = signal<number>(280);
@@ -93,10 +97,10 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
 
   async onVerifyPassword(): Promise<void> {
     const passwordValue = this.password();
-    
+
     // Clear any existing error
     this.passwordError.set(null);
-    
+
     if (!passwordValue.trim()) {
       this.passwordError.set('Please enter your password');
       return;
@@ -105,8 +109,9 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
     this.isLoading.set(true);
 
     try {
-      const isValid = await this.passwordManagerService.checkPassword(passwordValue);
-      
+      const isValid =
+        await this.passwordManagerService.checkPassword(passwordValue);
+
       if (!isValid) {
         this.passwordError.set('Incorrect password. Please try again.');
         this.password.set('');
@@ -115,7 +120,7 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
 
       // Get encrypted user data
       const encryptedData = localStorage.getItem(LOCAL_STORAGE_KEYS.USER_DATA);
-      
+
       if (!encryptedData) {
         this.passwordError.set('No wallet data found to export');
         return;
@@ -123,7 +128,6 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
 
       this.encryptedUserData.set(encryptedData);
       this.currentStep.set('export');
-      
     } catch (error) {
       console.error('Password verification error:', error);
       this.passwordError.set('Failed to verify password');
@@ -143,18 +147,21 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
       const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      
+
       link.href = url;
       link.download = 'kaspacom-wallets.key';
       link.style.display = 'none';
-      
+
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-      
+
       URL.revokeObjectURL(url);
-      
-      this.notificationService.success('Success', 'Wallet file downloaded successfully');
+
+      this.notificationService.success(
+        'Success',
+        'Wallet file downloaded successfully',
+      );
     } catch (error) {
       console.error('Download error:', error);
       this.notificationService.error('Error', 'Failed to download wallet file');
@@ -170,12 +177,15 @@ export class ExportKaspacomWalletFlowPageComponent extends FlowPageBaseComponent
 
     navigator.clipboard.writeText(data).then(
       () => {
-        this.notificationService.success('Success', 'Wallet data copied to clipboard');
+        this.notificationService.success(
+          'Success',
+          'Wallet data copied to clipboard',
+        );
       },
       (error) => {
         console.error('Copy error:', error);
         this.notificationService.error('Error', 'Failed to copy to clipboard');
-      }
+      },
     );
   }
 

--- a/src/app/v2/pages/app/flows/export-wallet/export-wallet.component.html
+++ b/src/app/v2/pages/app/flows/export-wallet/export-wallet.component.html
@@ -1,55 +1,88 @@
 <div class="export-wallet">
-	@if (currentStep() === 'password' && hasMnemonic()) {
-		<div class="export-wallet__password-step flex column align-items-center gap-24 full-width">
-			<div class="flex column align-items-center gap-8 text-align-center">
-				<span class="typo-title-3">Confirm Password</span>
-				<span class="typo-text-2 text-medium">
-					Enter your wallet password to reveal the seed phrase.
-				</span>
-			</div>
-			<div class="export-wallet__password-form flex column gap-16 full-width">
-				<label class="typo-text-1 text-gray-60" for="export-wallet-password">Password</label>
-				<input
-					id="export-wallet-password"
-					type="password"
-					class="export-wallet__password-input p-16 rounded-lg typo-text-1"
-					[class.error]="passwordError()"
-					placeholder="Enter your password"
-					[(ngModel)]="password"
-					(ngModelChange)="onPasswordInput()"
-					(keyup.enter)="onVerifyPassword()"
-				/>
-				@if (passwordError()) {
-					<span class="export-wallet__password-error typo-text-2">{{ passwordError() }}</span>
-				}
-				<kc-button
-					[variant]="'primary'"
-					[text]="'Continue'"
-					[isDisabled]="isVerifying() || !password().trim()"
-					(buttonClick)="onVerifyPassword()"
-				></kc-button>
-			</div>
-		</div>
-	} @else {
-		<div class="export-wallet__content flex column align-items-center gap-24 full-width">
-			<div class="flex column align-items-center gap-4">
-				<span class="typo-title-3 p-4">Seed Phrase</span>
-				<span class="typo-text-2 text-medium text-align-center" *ngIf="hasMnemonic()">This seed phrase is the only way to recover your wallet. Do NOT share it with anyone.</span>
-			</div>
-			<div class="seed-container" *ngIf="hasMnemonic(); else noMnemonic">
-				@for (item of seedWords(); track $index) {
-					<app-seed-phrase-word class="seed-container__word" [idx]="$index + 1" [word]="item"></app-seed-phrase-word>
-				}
-			</div>
-			<ng-template #noMnemonic>
-				<div class="flex column align-items-center gap-8">
-					<span class="typo-text-2 text-align-center">This wallet was created without a seed phrase (private key only) or the seed phrase is unavailable.</span>
-				</div>
-			</ng-template>
-			<div class="flex full-width justify-content-between" *ngIf="hasMnemonic()">
-				<kc-button [variant]="'tertiary'" [suffixIcon]="'icon-copy'" [text]="'Copy'" (buttonClick)="copySeedToClipboard()"></kc-button>
-				<kc-button [variant]="'primary'" [suffixIcon]="'icon-download'" [text]="'Download .txt'" (buttonClick)="downloadSeedAsTxt()"></kc-button>
-			</div>
-		</div>
-	}
+  @if (currentStep() === "password" && hasMnemonic()) {
+    <div
+      class="export-wallet__password-step flex column align-items-center gap-24 full-width"
+    >
+      <div class="flex column align-items-center gap-8 text-align-center">
+        <span class="typo-title-3">Confirm Password</span>
+        <span class="typo-text-2 text-medium">
+          Enter your wallet password to reveal the seed phrase.
+        </span>
+      </div>
+      <div class="export-wallet__password-form flex column gap-16 full-width">
+        <label class="typo-text-1 text-gray-60" for="export-wallet-password"
+          >Password</label
+        >
+        <input
+          id="export-wallet-password"
+          type="password"
+          class="export-wallet__password-input p-16 rounded-lg typo-text-1"
+          [class.error]="passwordError()"
+          placeholder="Enter your password"
+          [(ngModel)]="password"
+          (ngModelChange)="onPasswordInput()"
+          (keyup.enter)="onVerifyPassword()"
+        />
+        @if (passwordError()) {
+          <span class="export-wallet__password-error typo-text-2">{{
+            passwordError()
+          }}</span>
+        }
+        <kc-button
+          [variant]="'primary'"
+          [text]="'Continue'"
+          [isDisabled]="isVerifying() || !password().trim()"
+          (buttonClick)="onVerifyPassword()"
+        ></kc-button>
+      </div>
+    </div>
+  } @else {
+    <div
+      class="export-wallet__content flex column align-items-center gap-24 full-width"
+    >
+      <div class="flex column align-items-center gap-4">
+        <span class="typo-title-3 p-4">Seed Phrase</span>
+        @if (hasMnemonic()) {
+          <span class="typo-text-2 text-medium text-align-center"
+            >This seed phrase is the only way to recover your wallet. Do NOT
+            share it with anyone.</span
+          >
+        }
+      </div>
+      @if (hasMnemonic()) {
+        <div class="seed-container">
+          @for (item of seedWords(); track $index) {
+            <app-seed-phrase-word
+              class="seed-container__word"
+              [idx]="$index + 1"
+              [word]="item"
+            ></app-seed-phrase-word>
+          }
+        </div>
+      } @else {
+        <div class="flex column align-items-center gap-8">
+          <span class="typo-text-2 text-align-center"
+            >This wallet was created without a seed phrase (private key only) or
+            the seed phrase is unavailable.</span
+          >
+        </div>
+      }
+      @if (hasMnemonic()) {
+        <div class="flex full-width justify-content-between">
+          <kc-button
+            [variant]="'tertiary'"
+            [suffixIcon]="'icon-copy'"
+            [text]="'Copy'"
+            (buttonClick)="copySeedToClipboard()"
+          ></kc-button>
+          <kc-button
+            [variant]="'primary'"
+            [suffixIcon]="'icon-download'"
+            [text]="'Download .txt'"
+            (buttonClick)="downloadSeedAsTxt()"
+          ></kc-button>
+        </div>
+      }
+    </div>
+  }
 </div>

--- a/src/app/v2/pages/app/flows/export-wallet/export-wallet.component.ts
+++ b/src/app/v2/pages/app/flows/export-wallet/export-wallet.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { KcButtonComponent, NotificationService } from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../common/flow-page/interfaces/flow-page.interface';
@@ -18,7 +18,7 @@ interface ExportWalletTransientState {
 @Component({
   selector: 'app-export-wallet',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, SeedPhraseWordComponent, FormsModule],
+  imports: [KcButtonComponent, SeedPhraseWordComponent, FormsModule],
   templateUrl: './export-wallet.component.html',
   styleUrl: './export-wallet.component.scss',
 })
@@ -47,7 +47,9 @@ export class ExportWalletComponent extends FlowPageBaseComponent {
 
   override async ngOnInit(): Promise<void> {
     super.ngOnInit();
-    this.hasMnemonic.set(this.walletService.getCurrentWallet()?.isHasMnemonic() ?? false);
+    this.hasMnemonic.set(
+      this.walletService.getCurrentWallet()?.isHasMnemonic() ?? false,
+    );
 
     const saved = this.restoreTransientState<ExportWalletTransientState>();
     if (saved) {
@@ -89,9 +91,8 @@ export class ExportWalletComponent extends FlowPageBaseComponent {
     this.isVerifying.set(true);
 
     try {
-      const isValid = await this.passwordManagerService.checkAndLoadPassword(
-        passwordValue,
-      );
+      const isValid =
+        await this.passwordManagerService.checkAndLoadPassword(passwordValue);
 
       if (!isValid) {
         this.passwordError.set('Incorrect password. Please try again.');

--- a/src/app/v2/pages/app/flows/import-token/import-token-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/import-token/import-token-flow-page.component.ts
@@ -1,10 +1,5 @@
-import {
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+
 import { FormsModule } from '@angular/forms';
 import {
   KcButtonComponent,
@@ -25,7 +20,6 @@ type ImportState = 'idle' | 'loading' | 'found' | 'already-imported' | 'error';
   selector: 'app-import-token-flow-page',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     KcButtonComponent,
     KcInputComponent,
@@ -45,8 +39,12 @@ export class ImportTokenFlowPageComponent {
   private notificationService = inject(NotificationService);
 
   contractAddress = signal<string>('');
-  isAddressValid = computed(() => ethers.isAddress(this.contractAddress().trim()));
-  showAddressError = computed(() => this.contractAddress().trim().length > 0 && !this.isAddressValid());
+  isAddressValid = computed(() =>
+    ethers.isAddress(this.contractAddress().trim()),
+  );
+  showAddressError = computed(
+    () => this.contractAddress().trim().length > 0 && !this.isAddressValid(),
+  );
   state = signal<ImportState>('idle');
   errorMessage = signal<string>('');
   tokenInfo = signal<Erc20Token | null>(null);
@@ -56,9 +54,9 @@ export class ImportTokenFlowPageComponent {
   private lookupId = 0;
 
   private get l2Store(): L2AssetsStoreService {
-    return this.assetsManagerService.getAllAssetStores().l2 as L2AssetsStoreService;
+    return this.assetsManagerService.getAllAssetStores()
+      .l2 as L2AssetsStoreService;
   }
-
 
   onAddressChange(value: string): void {
     this.contractAddress.set(value || '');
@@ -76,7 +74,10 @@ export class ImportTokenFlowPageComponent {
       const text = await navigator.clipboard.readText();
       this.onAddressChange(text.trim());
     } catch {
-      this.notificationService.error('Clipboard Error', 'Could not read from clipboard');
+      this.notificationService.error(
+        'Clipboard Error',
+        'Could not read from clipboard',
+      );
     }
   }
 
@@ -109,16 +110,20 @@ export class ImportTokenFlowPageComponent {
 
     try {
       // Check if already imported
-      const savedToken = await this.l2Store.getSavedErc20TokenLocally(normalizedAddress);
+      const savedToken =
+        await this.l2Store.getSavedErc20TokenLocally(normalizedAddress);
 
       // Abort if the user changed the address while we were waiting
       if (this.lookupId !== thisLookupId) return;
 
       try {
         // Always try to fetch fresh token data (balance + current metadata)
-        const freshToken = await this.l2Store.getErc20InfoFromBlockchain(normalizedAddress);
+        const freshToken =
+          await this.l2Store.getErc20InfoFromBlockchain(normalizedAddress);
         if (this.lookupId !== thisLookupId) return;
-        this.tokenInfo.set(savedToken ? { ...savedToken, ...freshToken } : freshToken);
+        this.tokenInfo.set(
+          savedToken ? { ...savedToken, ...freshToken } : freshToken,
+        );
         if (savedToken) {
           this.errorMessage.set('Token has already been added.');
           this.state.set('already-imported');
@@ -133,13 +138,18 @@ export class ImportTokenFlowPageComponent {
           this.errorMessage.set('Token has already been added.');
           this.state.set('already-imported');
         } else {
-          throw new Error('Token not found. Make sure the address is a valid ERC20 contract.');
+          throw new Error(
+            'Token not found. Make sure the address is a valid ERC20 contract.',
+          );
         }
       }
     } catch (err: any) {
       if (this.lookupId !== thisLookupId) return;
       console.error('Failed to load token:', err);
-      this.errorMessage.set(err?.message || 'Token not found. Make sure the address is a valid ERC20 contract.');
+      this.errorMessage.set(
+        err?.message ||
+          'Token not found. Make sure the address is a valid ERC20 contract.',
+      );
       this.state.set('error');
     }
   }
@@ -151,10 +161,16 @@ export class ImportTokenFlowPageComponent {
     this.isSaving.set(true);
     try {
       await this.l2Store.addTokenToLocalStore(token);
-      this.notificationService.success('Token Imported', `${token.symbol} has been added to your wallet`);
+      this.notificationService.success(
+        'Token Imported',
+        `${token.symbol} has been added to your wallet`,
+      );
       this.flowPagesService.closePage();
     } catch (err: any) {
-      this.notificationService.error('Import Failed', err?.message || 'Failed to save token');
+      this.notificationService.error(
+        'Import Failed',
+        err?.message || 'Failed to save token',
+      );
     } finally {
       this.isSaving.set(false);
     }

--- a/src/app/v2/pages/app/flows/receive/receive-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/receive/receive-flow-page.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, OnDestroy, OnInit } from '@angular/core';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { WalletService } from '../../../../../services/wallet.service';
@@ -7,12 +6,7 @@ import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.compo
 
 @Component({
   selector: 'app-receive-flow-page',
-  imports: [
-    CommonModule,
-    QRCodeComponent,
-    CopyButtonComponent,
-    SkeletonComponent,
-  ],
+  imports: [QRCodeComponent, CopyButtonComponent, SkeletonComponent],
   templateUrl: './receive-flow-page.component.html',
   styleUrl: './receive-flow-page.component.scss',
   host: {

--- a/src/app/v2/pages/app/flows/settings/delete-wallet-confirmation.component.ts
+++ b/src/app/v2/pages/app/flows/settings/delete-wallet-confirmation.component.ts
@@ -1,8 +1,12 @@
 import { Component, computed, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { KcButtonComponent, KcIconComponent, KcInputComponent } from 'kaspacom-ui';
+import {
+  KcButtonComponent,
+  KcIconComponent,
+  KcInputComponent,
+} from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../common/flow-page/interfaces/flow-page.interface';
 import { FlowPagesService } from '../../../../services/flow-pages.service';
@@ -17,7 +21,7 @@ import {
 @Component({
   selector: 'app-delete-wallet-confirmation',
   standalone: true,
-  imports: [CommonModule, FormsModule, KcButtonComponent, KcIconComponent, KcInputComponent],
+  imports: [FormsModule, KcButtonComponent, KcIconComponent, KcInputComponent],
   templateUrl: './delete-wallet-confirmation.component.html',
   styleUrl: './delete-wallet-confirmation.component.scss',
 })
@@ -56,13 +60,13 @@ export class DeleteWalletConfirmationComponent extends FlowPageBaseComponent {
     try {
       // Clear all wallet data
       await this.passwordManagerService.clearAllData();
-      
+
       // Deselect current wallet from memory
       await this.walletService.deselectCurrentWallet();
-      
+
       // Close all flow pages
       this.flowPagesService.closePage();
-      
+
       // Force page reload to ensure clean state
       window.location.reload();
     } catch (error) {

--- a/src/app/v2/pages/app/flows/settings/settings-menu.component.ts
+++ b/src/app/v2/pages/app/flows/settings/settings-menu.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { Router } from '@angular/router';
 import { KcButtonComponent, KcIconComponent } from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
@@ -11,7 +11,7 @@ import { WalletService } from '../../../../../services/wallet.service';
 @Component({
   selector: 'app-settings-menu',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, KcIconComponent],
+  imports: [KcButtonComponent, KcIconComponent],
   templateUrl: './settings-menu.component.html',
   styleUrl: './settings-menu.component.scss',
 })
@@ -54,10 +54,10 @@ export class SettingsMenuComponent extends FlowPageBaseComponent {
     try {
       // Use centralized logout method from WalletService
       await this.walletService.logout();
-      
+
       // Close all flow pages
       this.flowPagesService.closePage();
-      
+
       // Navigate to the onboarding screen which now handles login
       this.router.navigate(['/onboarding']);
     } catch (error) {

--- a/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.ts
+++ b/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.ts
@@ -8,7 +8,7 @@ import {
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import {
   ReactiveFormsModule,
   FormBuilder,
@@ -27,7 +27,6 @@ import type { SwapSettings } from '@kaspacom/swap-sdk';
   selector: 'app-swap-settings-modal',
   standalone: true,
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcBaseModalComponent,
     KcInputComponent,

--- a/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.ts
+++ b/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.ts
@@ -11,8 +11,13 @@ import {
   untracked,
   DestroyRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { KcBaseModalComponent, KcInputComponent, KcIconComponent, KcTooltipDirective } from 'kaspacom-ui';
+
+import {
+  KcBaseModalComponent,
+  KcInputComponent,
+  KcIconComponent,
+  KcTooltipDirective,
+} from 'kaspacom-ui';
 import { MessagePopupService } from '../../../../../../../services/message-popup.service';
 import type { Erc20Token } from '@kaspacom/swap-sdk';
 import { CommaFormatterPipe } from '../../../../../../../pipes/comma-formatter.pipe';
@@ -51,7 +56,6 @@ function isLocalStorageAvailable(): boolean {
   selector: 'app-token-selector-modal',
   standalone: true,
   imports: [
-    CommonModule,
     KcBaseModalComponent,
     KcInputComponent,
     KcIconComponent,
@@ -78,7 +82,9 @@ export class TokenSelectorModalComponent implements OnInit {
 
   isVerifiedToken(token: Erc20Token): boolean {
     const addr = token.address.toLowerCase();
-    return this.verifiedTokensList().some((v) => v.address.toLowerCase() === addr);
+    return this.verifiedTokensList().some(
+      (v) => v.address.toLowerCase() === addr,
+    );
   }
 
   isPotentialHarm(token: Erc20Token): boolean {
@@ -87,7 +93,8 @@ export class TokenSelectorModalComponent implements OnInit {
     const symbol = token.symbol.toLowerCase();
     const addr = token.address.toLowerCase();
     return verified.some(
-      (v) => v.symbol.toLowerCase() === symbol && v.address.toLowerCase() !== addr,
+      (v) =>
+        v.symbol.toLowerCase() === symbol && v.address.toLowerCase() !== addr,
     );
   }
 

--- a/src/app/v2/pages/app/flows/swap/swap-flow-page.component.html
+++ b/src/app/v2/pages/app/flows/swap/swap-flow-page.component.html
@@ -1,115 +1,184 @@
 <div class="swap-flow-container flex column full-height p-16 gap-16">
-    <!-- Swap Card -->
-    <div class="swap-card flex column">
-        <!-- Header -->
-        <div class="swap-header flex justify-content-between align-items-center">
-            <span class="swap-title">Swap</span>
-            <button class="settings-btn" (click)="settingsOpen.set(true)" title="Settings">
-                <kc-icon [iconClass]="'icon-settings'" [size]="'sm'"></kc-icon>
-            </button>
-        </div>
-
-        <!-- Percentage Options -->
-        <div class="percentage-options-wrapper flex justify-content-end">
-          <div class="percentage-options">
-              <button class="percentage-btn" [class.active]="selectedPercentage() === 25" (click)="onPercentageClick(25)">25%</button>
-              <button class="percentage-btn" [class.active]="selectedPercentage() === 50" (click)="onPercentageClick(50)">50%</button>
-              <button class="percentage-btn" [class.active]="selectedPercentage() === 75" (click)="onPercentageClick(75)">75%</button>
-              <button class="percentage-btn" [class.active]="selectedPercentage() === 100" (click)="onPercentageClick(100)">MAX</button>
-          </div>
-        </div>
-
-        <!-- Token Inputs Wrapper -->
-        <div class="token-inputs-wrapper">
-            <!-- SELL (From) -->
-            <div class="token-input-box sell-box" [class.error]="fromInputError()">
-                <div class="token-input-header">
-                    <span class="token-input-label">Sell</span>
-                    <span class="token-balance" *ngIf="fromToken()" [class.error-text]="isInsufficientBalance()">
-                        Balance: {{ fromToken()?.balance | commaFormatter }}
-                    </span>
-                </div>
-                <div class="token-input-row">
-                    <input type="text"
-                           inputmode="decimal"
-                           class="token-amount-input"
-                           [class.error]="fromInputError()"
-                           placeholder="0"
-                           [ngModel]="fromAmountInput()"
-                           (ngModelChange)="onFromAmountChange($event)" />
-                    <button class="token-select-btn" (click)="openTokenModal('from')">
-                        @if (fromToken()) {
-                            <kc-token-logo [ticker]="fromToken()!.symbol" [address]="fromToken()!.address" size="md"></kc-token-logo>
-                            <span class="token-symbol">{{ fromToken()?.symbol }}</span>
-                        } @else {
-                            <span class="select-token-text">Select</span>
-                        }
-                        <kc-icon iconClass="icon-chevron-down" size="xs"></kc-icon>
-                    </button>
-                </div>
-            </div>
-
-            <!-- Switch Button -->
-            <div class="switch-btn-container">
-                <button class="switch-btn" (click)="switchTokens()" title="Switch tokens">
-                    <div class="switch-arrows">
-                        <kc-icon iconClass="icon-switch-vertical-01" size="sm"></kc-icon>
-                    </div>
-                </button>
-            </div>
-
-            <!-- BUY (To) -->
-            <div class="token-input-box buy-box">
-                <div class="token-input-header">
-                    <span class="token-input-label">Buy</span>
-                    <span class="token-balance" *ngIf="toToken()">
-                        Balance: {{ toToken()?.balance | commaFormatter }}
-                    </span>
-                </div>
-                <div class="token-input-row">
-                    <input type="text"
-                           inputmode="decimal"
-                           class="token-amount-input"
-                           placeholder="0"
-                           [ngModel]="toAmountInput()"
-                           (ngModelChange)="onToAmountChange($event)" />
-                    <button class="token-select-btn" (click)="openTokenModal('to')">
-                        @if (toToken()) {
-                            <kc-token-logo [ticker]="toToken()!.symbol" [address]="toToken()!.address" size="md"></kc-token-logo>
-                            <span class="token-symbol">{{ toToken()?.symbol }}</span>
-                        } @else {
-                            <span class="select-token-text">Select</span>
-                        }
-                        <kc-icon iconClass="icon-chevron-down" size="xs"></kc-icon>
-                    </button>
-                </div>
-                <!-- Min Received -->
-                <div class="min-received" *ngIf="!currentIsOutput() && minReceived()">
-                    Min received: {{ minReceived() }} {{ toToken()?.symbol }}
-                </div>
-            </div>
-        </div>
-
-        <!-- Trade Info -->
-        <div class="trade-info" *ngIf="controllerState()?.tradeInfo?.route">
-            <div class="trade-info-row">
-                <span class="trade-info-label">Route</span>
-                <span class="trade-info-value">{{ routePath() }}</span>
-            </div>
-        </div>
-
-        <!-- Swap Button -->
-        <kc-button [text]="swapText()" [variant]="'primary'" [isFullWidth]="true" [isDisabled]="isSwapDisabled()"
-            (buttonClick)="executeSwap()">
-        </kc-button>
+  <!-- Swap Card -->
+  <div class="swap-card flex column">
+    <!-- Header -->
+    <div class="swap-header flex justify-content-between align-items-center">
+      <span class="swap-title">Swap</span>
+      <button
+        class="settings-btn"
+        (click)="settingsOpen.set(true)"
+        title="Settings"
+      >
+        <kc-icon [iconClass]="'icon-settings'" [size]="'sm'"></kc-icon>
+      </button>
     </div>
 
-    <app-token-selector-modal [open]="!!tokenModalOpen()" [tokens]="allTokens()" [isLoading]="loadingTokens()"
-        [excludedToken]="tokenModalOpen() === 'from' ? toToken() : fromToken()" (close)="tokenModalOpen.set(null)"
-        (selectToken)="onTokenSelect($event)">
-    </app-token-selector-modal>
+    <!-- Percentage Options -->
+    <div class="percentage-options-wrapper flex justify-content-end">
+      <div class="percentage-options">
+        <button
+          class="percentage-btn"
+          [class.active]="selectedPercentage() === 25"
+          (click)="onPercentageClick(25)"
+        >
+          25%
+        </button>
+        <button
+          class="percentage-btn"
+          [class.active]="selectedPercentage() === 50"
+          (click)="onPercentageClick(50)"
+        >
+          50%
+        </button>
+        <button
+          class="percentage-btn"
+          [class.active]="selectedPercentage() === 75"
+          (click)="onPercentageClick(75)"
+        >
+          75%
+        </button>
+        <button
+          class="percentage-btn"
+          [class.active]="selectedPercentage() === 100"
+          (click)="onPercentageClick(100)"
+        >
+          MAX
+        </button>
+      </div>
+    </div>
 
-    <app-swap-settings-modal [open]="settingsOpen()" [initialSettings]="currentSettings()"
-        (close)="settingsOpen.set(false)" (save)="onSettingsSave($event)">
-    </app-swap-settings-modal>
+    <!-- Token Inputs Wrapper -->
+    <div class="token-inputs-wrapper">
+      <!-- SELL (From) -->
+      <div class="token-input-box sell-box" [class.error]="fromInputError()">
+        <div class="token-input-header">
+          <span class="token-input-label">Sell</span>
+          @if (fromToken()) {
+            <span
+              class="token-balance"
+              [class.error-text]="isInsufficientBalance()"
+            >
+              Balance: {{ fromToken()?.balance | commaFormatter }}
+            </span>
+          }
+        </div>
+        <div class="token-input-row">
+          <input
+            type="text"
+            inputmode="decimal"
+            class="token-amount-input"
+            [class.error]="fromInputError()"
+            placeholder="0"
+            [ngModel]="fromAmountInput()"
+            (ngModelChange)="onFromAmountChange($event)"
+          />
+          <button class="token-select-btn" (click)="openTokenModal('from')">
+            @if (fromToken()) {
+              <kc-token-logo
+                [ticker]="fromToken()!.symbol"
+                [address]="fromToken()!.address"
+                size="md"
+              ></kc-token-logo>
+              <span class="token-symbol">{{ fromToken()?.symbol }}</span>
+            } @else {
+              <span class="select-token-text">Select</span>
+            }
+            <kc-icon iconClass="icon-chevron-down" size="xs"></kc-icon>
+          </button>
+        </div>
+      </div>
+
+      <!-- Switch Button -->
+      <div class="switch-btn-container">
+        <button
+          class="switch-btn"
+          (click)="switchTokens()"
+          title="Switch tokens"
+        >
+          <div class="switch-arrows">
+            <kc-icon iconClass="icon-switch-vertical-01" size="sm"></kc-icon>
+          </div>
+        </button>
+      </div>
+
+      <!-- BUY (To) -->
+      <div class="token-input-box buy-box">
+        <div class="token-input-header">
+          <span class="token-input-label">Buy</span>
+          @if (toToken()) {
+            <span class="token-balance">
+              Balance: {{ toToken()?.balance | commaFormatter }}
+            </span>
+          }
+        </div>
+        <div class="token-input-row">
+          <input
+            type="text"
+            inputmode="decimal"
+            class="token-amount-input"
+            placeholder="0"
+            [ngModel]="toAmountInput()"
+            (ngModelChange)="onToAmountChange($event)"
+          />
+          <button class="token-select-btn" (click)="openTokenModal('to')">
+            @if (toToken()) {
+              <kc-token-logo
+                [ticker]="toToken()!.symbol"
+                [address]="toToken()!.address"
+                size="md"
+              ></kc-token-logo>
+              <span class="token-symbol">{{ toToken()?.symbol }}</span>
+            } @else {
+              <span class="select-token-text">Select</span>
+            }
+            <kc-icon iconClass="icon-chevron-down" size="xs"></kc-icon>
+          </button>
+        </div>
+        <!-- Min Received -->
+        @if (!currentIsOutput() && minReceived()) {
+          <div class="min-received">
+            Min received: {{ minReceived() }} {{ toToken()?.symbol }}
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Trade Info -->
+    @if (controllerState()?.tradeInfo?.route) {
+      <div class="trade-info">
+        <div class="trade-info-row">
+          <span class="trade-info-label">Route</span>
+          <span class="trade-info-value">{{ routePath() }}</span>
+        </div>
+      </div>
+    }
+
+    <!-- Swap Button -->
+    <kc-button
+      [text]="swapText()"
+      [variant]="'primary'"
+      [isFullWidth]="true"
+      [isDisabled]="isSwapDisabled()"
+      (buttonClick)="executeSwap()"
+    >
+    </kc-button>
+  </div>
+
+  <app-token-selector-modal
+    [open]="!!tokenModalOpen()"
+    [tokens]="allTokens()"
+    [isLoading]="loadingTokens()"
+    [excludedToken]="tokenModalOpen() === 'from' ? toToken() : fromToken()"
+    (close)="tokenModalOpen.set(null)"
+    (selectToken)="onTokenSelect($event)"
+  >
+  </app-token-selector-modal>
+
+  <app-swap-settings-modal
+    [open]="settingsOpen()"
+    [initialSettings]="currentSettings()"
+    (close)="settingsOpen.set(false)"
+    (save)="onSettingsSave($event)"
+  >
+  </app-swap-settings-modal>
 </div>

--- a/src/app/v2/pages/app/flows/swap/swap-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/swap/swap-flow-page.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   computed,
@@ -55,7 +54,6 @@ import {
   selector: 'app-swap-flow-page',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     KcButtonComponent,
     KcIconComponent,

--- a/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-kns-list/send-kns-list.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-kns-list/send-kns-list.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
 import { KcTooltipDirective } from 'kaspacom-ui';
 import { AssetsManagerService } from '../../../../../../../../../../services/assets-manager/assets-manager.service';
@@ -14,7 +13,7 @@ import { IFlowPageConfig } from '../../../../../../../common/flow-page/interface
 @Component({
   selector: 'app-send-kns-list',
   standalone: true,
-  imports: [CommonModule, KcTooltipDirective, SkeletonComponent],
+  imports: [KcTooltipDirective, SkeletonComponent],
   templateUrl: './send-kns-list.component.html',
   styleUrl: './send-kns-list.component.scss',
 })

--- a/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-kns/send-kns.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-kns/send-kns.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   effect,
@@ -35,7 +34,6 @@ import { IFlowPageConfig } from '../../../../../../../common/flow-page/interface
   selector: 'app-send-kns',
   standalone: true,
   imports: [
-    CommonModule,
     KcCheckboxComponent,
     KcButtonComponent,
     FormsModule,

--- a/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-nft/send-nft.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/components/send-asset/l1/send-nft/send-nft.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   effect,
@@ -34,7 +33,6 @@ import { INft } from '../../../../../../../common/interfaces/nft.interface';
   selector: 'app-send-nft',
   standalone: true,
   imports: [
-    CommonModule,
     KcCheckboxComponent,
     KcButtonComponent,
     FormsModule,

--- a/src/app/v2/pages/app/flows/transaction/send-page/l1-send-assets-container.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/l1-send-assets-container.component.ts
@@ -1,12 +1,12 @@
 import { Component, output } from '@angular/core';
 import { BaseSendAssetsContainerComponent } from './base-send-assets-container';
-import { CommonModule } from '@angular/common';
+
 import { Krc20TokenLogoComponent } from '../../../home/assets-lists/l1/logo/krc20-token-logo/krc20-token-logo.component';
 
 @Component({
   selector: 'app-l1-send-assets-container',
   standalone: true,
-  imports: [CommonModule, Krc20TokenLogoComponent],
+  imports: [Krc20TokenLogoComponent],
   templateUrl: './l1-send-assets-container.component.html',
   styleUrl: './l1-send-assets-container.component.scss',
 })

--- a/src/app/v2/pages/app/flows/transaction/send-page/l2-send-assets-container.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/l2-send-assets-container.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, output } from '@angular/core';
 import { TokenLogoComponent } from '../../../../../../components/token-logo/token-logo.component';
 import { BaseSendAssetsContainerComponent } from './base-send-assets-container';
@@ -6,7 +5,7 @@ import { BaseSendAssetsContainerComponent } from './base-send-assets-container';
 @Component({
   selector: 'app-l2-send-assets-container',
   standalone: true,
-  imports: [CommonModule, TokenLogoComponent],
+  imports: [TokenLogoComponent],
   templateUrl: './l2-send-assets-container.component.html',
   styleUrl: './l2-send-assets-container.component.scss',
 })

--- a/src/app/v2/pages/app/flows/transaction/send-page/send-page.component.html
+++ b/src/app/v2/pages/app/flows/transaction/send-page/send-page.component.html
@@ -1,17 +1,19 @@
 <div class="send-page-content">
   <!-- L1 Assets Container -->
-  <app-l1-send-assets-container
-    *ngIf="!isL2Network()"
-    (kaspaClick)="onKaspaCardClick()"
-    (krc20Click)="onKrc20CardClick()"
-    (nftClick)="onNftCardClick()"
-    (knsClick)="onKnsCardClick()"
-  ></app-l1-send-assets-container>
+  @if (!isL2Network()) {
+    <app-l1-send-assets-container
+      (kaspaClick)="onKaspaCardClick()"
+      (krc20Click)="onKrc20CardClick()"
+      (nftClick)="onNftCardClick()"
+      (knsClick)="onKnsCardClick()"
+    ></app-l1-send-assets-container>
+  }
 
   <!-- L2 Assets Container -->
-  <app-l2-send-assets-container
-    *ngIf="isL2Network()"
-    (kaspaClick)="onL2KaspaCardClick()"
-    (erc20Click)="onL2Erc20CardClick()"
-  ></app-l2-send-assets-container>
+  @if (isL2Network()) {
+    <app-l2-send-assets-container
+      (kaspaClick)="onL2KaspaCardClick()"
+      (erc20Click)="onL2Erc20CardClick()"
+    ></app-l2-send-assets-container>
+  }
 </div>

--- a/src/app/v2/pages/app/flows/transaction/send-page/send-page.component.ts
+++ b/src/app/v2/pages/app/flows/transaction/send-page/send-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FlowPageBaseComponent } from '../../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../../common/flow-page/interfaces/flow-page.interface';
 import { L1SendAssetsContainerComponent } from './l1-send-assets-container.component';
@@ -9,11 +9,7 @@ import { WalletService } from '../../../../../../services/wallet.service';
 @Component({
   selector: 'app-send-page',
   standalone: true,
-  imports: [
-    CommonModule,
-    L1SendAssetsContainerComponent,
-    L2SendAssetsContainerComponent,
-  ],
+  imports: [L1SendAssetsContainerComponent, L2SendAssetsContainerComponent],
   templateUrl: './send-page.component.html',
   styleUrl: './send-page.component.scss',
 })

--- a/src/app/v2/pages/app/flows/wallet-selection/wallet-selection-page.component.ts
+++ b/src/app/v2/pages/app/flows/wallet-selection/wallet-selection-page.component.ts
@@ -1,6 +1,11 @@
 import { Component, inject, signal, computed, Signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { KcButtonComponent, KcIconComponent, KcTooltipDirective, KcSpinnerComponent } from 'kaspacom-ui';
+
+import {
+  KcButtonComponent,
+  KcIconComponent,
+  KcTooltipDirective,
+  KcSpinnerComponent,
+} from 'kaspacom-ui';
 import { FlowPageBaseComponent } from '../../common/flow-page/base/flow-page-base.component';
 import { IFlowPageConfig } from '../../common/flow-page/interfaces/flow-page.interface';
 import { WalletService } from '../../../../../services/wallet.service';
@@ -22,7 +27,13 @@ interface WalletGroupItem {
 @Component({
   selector: 'app-wallet-selection-page',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, KcIconComponent, KcTooltipDirective, KcSpinnerComponent, ShortenAddressPipe],
+  imports: [
+    KcButtonComponent,
+    KcIconComponent,
+    KcTooltipDirective,
+    KcSpinnerComponent,
+    ShortenAddressPipe,
+  ],
   templateUrl: './wallet-selection-page.component.html',
   styleUrl: './wallet-selection-page.component.scss',
 })
@@ -65,7 +76,7 @@ export class WalletSelectionPageComponent extends FlowPageBaseComponent {
       const name = group[0].getName();
       const address = this.getWalletAddress(group[0]);
       const isSelected = currentWallet ? currentWallet.getId() === id : false;
-      
+
       // Check if any wallet in the group has pending transactions
       const hasPendingTransactions = computed(() => {
         return group.some((wallet) => {
@@ -163,12 +174,14 @@ export class WalletSelectionPageComponent extends FlowPageBaseComponent {
     event.stopPropagation();
     const currentWallets = this.wallets();
     const updatedWallets = currentWallets.map((w) =>
-      w.id === item.id ? { ...w, isExpanded: !w.isExpanded } : w
+      w.id === item.id ? { ...w, isExpanded: !w.isExpanded } : w,
     );
     this.wallets.set(updatedWallets);
   }
 
   private getWalletAddress(wallet: AppWallet): string {
-    return this.walletService.isL2Display() ? wallet.getL2WalletAddress() : wallet.getAddress();
+    return this.walletService.isL2Display()
+      ? wallet.getL2WalletAddress()
+      : wallet.getAddress();
   }
 }

--- a/src/app/v2/pages/app/home/assets-container/l2-assets-container.component.ts
+++ b/src/app/v2/pages/app/home/assets-container/l2-assets-container.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import {
   KcLabeledTabsComponent,
   TabItem,
@@ -18,7 +18,12 @@ import { FlowPagesService } from '../../../../services/flow-pages.service';
 @Component({
   selector: 'app-l2-assets-container',
   standalone: true,
-  imports: [CommonModule, KcLabeledTabsComponent, Erc20SummaryComponent, L2TxHistoryComponent, KcButtonComponent],
+  imports: [
+    KcLabeledTabsComponent,
+    Erc20SummaryComponent,
+    L2TxHistoryComponent,
+    KcButtonComponent,
+  ],
   templateUrl: './l2-assets-container.component.html',
   styleUrl: './l2-assets-container.component.scss',
 })
@@ -31,12 +36,18 @@ export class L2AssetsContainerComponent extends BaseAssetsContainerComponent {
     { id: ASSET_TAB_IDS.L2_TX_HISTORY, label: 'History' },
   ];
 
-  hasErc20Tokens = computed(() =>
-    (this.assetsManagerService.getAllAssetStores().l2.getAssets(L2_ASSET_KEYS.erc20) ?? []).length > 0
+  hasErc20Tokens = computed(
+    () =>
+      (
+        this.assetsManagerService
+          .getAllAssetStores()
+          .l2.getAssets(L2_ASSET_KEYS.erc20) ?? []
+      ).length > 0,
   );
 
-  showImportTokenFab = computed(() =>
-    this.selectedTabId() === ASSET_TAB_IDS.L2_ERC20 && this.hasErc20Tokens()
+  showImportTokenFab = computed(
+    () =>
+      this.selectedTabId() === ASSET_TAB_IDS.L2_ERC20 && this.hasErc20Tokens(),
   );
 
   onImportToken(): void {

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset-card/krc20-asset-card/krc20-asset-card.component.html
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset-card/krc20-asset-card/krc20-asset-card.component.html
@@ -1,29 +1,50 @@
-<div class="asset-card card-0 card-hover full-width flex align-items-center justify-content-between p-16 cursor-pointer"
-  (click)="onClick()">
+<div
+  class="asset-card card-0 card-hover full-width flex align-items-center justify-content-between p-16 cursor-pointer"
+  (click)="onClick()"
+>
   <div class="asset-card__info flex align-items-center gap-16">
-    <krc20-token-logo class="asset-card__logo" [ticker]="krc20()?.symbol || ''" [size]="'lg'"></krc20-token-logo>
+    <krc20-token-logo
+      class="asset-card__logo"
+      [ticker]="krc20()?.symbol || ''"
+      [size]="'lg'"
+    ></krc20-token-logo>
     <div class="flex column gap-4">
-      <div class="text-gray-90">{{ krc20()?.name || '' | titlecase }}</div>
+      <div class="text-gray-90">{{ krc20()?.name || "" | titlecase }}</div>
       <div class="text-gray-60 typo-text-1 asset-card__meta">
-        {{ krc20()?.balance || 0 | number : '1.0-4' }}
-        &nbsp;{{ krc20()?.symbol || '' | uppercase }}
+        {{ krc20()?.balance || 0 | number: "1.0-4" }}
+        &nbsp;{{ krc20()?.symbol || "" | uppercase }}
       </div>
       <ng-container>
-        <div *ngIf="krc20()?.maxSupply && !krc20()?.isLoadingMetadata" class="text-gray-50 typo-text-1">
-          Supply: {{ krc20()?.maxSupply }}
-        </div>
-        <app-skeleton *ngIf="krc20()?.isLoadingMetadata" [height]="'14px'" [width]="'100px'"
-          [fullRound]="false"></app-skeleton>
+        @if (krc20()?.maxSupply && !krc20()?.isLoadingMetadata) {
+          <div class="text-gray-50 typo-text-1">
+            Supply: {{ krc20()?.maxSupply }}
+          </div>
+        }
+        @if (krc20()?.isLoadingMetadata) {
+          <app-skeleton
+            [height]="'14px'"
+            [width]="'100px'"
+            [fullRound]="false"
+          ></app-skeleton>
+        }
       </ng-container>
     </div>
   </div>
   <div class="asset-card__usd-info flex column align-items-end">
     <div class="text-gray-90">
-      {{ (krc20()?.balance || 0) * (krc20()?.priceKas || 0 )| number : "1.2-2" }} KAS
+      {{
+        (krc20()?.balance || 0) * (krc20()?.priceKas || 0) | number: "1.2-2"
+      }}
+      KAS
     </div>
-    <div class="text-gray-60 typo-text-1 asset-card__usd-meta">${{ getPriceUsd((krc20()?.balance || 0) * (krc20()?.priceKas || 0)) | number : "1.2-2" }}</div>
-    <div *ngIf="krc20()?.holders && !krc20()?.isLoadingMetadata" class="text-gray-50 typo-text-1">
-      {{ krc20()?.holders }} holders
+    <div class="text-gray-60 typo-text-1 asset-card__usd-meta">
+      ${{
+        getPriceUsd((krc20()?.balance || 0) * (krc20()?.priceKas || 0))
+          | number: "1.2-2"
+      }}
     </div>
+    @if (krc20()?.holders && !krc20()?.isLoadingMetadata) {
+      <div class="text-gray-50 typo-text-1">{{ krc20()?.holders }} holders</div>
+    }
   </div>
 </div>

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/kns-asset/kns-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/kns-asset/kns-asset.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import {
@@ -23,7 +23,6 @@ import { KaspaL1NetworkService } from '../../../../../../../../services/kaspa-ne
 @Component({
   selector: 'app-kns-asset',
   imports: [
-    CommonModule,
     KcButtonComponent,
     KcIconComponent,
     KcTooltipDirective,

--- a/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l1/asset/krc721-asset/krc721-asset.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { KcButtonComponent, KcIconComponent } from 'kaspacom-ui';
@@ -27,7 +27,6 @@ interface NftMetadata {
   selector: 'app-krc721-asset',
   standalone: true,
   imports: [
-    CommonModule,
     KcButtonComponent,
     KcIconComponent,
     SkeletonComponent,

--- a/src/app/v2/pages/app/home/assets-lists/l2/asset/erc20-asset/erc20-asset.component.ts
+++ b/src/app/v2/pages/app/home/assets-lists/l2/asset/erc20-asset/erc20-asset.component.ts
@@ -1,8 +1,11 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { formatUnits, getAddress } from 'ethers';
-import { KcButtonComponent, KcIconComponent, NotificationService } from 'kaspacom-ui';
+import {
+  KcButtonComponent,
+  KcIconComponent,
+  NotificationService,
+} from 'kaspacom-ui';
 import { AssetsManagerService } from '../../../../../../../../services/assets-manager/assets-manager.service';
 import { L2AssetsStoreService } from '../../../../../../../../services/assets-manager/assets-stores/l2-assets-store.service';
 import { ERC20Contract } from '../../../../../../../../services/etherium-services/smart-contracts/contracts/erc20-contract';
@@ -26,7 +29,6 @@ interface Erc20TokenInfo {
 @Component({
   selector: 'app-erc20-asset',
   imports: [
-    CommonModule,
     KcButtonComponent,
     KcIconComponent,
     SkeletonComponent,
@@ -56,7 +58,8 @@ export class Erc20AssetComponent
   protected tokenInfo = signal<Erc20TokenInfo | null>(null);
 
   private get l2Store(): L2AssetsStoreService {
-    return this.assetsManagerService.getAllAssetStores().l2 as L2AssetsStoreService;
+    return this.assetsManagerService.getAllAssetStores()
+      .l2 as L2AssetsStoreService;
   }
 
   override ngOnInit(): void {
@@ -171,11 +174,17 @@ export class Erc20AssetComponent
         ...info,
         address: getAddress(info.address),
       });
-      this.notificationService.success('Token Removed', `${info.symbol} has been removed from your wallet`);
+      this.notificationService.success(
+        'Token Removed',
+        `${info.symbol} has been removed from your wallet`,
+      );
       this.isTokenSaved.set(false);
       this.goBack();
     } catch (err: any) {
-      this.notificationService.error('Remove Failed', err?.message || 'Failed to remove token');
+      this.notificationService.error(
+        'Remove Failed',
+        err?.message || 'Failed to remove token',
+      );
     } finally {
       this.isRemoving.set(false);
     }

--- a/src/app/v2/pages/app/home/erc20-transaction-details/erc20-transaction-details.component.ts
+++ b/src/app/v2/pages/app/home/erc20-transaction-details/erc20-transaction-details.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { KcIconComponent, KcButtonComponent } from 'kaspacom-ui';
 import { Erc20ActivityItem } from '../../activity/activity.component';
@@ -7,7 +7,7 @@ import { Erc20ActivityItem } from '../../activity/activity.component';
 @Component({
   selector: 'app-erc20-transaction-details',
   standalone: true,
-  imports: [CommonModule, KcIconComponent, KcButtonComponent],
+  imports: [KcIconComponent, KcButtonComponent],
   template: `
     <div
       class="transaction-details-container flex column full-width full-height p-24"

--- a/src/app/v2/pages/app/home/home.component.html
+++ b/src/app/v2/pages/app/home/home.component.html
@@ -4,7 +4,11 @@
   <app-balance [kasBalanceInput]="kasBalance()"></app-balance>
   <app-pending-transactions-banner></app-pending-transactions-banner>
   <app-crypto-actions></app-crypto-actions>
-  
-  <app-l1-assets-container *ngIf="!isL2Display()" class="full-width"></app-l1-assets-container>
-  <app-l2-assets-container *ngIf="isL2Display()" class="full-width"></app-l2-assets-container>
+
+  @if (!isL2Display()) {
+    <app-l1-assets-container class="full-width"></app-l1-assets-container>
+  }
+  @if (isL2Display()) {
+    <app-l2-assets-container class="full-width"></app-l2-assets-container>
+  }
 </div>

--- a/src/app/v2/pages/app/home/home.component.ts
+++ b/src/app/v2/pages/app/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, signal, OnInit, inject, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { BalanceComponent } from './balance/balance.component';
 import { CryptoActionsComponent } from './crypto-actions/crypto-actions.component';
@@ -12,7 +12,6 @@ import { KaspaNetworkActionsService } from '../../../../services/kaspa-netwrok-s
 @Component({
   selector: 'app-home',
   imports: [
-    CommonModule,
     BalanceComponent,
     CryptoActionsComponent,
     L1AssetsContainerComponent,
@@ -27,13 +26,18 @@ export class HomeComponent implements OnInit {
 
   kasBalance = computed<number | null>(() => {
     if (this.walletService.isL2Display()) {
-      return this.walletService.getCurrentWallet()?.getL2WalletStateSignal()()?.balanceFormatted || 0;
+      return (
+        this.walletService.getCurrentWallet()?.getL2WalletStateSignal()()
+          ?.balanceFormatted || 0
+      );
     } else {
-      return this.walletService.getCurrentWallet()?.getTotalBalanceAsSignal() || 0;
+      return (
+        this.walletService.getCurrentWallet()?.getTotalBalanceAsSignal() || 0
+      );
     }
   });
 
   isL2Display = computed(() => this.walletService.getIsL2DisplaySignal()());
 
-  ngOnInit() { }
+  ngOnInit() {}
 }

--- a/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.html
+++ b/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.html
@@ -1,17 +1,23 @@
-<div class="transaction-details-container full-width full-height column p-16 flex column gap-24" [class.loading]="loading()">
+<div
+  class="transaction-details-container full-width full-height column p-16 flex column gap-24"
+  [class.loading]="loading()"
+>
   <!-- Header with back button -->
-  <div class="transaction-header flex align-items-center justify-content-between">
+  <div
+    class="transaction-header flex align-items-center justify-content-between"
+  >
     <!-- Left side: back button and title -->
     <div class="header-left flex align-items-center gap-16">
-      <kc-icon 
+      <kc-icon
         [iconClass]="'icon-arrow-left'"
         [size]="'md'"
         (click)="goBack()"
-        class="cursor-pointer hover-opacity">
+        class="cursor-pointer hover-opacity"
+      >
       </kc-icon>
       <h1 class="transaction-title text-gray-90">Transaction Details</h1>
     </div>
-    
+
     <!-- Right side: chevron or additional actions if needed -->
     <div class="header-right">
       <!-- Could add additional actions here if needed -->
@@ -21,11 +27,19 @@
   @if (loading()) {
     <!-- Loading state -->
     <div class="details-section flex column gap-16">
-      <app-skeleton [height]="'24px'" [width]="'180px'" class="mb-16"></app-skeleton>
+      <app-skeleton
+        [height]="'24px'"
+        [width]="'180px'"
+        class="mb-16"
+      ></app-skeleton>
       <div class="details-grid">
-        @for (item of [1,2,3,4,5,6,7,8]; track item) {
+        @for (item of [1, 2, 3, 4, 5, 6, 7, 8]; track item) {
           <div class="detail-card">
-            <app-skeleton [height]="'16px'" [width]="'80px'" class="mb-8"></app-skeleton>
+            <app-skeleton
+              [height]="'16px'"
+              [width]="'80px'"
+              class="mb-8"
+            ></app-skeleton>
             <app-skeleton [height]="'20px'" [width]="'100%'"></app-skeleton>
           </div>
         }
@@ -35,20 +49,26 @@
     <!-- Transaction Details Section -->
     <div class="details-section flex column gap-16">
       <h3 class="section-title text-gray-90">Transaction Details</h3>
-      
+
       <div class="details-grid">
         <!-- Net Amount -->
         <div class="detail-card">
           <div class="detail-label">Net Amount</div>
           <div class="detail-value-container flex align-items-center">
             <div class="kaspa-amount-display flex align-items-center gap-8">
-              <kc-icon 
-                [iconClass]="'icon-kaspa-coin'" 
-                [size]="'sm'">
-              </kc-icon>
-              <div class="detail-value kaspa-amount font-weight-bold" 
-                   [style.color]="getNetAmountForWallet().isIncoming ? 'var(--success)' : 'var(--error)'">
-                {{ (getNetAmountForWallet().isIncoming ? '+' : '-') + formatAmount(getNetAmountForWallet().amount) }}
+              <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'"> </kc-icon>
+              <div
+                class="detail-value kaspa-amount font-weight-bold"
+                [style.color]="
+                  getNetAmountForWallet().isIncoming
+                    ? 'var(--success)'
+                    : 'var(--error)'
+                "
+              >
+                {{
+                  (getNetAmountForWallet().isIncoming ? "+" : "-") +
+                    formatAmount(getNetAmountForWallet().amount)
+                }}
               </div>
             </div>
           </div>
@@ -59,11 +79,10 @@
           <div class="detail-label">Transaction Fee</div>
           <div class="detail-value-container flex align-items-center">
             <div class="kaspa-amount-display flex align-items-center gap-8">
-              <kc-icon 
-                [iconClass]="'icon-kaspa-coin'" 
-                [size]="'sm'">
-              </kc-icon>
-              <div class="detail-value kaspa-amount font-weight-bold text-white">
+              <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'"> </kc-icon>
+              <div
+                class="detail-value kaspa-amount font-weight-bold text-white"
+              >
                 {{ formatAmount(getTransactionFee()) }}
               </div>
             </div>
@@ -75,11 +94,10 @@
           <div class="detail-label">Total Input</div>
           <div class="detail-value-container flex align-items-center">
             <div class="kaspa-amount-display flex align-items-center gap-8">
-              <kc-icon 
-                [iconClass]="'icon-kaspa-coin'" 
-                [size]="'sm'">
-              </kc-icon>
-              <div class="detail-value kaspa-amount font-weight-bold text-white">
+              <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'"> </kc-icon>
+              <div
+                class="detail-value kaspa-amount font-weight-bold text-white"
+              >
                 {{ formatAmount(getTotalInputAmount()) }}
               </div>
             </div>
@@ -91,11 +109,10 @@
           <div class="detail-label">Total Output</div>
           <div class="detail-value-container flex align-items-center">
             <div class="kaspa-amount-display flex align-items-center gap-8">
-              <kc-icon 
-                [iconClass]="'icon-kaspa-coin'" 
-                [size]="'sm'">
-              </kc-icon>
-              <div class="detail-value kaspa-amount font-weight-bold text-white">
+              <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'"> </kc-icon>
+              <div
+                class="detail-value kaspa-amount font-weight-bold text-white"
+              >
                 {{ formatAmount(getTotalOutputAmount()) }}
               </div>
             </div>
@@ -103,12 +120,14 @@
         </div>
 
         <!-- Status -->
-        <div class="detail-card" *ngIf="transactionDetails()?.is_accepted">
-          <div class="detail-label">Status</div>
-          <div class="detail-value font-weight-medium status-accepted">
-            {{ getTransactionStatus(transactionDetails()!) }}
+        @if (transactionDetails()?.is_accepted) {
+          <div class="detail-card">
+            <div class="detail-label">Status</div>
+            <div class="detail-value font-weight-medium status-accepted">
+              {{ getTransactionStatus(transactionDetails()!) }}
+            </div>
           </div>
-        </div>
+        }
 
         <!-- Block Time -->
         <div class="detail-card">
@@ -126,9 +145,7 @@
               <div class="detail-value font-mono break-all">
                 {{ shortenAddress(getBlockHashDisplay()) }}
               </div>
-              <app-copy-button 
-                [value]="getBlockHashDisplay()"
-                [size]="'xs'">
+              <app-copy-button [value]="getBlockHashDisplay()" [size]="'xs'">
               </app-copy-button>
             </div>
           </div>
@@ -138,13 +155,16 @@
         <div class="detail-card">
           <div class="detail-label">Transaction ID</div>
           <div class="detail-value-container flex align-items-center gap-8">
-            <div class="detail-value text-primary font-mono cursor-pointer hover-opacity break-all"
-                 (click)="openTransactionInExplorer()">
+            <div
+              class="detail-value text-primary font-mono cursor-pointer hover-opacity break-all"
+              (click)="openTransactionInExplorer()"
+            >
               {{ transactionDetails()?.transaction_id }}
             </div>
-            <app-copy-button 
+            <app-copy-button
               [value]="transactionDetails()?.transaction_id || ''"
-              [size]="'xs'">
+              [size]="'xs'"
+            >
             </app-copy-button>
             <kc-icon
               [iconClass]="'icon-link'"
@@ -158,31 +178,47 @@
       </div>
 
       <!-- Inputs Section -->
-      @if (transactionDetails()?.inputs && transactionDetails()!.inputs.length > 0) {
+      @if (
+        transactionDetails()?.inputs && transactionDetails()!.inputs.length > 0
+      ) {
         <div class="inputs-section">
-          <h4 class="section-subtitle text-gray-90">Inputs ({{ transactionDetails()!.inputs.length }})</h4>
+          <h4 class="section-subtitle text-gray-90">
+            Inputs ({{ transactionDetails()!.inputs.length }})
+          </h4>
           <div class="inputs-list">
-            @for (input of transactionDetails()!.inputs; track input.previous_outpoint_hash + ':' + input.previous_outpoint_index) {
+            @for (
+              input of transactionDetails()!.inputs;
+              track input.previous_outpoint_hash +
+                ":" +
+                input.previous_outpoint_index
+            ) {
               <div class="input-card detail-card">
-                <div class="input-header flex justify-content-between align-items-center mb-8">
+                <div
+                  class="input-header flex justify-content-between align-items-center mb-8"
+                >
                   <div class="detail-label">Address</div>
-                  <div class="kaspa-amount-display flex align-items-center gap-8">
-                    <kc-icon 
-                      [iconClass]="'icon-kaspa-coin'" 
-                      [size]="'sm'">
+                  <div
+                    class="kaspa-amount-display flex align-items-center gap-8"
+                  >
+                    <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'">
                     </kc-icon>
-                    <div class="detail-value kaspa-amount font-weight-bold text-white">
+                    <div
+                      class="detail-value kaspa-amount font-weight-bold text-white"
+                    >
                       {{ formatInputAmount(input.previous_outpoint_amount) }}
                     </div>
                   </div>
                 </div>
-                <div class="detail-value-container flex align-items-center gap-8">
+                <div
+                  class="detail-value-container flex align-items-center gap-8"
+                >
                   <div class="detail-value font-mono break-all">
-                    {{ shortenAddress(input.previous_outpoint_address || '') }}
+                    {{ shortenAddress(input.previous_outpoint_address || "") }}
                   </div>
-                  <app-copy-button 
+                  <app-copy-button
                     [value]="input.previous_outpoint_address || ''"
-                    [size]="'xs'">
+                    [size]="'xs'"
+                  >
                   </app-copy-button>
                 </div>
               </div>
@@ -192,31 +228,43 @@
       }
 
       <!-- Outputs Section -->
-      @if (transactionDetails()?.outputs && transactionDetails()!.outputs.length > 0) {
+      @if (
+        transactionDetails()?.outputs &&
+        transactionDetails()!.outputs.length > 0
+      ) {
         <div class="outputs-section">
-          <h4 class="section-subtitle text-gray-90">Outputs ({{ transactionDetails()!.outputs.length }})</h4>
+          <h4 class="section-subtitle text-gray-90">
+            Outputs ({{ transactionDetails()!.outputs.length }})
+          </h4>
           <div class="outputs-list">
             @for (output of transactionDetails()!.outputs; track $index) {
               <div class="output-card detail-card">
-                <div class="output-header flex justify-content-between align-items-center mb-8">
+                <div
+                  class="output-header flex justify-content-between align-items-center mb-8"
+                >
                   <div class="detail-label">Address</div>
-                  <div class="kaspa-amount-display flex align-items-center gap-8">
-                    <kc-icon 
-                      [iconClass]="'icon-kaspa-coin'" 
-                      [size]="'sm'">
+                  <div
+                    class="kaspa-amount-display flex align-items-center gap-8"
+                  >
+                    <kc-icon [iconClass]="'icon-kaspa-coin'" [size]="'sm'">
                     </kc-icon>
-                    <div class="detail-value kaspa-amount font-weight-bold text-white">
+                    <div
+                      class="detail-value kaspa-amount font-weight-bold text-white"
+                    >
                       {{ formatOutputAmount(output.amount) }}
                     </div>
                   </div>
                 </div>
-                <div class="detail-value-container flex align-items-center gap-8">
+                <div
+                  class="detail-value-container flex align-items-center gap-8"
+                >
                   <div class="detail-value font-mono break-all">
-                    {{ shortenAddress(output.script_public_key_address || '') }}
+                    {{ shortenAddress(output.script_public_key_address || "") }}
                   </div>
-                  <app-copy-button 
+                  <app-copy-button
                     [value]="output.script_public_key_address || ''"
-                    [size]="'xs'">
+                    [size]="'xs'"
+                  >
                   </app-copy-button>
                 </div>
               </div>
@@ -227,9 +275,15 @@
     </div>
   } @else {
     <!-- Error state -->
-    <div class="error-container flex column align-items-center justify-content-center gap-16 p-32">
-      <div class="text-gray-60 typo-text-2 text-center">Transaction not found</div>
-      <div class="text-gray-50 typo-text-1 text-center">The requested transaction details could not be loaded.</div>
+    <div
+      class="error-container flex column align-items-center justify-content-center gap-16 p-32"
+    >
+      <div class="text-gray-60 typo-text-2 text-center">
+        Transaction not found
+      </div>
+      <div class="text-gray-50 typo-text-1 text-center">
+        The requested transaction details could not be loaded.
+      </div>
     </div>
   }
-</div> 
+</div>

--- a/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.ts
+++ b/src/app/v2/pages/app/home/kaspa-transaction-details/kaspa-transaction-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
-import {  KcIconComponent } from 'kaspacom-ui';
+import { KcIconComponent } from 'kaspacom-ui';
 import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.component';
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { KaspaApiService } from '../../../../../services/kaspa-api/kaspa-api.service';
@@ -12,14 +12,9 @@ import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-ser
 
 @Component({
   selector: 'app-kaspa-transaction-details',
-  imports: [
-    CommonModule,
-    KcIconComponent,
-    SkeletonComponent,
-    CopyButtonComponent
-  ],
+  imports: [KcIconComponent, SkeletonComponent, CopyButtonComponent],
   templateUrl: './kaspa-transaction-details.component.html',
-  styleUrl: './kaspa-transaction-details.component.scss'
+  styleUrl: './kaspa-transaction-details.component.scss',
 })
 export class KaspaTransactionDetailsComponent implements OnInit {
   private route = inject(ActivatedRoute);
@@ -30,7 +25,9 @@ export class KaspaTransactionDetailsComponent implements OnInit {
   private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
   protected transactionId: string | null = null;
-  protected transactionDetails = signal<FullTransactionResponseItem | null>(null);
+  protected transactionDetails = signal<FullTransactionResponseItem | null>(
+    null,
+  );
   protected loading = signal<boolean>(true);
 
   ngOnInit(): void {
@@ -66,7 +63,10 @@ export class KaspaTransactionDetailsComponent implements OnInit {
       }
 
       // If no transaction data is available, we can't load the details
-      console.warn('No transaction data available for transaction ID:', this.transactionId);
+      console.warn(
+        'No transaction data available for transaction ID:',
+        this.transactionId,
+      );
       this.loading.set(false);
     } catch (error) {
       console.error('Failed to load transaction details:', error);
@@ -82,7 +82,7 @@ export class KaspaTransactionDetailsComponent implements OnInit {
     const numAmount = this.kaspaNetworkActionsService.sompiToNumber(amount);
     return numAmount.toLocaleString('en-US', {
       minimumFractionDigits: 0,
-      maximumFractionDigits: 8
+      maximumFractionDigits: 8,
     });
   }
 
@@ -95,7 +95,7 @@ export class KaspaTransactionDetailsComponent implements OnInit {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: true
+      hour12: true,
     });
   }
 
@@ -104,7 +104,9 @@ export class KaspaTransactionDetailsComponent implements OnInit {
     return `${address.slice(0, 10)}...${address.slice(-8)}`;
   }
 
-  protected getTransactionStatus(transaction: FullTransactionResponseItem): string {
+  protected getTransactionStatus(
+    transaction: FullTransactionResponseItem,
+  ): string {
     return transaction.is_accepted ? 'Accepted' : 'Pending';
   }
 
@@ -163,7 +165,7 @@ export class KaspaTransactionDetailsComponent implements OnInit {
     const netAmount = outputAmount - inputAmount;
     return {
       amount: netAmount < 0n ? -netAmount : netAmount,
-      isIncoming: netAmount > 0n
+      isIncoming: netAmount > 0n,
     };
   }
 
@@ -181,6 +183,8 @@ export class KaspaTransactionDetailsComponent implements OnInit {
       return '';
     }
     // Return the first block hash if it's an array
-    return Array.isArray(transaction.block_hash) ? transaction.block_hash[0] : transaction.block_hash;
+    return Array.isArray(transaction.block_hash)
+      ? transaction.block_hash[0]
+      : transaction.block_hash;
   }
 }

--- a/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.html
+++ b/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.html
@@ -1,17 +1,23 @@
-<div class="transaction-details-container full-width full-height column p-16 flex column gap-24" [class.loading]="loading()">
+<div
+  class="transaction-details-container full-width full-height column p-16 flex column gap-24"
+  [class.loading]="loading()"
+>
   <!-- Header with back button -->
-  <div class="transaction-header flex align-items-center justify-content-between">
+  <div
+    class="transaction-header flex align-items-center justify-content-between"
+  >
     <!-- Left side: back button and title -->
     <div class="header-left flex align-items-center gap-16">
-      <kc-icon 
+      <kc-icon
         [iconClass]="'icon-arrow-left'"
         [size]="'md'"
         (click)="goBack()"
-        class="cursor-pointer hover-opacity">
+        class="cursor-pointer hover-opacity"
+      >
       </kc-icon>
       <h1 class="transaction-title text-gray-90">Transaction Details</h1>
     </div>
-    
+
     <!-- Right side: chevron or additional actions if needed -->
     <div class="header-right">
       <!-- Could add additional actions here if needed -->
@@ -21,11 +27,19 @@
   @if (loading()) {
     <!-- Loading state -->
     <div class="details-section flex column gap-16">
-      <app-skeleton [height]="'24px'" [width]="'180px'" class="mb-16"></app-skeleton>
+      <app-skeleton
+        [height]="'24px'"
+        [width]="'180px'"
+        class="mb-16"
+      ></app-skeleton>
       <div class="details-grid">
-        @for (item of [1,2,3,4,5,6,7,8,9,10]; track item) {
+        @for (item of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]; track item) {
           <div class="detail-card">
-            <app-skeleton [height]="'16px'" [width]="'80px'" class="mb-8"></app-skeleton>
+            <app-skeleton
+              [height]="'16px'"
+              [width]="'80px'"
+              class="mb-8"
+            ></app-skeleton>
             <app-skeleton [height]="'20px'" [width]="'100%'"></app-skeleton>
           </div>
         }
@@ -35,7 +49,7 @@
     <!-- Transaction Details Section -->
     <div class="details-section flex column gap-16">
       <h3 class="section-title text-gray-90">Transaction Details</h3>
-      
+
       <div class="details-grid">
         <!-- Amount -->
         <div class="detail-card">
@@ -50,11 +64,12 @@
           <div class="detail-label">From</div>
           <div class="detail-value-container flex align-items-center gap-8">
             <div class="detail-value font-mono break-all">
-              {{ shortenAddress(operationDetails()?.from || '') }}
+              {{ shortenAddress(operationDetails()?.from || "") }}
             </div>
-            <app-copy-button 
+            <app-copy-button
               [value]="operationDetails()?.from || ''"
-              [size]="'xs'">
+              [size]="'xs'"
+            >
             </app-copy-button>
           </div>
         </div>
@@ -65,11 +80,12 @@
             <div class="detail-label">To</div>
             <div class="detail-value-container flex align-items-center gap-8">
               <div class="detail-value font-mono break-all">
-                {{ shortenAddress(operationDetails()?.to || '') }}
+                {{ shortenAddress(operationDetails()?.to || "") }}
               </div>
-              <app-copy-button 
+              <app-copy-button
                 [value]="operationDetails()?.to || ''"
-                [size]="'xs'">
+                [size]="'xs'"
+              >
               </app-copy-button>
             </div>
           </div>
@@ -79,7 +95,7 @@
         <div class="detail-card">
           <div class="detail-label">Protocol</div>
           <div class="detail-value font-weight-medium">
-            {{ operationDetails()?.p || 'KRC-20' }}
+            {{ operationDetails()?.p || "KRC-20" }}
           </div>
         </div>
 
@@ -108,19 +124,19 @@
         </div>
 
         <!-- TX State -->
-        <div class="detail-card" *ngIf="isOperationAccepted(operationDetails()!)">
-          <div class="detail-label">TX State</div>
-          <div class="detail-value font-weight-medium status-accepted">
-            {{ getOperationStatus(operationDetails()!) }}
+        @if (isOperationAccepted(operationDetails()!)) {
+          <div class="detail-card">
+            <div class="detail-label">TX State</div>
+            <div class="detail-value font-weight-medium status-accepted">
+              {{ getOperationStatus(operationDetails()!) }}
+            </div>
           </div>
-        </div>
+        }
 
         <!-- TX State (Second entry - "Implemented") -->
         <div class="detail-card">
           <div class="detail-label">TX State</div>
-          <div class="detail-value font-weight-medium">
-            Implemented
-          </div>
+          <div class="detail-value font-weight-medium">Implemented</div>
         </div>
 
         <!-- Check Point -->
@@ -130,9 +146,10 @@
             <div class="detail-value font-mono break-all">
               {{ operationDetails()?.checkpoint }}
             </div>
-            <app-copy-button 
+            <app-copy-button
               [value]="operationDetails()?.checkpoint || ''"
-              [size]="'xs'">
+              [size]="'xs'"
+            >
             </app-copy-button>
           </div>
         </div>
@@ -141,7 +158,7 @@
         <div class="detail-card">
           <div class="detail-label">OP Created at</div>
           <div class="detail-value">
-            {{ formatDate(operationDetails()?.mtsAdd || '') }}
+            {{ formatDate(operationDetails()?.mtsAdd || "") }}
           </div>
         </div>
 
@@ -149,7 +166,7 @@
         <div class="detail-card">
           <div class="detail-label">OP Updated at</div>
           <div class="detail-value">
-            {{ formatDate(operationDetails()?.mtsMod || '') }}
+            {{ formatDate(operationDetails()?.mtsMod || "") }}
           </div>
         </div>
 
@@ -157,13 +174,16 @@
         <div class="detail-card">
           <div class="detail-label">Reveal TX</div>
           <div class="detail-value-container flex align-items-center gap-8">
-            <div class="detail-value text-primary font-mono cursor-pointer hover-opacity break-all"
-                 (click)="openTransactionInExplorer()">
+            <div
+              class="detail-value text-primary font-mono cursor-pointer hover-opacity break-all"
+              (click)="openTransactionInExplorer()"
+            >
               {{ operationDetails()?.hashRev }}
             </div>
-            <app-copy-button 
+            <app-copy-button
               [value]="operationDetails()?.hashRev || ''"
-              [size]="'xs'">
+              [size]="'xs'"
+            >
             </app-copy-button>
             <kc-icon
               [iconClass]="'icon-link'"
@@ -178,9 +198,15 @@
     </div>
   } @else {
     <!-- Error state -->
-    <div class="error-container flex column align-items-center justify-content-center gap-16 p-32">
-      <div class="text-gray-60 typo-text-2 text-center">Transaction not found</div>
-      <div class="text-gray-50 typo-text-1 text-center">The requested transaction details could not be loaded.</div>
+    <div
+      class="error-container flex column align-items-center justify-content-center gap-16 p-32"
+    >
+      <div class="text-gray-60 typo-text-2 text-center">
+        Transaction not found
+      </div>
+      <div class="text-gray-50 typo-text-1 text-center">
+        The requested transaction details could not be loaded.
+      </div>
     </div>
   }
-</div> 
+</div>

--- a/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.ts
+++ b/src/app/v2/pages/app/home/krc20-transaction-details/krc20-transaction-details.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { KcIconComponent } from 'kaspacom-ui';
@@ -12,14 +12,9 @@ import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-ser
 
 @Component({
   selector: 'app-krc20-transaction-details',
-  imports: [
-    CommonModule,
-    KcIconComponent,
-    SkeletonComponent,
-    CopyButtonComponent
-  ],
+  imports: [KcIconComponent, SkeletonComponent, CopyButtonComponent],
   templateUrl: './krc20-transaction-details.component.html',
-  styleUrl: './krc20-transaction-details.component.scss'
+  styleUrl: './krc20-transaction-details.component.scss',
 })
 export class Krc20TransactionDetailsComponent implements OnInit {
   private route = inject(ActivatedRoute);
@@ -50,7 +45,7 @@ export class Krc20TransactionDetailsComponent implements OnInit {
     try {
       this.loading.set(true);
       const response = await firstValueFrom(
-        this.kasplexService.getOperationDetails(this.transactionId)
+        this.kasplexService.getOperationDetails(this.transactionId),
       );
 
       if (response.message === 'successful' && response.result?.length > 0) {
@@ -68,7 +63,8 @@ export class Krc20TransactionDetailsComponent implements OnInit {
     const navigationState = this.router.getCurrentNavigation()?.extras?.state;
     const historyState = history.state;
 
-    const returnTo = navigationState?.['returnTo'] || historyState?.['returnTo'];
+    const returnTo =
+      navigationState?.['returnTo'] || historyState?.['returnTo'];
 
     if (returnTo === 'activity') {
       this.router.navigate(['/app/activity']);
@@ -82,10 +78,11 @@ export class Krc20TransactionDetailsComponent implements OnInit {
   protected formatAmount(amount: string | undefined): string {
     if (!amount) return '0';
     const amountInSompi = BigInt(amount);
-    const numAmount = this.kaspaNetworkActionsService.sompiToNumber(amountInSompi);
+    const numAmount =
+      this.kaspaNetworkActionsService.sompiToNumber(amountInSompi);
     return numAmount.toLocaleString('en-US', {
       minimumFractionDigits: 0,
-      maximumFractionDigits: 8
+      maximumFractionDigits: 8,
     });
   }
 
@@ -98,7 +95,7 @@ export class Krc20TransactionDetailsComponent implements OnInit {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: true
+      hour12: true,
     });
   }
 

--- a/src/app/v2/pages/app/home/pending-transactions-banner/pending-transactions-banner.component.ts
+++ b/src/app/v2/pages/app/home/pending-transactions-banner/pending-transactions-banner.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
 import { KcIconComponent, KcSpinnerComponent } from 'kaspacom-ui';
 import { KaspaNetworkActionsService } from '../../../../../services/kaspa-netwrok-services/kaspa-network-actions.service';
@@ -7,7 +6,7 @@ import { WalletService } from '../../../../../services/wallet.service';
 @Component({
   selector: 'app-pending-transactions-banner',
   standalone: true,
-  imports: [CommonModule, KcIconComponent, KcSpinnerComponent],
+  imports: [KcIconComponent, KcSpinnerComponent],
   templateUrl: './pending-transactions-banner.component.html',
   styleUrl: './pending-transactions-banner.component.scss',
 })

--- a/src/app/v2/pages/app/home/utxo-asset/utxo-asset.component.ts
+++ b/src/app/v2/pages/app/home/utxo-asset/utxo-asset.component.ts
@@ -1,8 +1,11 @@
 import { Component, computed, inject, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute } from '@angular/router';
 import { KcIconComponent } from 'kaspacom-ui';
-import { BaseAssetPageComponent, AssetDetail } from '../../common/base-asset-page/base-asset-page.component';
+import {
+  BaseAssetPageComponent,
+  AssetDetail,
+} from '../../common/base-asset-page/base-asset-page.component';
 import { CopyButtonComponent } from '../../../../shared/ui/copy-button/copy-button.component';
 import { SkeletonComponent } from '../../../../shared/ui/skeleton/skeleton.component';
 import { UtxoEntryReference } from '../../../../../../../public/kaspa/kaspa';
@@ -10,16 +13,14 @@ import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-ser
 
 @Component({
   selector: 'app-utxo-asset',
-  imports: [
-    CommonModule,
-    KcIconComponent,
-    CopyButtonComponent,
-    SkeletonComponent
-  ],
+  imports: [KcIconComponent, CopyButtonComponent, SkeletonComponent],
   templateUrl: './utxo-asset.component.html',
-  styleUrl: './utxo-asset.component.scss'
+  styleUrl: './utxo-asset.component.scss',
 })
-export class UtxoAssetComponent extends BaseAssetPageComponent implements OnInit {
+export class UtxoAssetComponent
+  extends BaseAssetPageComponent
+  implements OnInit
+{
   protected route = inject(ActivatedRoute);
   private kaspaL1NetworkService = inject(KaspaL1NetworkService);
 
@@ -31,9 +32,11 @@ export class UtxoAssetComponent extends BaseAssetPageComponent implements OnInit
     const balance = wallet.getBalanceSignal()();
     if (!balance?.utxoEntries) return null;
 
-    return balance.utxoEntries.find(utxo =>
-      utxo.outpoint.transactionId === this.transactionId
-    ) || null;
+    return (
+      balance.utxoEntries.find(
+        (utxo) => utxo.outpoint.transactionId === this.transactionId,
+      ) || null
+    );
   });
 
   override ngOnInit() {
@@ -58,7 +61,7 @@ export class UtxoAssetComponent extends BaseAssetPageComponent implements OnInit
           name: 'UTXO Transaction',
           symbol: 'KAS',
           balance: kasAmount.toFixed(3),
-          decimals: 3
+          decimals: 3,
         };
         this.assetDetail.set(assetDetail);
       }

--- a/src/app/v2/pages/app/iframe-account-selection/iframe-account-selection.component.html
+++ b/src/app/v2/pages/app/iframe-account-selection/iframe-account-selection.component.html
@@ -5,95 +5,111 @@
     <div class="selection-panel">
       <div class="selection-panel__header">
         <p class="selection-panel__eyebrow">
-          {{ isWalletSelectionVisible() ? 'Select wallet' : 'Select account' }}
+          {{ isWalletSelectionVisible() ? "Select wallet" : "Select account" }}
         </p>
         <h2 class="selection-panel__title">
-          {{ isWalletSelectionVisible() ? 'Choose a wallet' : 'Choose an account' }}
+          {{
+            isWalletSelectionVisible() ? "Choose a wallet" : "Choose an account"
+          }}
         </h2>
-        <p class="selection-panel__subtitle" *ngIf="isWalletSelectionVisible()">
-          Pick the wallet you want to use inside this application.
-        </p>
-        <p
-          class="selection-panel__subtitle"
-          *ngIf="!isWalletSelectionVisible() && selectedWalletGroup()"
-        >
-          Wallet: {{ selectedWalletGroup()?.name }}
-        </p>
+        @if (isWalletSelectionVisible()) {
+          <p class="selection-panel__subtitle">
+            Pick the wallet you want to use inside this application.
+          </p>
+        }
+        @if (!isWalletSelectionVisible() && selectedWalletGroup()) {
+          <p class="selection-panel__subtitle">
+            Wallet: {{ selectedWalletGroup()?.name }}
+          </p>
+        }
 
-        <button
-          type="button"
-          class="selection-panel__back-button"
-          *ngIf="hasMultipleWallets() && !isWalletSelectionVisible()"
-          (click)="onChangeWallet()"
-        >
-          <kc-icon iconClass="icon-arrow-left" size="xs"></kc-icon>
-          Change wallet
-        </button>
-      </div>
-
-      <div class="wallets-list" *ngIf="isWalletSelectionVisible()">
-        @if (walletGroups().length === 0) {
-          <div class="empty-state">
-            <p>No wallets were found for this profile.</p>
-          </div>
-        } @else {
-          @for (item of walletGroups(); track item.id) {
-            <div
-              class="wallet-item"
-              [class.selected]="item === selectedWalletGroup()"
-              (click)="selectWalletGroup(item)"
-            >
-              <div class="wallet-item__icon">
-                <kc-icon
-                  [iconClass]="item === selectedWalletGroup() ? 'icon-user' : 'icon-user-12px'"
-                  [size]="'sm'"
-                ></kc-icon>
-              </div>
-              <div class="wallet-item__info">
-                <div class="wallet-item__name">{{ item.name }}</div>
-                <div class="wallet-item__address">
-                  {{ item.address | shortenAddress }}
-                </div>
-              </div>
-              <div class="wallet-item__chevron">
-                <kc-icon iconClass="icon-arrow-right" size="xs"></kc-icon>
-              </div>
-            </div>
-          }
+        @if (hasMultipleWallets() && !isWalletSelectionVisible()) {
+          <button
+            type="button"
+            class="selection-panel__back-button"
+            (click)="onChangeWallet()"
+          >
+            <kc-icon iconClass="icon-arrow-left" size="xs"></kc-icon>
+            Change wallet
+          </button>
         }
       </div>
 
-      <div class="accounts-list" *ngIf="!isWalletSelectionVisible()">
-        @if (accountItems().length === 0) {
-          <div class="empty-state">
-            <p>No accounts available in this wallet.</p>
-          </div>
-        } @else {
-          @for (account of accountItems(); track account.id) {
-            <div
-              class="account-item"
-              [class.selected]="account.isSelected"
-              (click)="selectAccount(account)"
-            >
-              <div class="account-item__icon">
-                <kc-icon
-                  [iconClass]="account.isSelected ? 'icon-user' : 'icon-user-12px'"
-                  [size]="'sm'"
-                ></kc-icon>
-              </div>
-              <div class="account-item__info">
-                <div class="account-item__name">{{ account.name }}</div>
-                <div class="account-item__address">
-                  {{ account.address | shortenAddress }}
+      @if (isWalletSelectionVisible()) {
+        <div class="wallets-list">
+          @if (walletGroups().length === 0) {
+            <div class="empty-state">
+              <p>No wallets were found for this profile.</p>
+            </div>
+          } @else {
+            @for (item of walletGroups(); track item.id) {
+              <div
+                class="wallet-item"
+                [class.selected]="item === selectedWalletGroup()"
+                (click)="selectWalletGroup(item)"
+              >
+                <div class="wallet-item__icon">
+                  <kc-icon
+                    [iconClass]="
+                      item === selectedWalletGroup()
+                        ? 'icon-user'
+                        : 'icon-user-12px'
+                    "
+                    [size]="'sm'"
+                  ></kc-icon>
+                </div>
+                <div class="wallet-item__info">
+                  <div class="wallet-item__name">{{ item.name }}</div>
+                  <div class="wallet-item__address">
+                    {{ item.address | shortenAddress }}
+                  </div>
+                </div>
+                <div class="wallet-item__chevron">
+                  <kc-icon iconClass="icon-arrow-right" size="xs"></kc-icon>
                 </div>
               </div>
-              <div class="account-item__status" *ngIf="account.isSelected">
-                <span>Current</span>
-              </div>
-            </div>
+            }
           }
-        }
-      </div>
+        </div>
+      }
+
+      @if (!isWalletSelectionVisible()) {
+        <div class="accounts-list">
+          @if (accountItems().length === 0) {
+            <div class="empty-state">
+              <p>No accounts available in this wallet.</p>
+            </div>
+          } @else {
+            @for (account of accountItems(); track account.id) {
+              <div
+                class="account-item"
+                [class.selected]="account.isSelected"
+                (click)="selectAccount(account)"
+              >
+                <div class="account-item__icon">
+                  <kc-icon
+                    [iconClass]="
+                      account.isSelected ? 'icon-user' : 'icon-user-12px'
+                    "
+                    [size]="'sm'"
+                  ></kc-icon>
+                </div>
+                <div class="account-item__info">
+                  <div class="account-item__name">{{ account.name }}</div>
+                  <div class="account-item__address">
+                    {{ account.address | shortenAddress }}
+                  </div>
+                </div>
+                @if (account.isSelected) {
+                  <div class="account-item__status">
+                    <span>Current</span>
+                  </div>
+                }
+              </div>
+            }
+          }
+        </div>
+      }
 
       <div class="selection-panel__actions">
         <kc-button
@@ -108,4 +124,3 @@
     </div>
   </div>
 </div>
-

--- a/src/app/v2/pages/app/iframe-account-selection/iframe-account-selection.component.ts
+++ b/src/app/v2/pages/app/iframe-account-selection/iframe-account-selection.component.ts
@@ -1,5 +1,12 @@
-import { Component, inject, signal, EventEmitter, Output, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  inject,
+  signal,
+  EventEmitter,
+  Output,
+  computed,
+} from '@angular/core';
+
 import { Router } from '@angular/router';
 import { KcButtonComponent, KcIconComponent } from 'kaspacom-ui';
 import { WalletService } from '../../../../services/wallet.service';
@@ -25,7 +32,7 @@ interface WalletAccountItem {
 @Component({
   selector: 'app-iframe-account-selection',
   standalone: true,
-  imports: [CommonModule, KcButtonComponent, KcIconComponent, ShortenAddressPipe],
+  imports: [KcButtonComponent, KcIconComponent, ShortenAddressPipe],
   templateUrl: './iframe-account-selection.component.html',
   styleUrl: './iframe-account-selection.component.scss',
 })
@@ -42,9 +49,7 @@ export class IframeAccountSelectionComponent {
   isWalletSelectionVisible = computed(
     () => this.hasMultipleWallets() && !this.selectedWalletGroup(),
   );
-  selectedWalletName = computed(
-    () => this.selectedWalletGroup()?.name || '',
-  );
+  selectedWalletName = computed(() => this.selectedWalletGroup()?.name || '');
   accountItems = computed<WalletAccountItem[]>(() => {
     const group = this.selectedWalletGroup();
     if (!group) {
@@ -114,7 +119,9 @@ export class IframeAccountSelectionComponent {
   }
 
   async selectAccount(account: WalletAccountItem): Promise<void> {
-    await this.walletService.selectCurrentWallet(account.wallet.getIdWithAccount());
+    await this.walletService.selectCurrentWallet(
+      account.wallet.getIdWithAccount(),
+    );
     this.accountSelected.emit();
   }
 
@@ -138,7 +145,8 @@ export class IframeAccountSelectionComponent {
   }
 
   private getWalletAddress(wallet: AppWallet): string {
-    return this.walletService.isL2Display() ? wallet.getL2WalletAddress() : wallet.getAddress();
+    return this.walletService.isL2Display()
+      ? wallet.getL2WalletAddress()
+      : wallet.getAddress();
   }
 }
-

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
@@ -8,7 +8,7 @@ import {
   OnDestroy,
   inject,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import {
   FormBuilder,
   FormsModule,
@@ -45,7 +45,6 @@ interface PanelCopy {
 @Component({
   selector: 'app-onboarding-page-v2',
   imports: [
-    CommonModule,
     FormsModule,
     ReactiveFormsModule,
     KcButtonComponent,

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/import-existing-flow.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/import-existing-flow.component.ts
@@ -1,4 +1,11 @@
-import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
 import { ImportExistingStep } from './import-existing-step.enum';
 import { ImportExistingFlowService } from './service/import-existing-flow.service';
 import {
@@ -6,7 +13,7 @@ import {
   slideAnimation,
 } from '../../shared/animation/slide.animation';
 import { StepIndicatorComponent } from '../../shared/component/step-indicator/step-indicator.component';
-import { CommonModule } from '@angular/common';
+
 import { ImportSwitchImportExistingStepComponent } from './steps/import-switch-import-existing-step/import-switch-import-existing-step.component';
 import { CreatePinImportExistingStepComponent } from './steps/create-pin-import-existing-step/create-pin-import-existing-step.component';
 import { SuccessImportExistingStepComponent } from './steps/success-import-existing-step/success-import-existing-step.component';
@@ -19,7 +26,6 @@ import { BackupImportExistingStepComponent } from './steps/backup-import-existin
 @Component({
   selector: 'app-import-existing-flow',
   imports: [
-    CommonModule,
     StepIndicatorComponent,
     ImportSwitchImportExistingStepComponent,
     SeedPhraseImportExistingStepComponent,

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/backup-import-existing-step/backup-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/backup-import-existing-step/backup-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
@@ -12,12 +11,7 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-backup-import-existing-step',
-  imports: [
-    CommonModule,
-    FormsModule,
-    KcButtonComponent,
-    KcIconComponent,
-  ],
+  imports: [FormsModule, KcButtonComponent, KcIconComponent],
   templateUrl: './backup-import-existing-step.component.html',
   styleUrl: './backup-import-existing-step.component.scss',
 })
@@ -64,18 +58,18 @@ export class BackupImportExistingStepComponent {
     this.isImporting.set(true);
 
     // Small delay to ensure UI updates
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     try {
       // Import the encrypted data
       const success = this.passwordManagerService.importFromEncryptedData(
-        this.backupData.trim()
+        this.backupData.trim(),
       );
-      
+
       if (!success) {
         this.notificationService.error(
           'Invalid Backup',
-          'Please check your backup data and try again.'
+          'Please check your backup data and try again.',
         );
         this.isImporting.set(false);
         return;
@@ -83,7 +77,7 @@ export class BackupImportExistingStepComponent {
 
       this.notificationService.success(
         'Success',
-        'Backup imported! Redirecting to login...'
+        'Backup imported! Redirecting to login...',
       );
 
       // Reload the page to refresh the login state
@@ -94,10 +88,9 @@ export class BackupImportExistingStepComponent {
       console.error('Error importing backup:', error);
       this.notificationService.error(
         'Import Failed',
-        'Unable to import backup. Please try again.'
+        'Unable to import backup. Please try again.',
       );
       this.isImporting.set(false);
     }
   }
 }
-

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/create-pin-import-existing-step/create-pin-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/create-pin-import-existing-step/create-pin-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, output, signal } from '@angular/core';
 import {
   AbstractControl,
@@ -18,7 +17,6 @@ import { ImportExistingFlowService } from '../../service/import-existing-flow.se
 @Component({
   selector: 'app-create-pin-import-existing-step',
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcButtonComponent,
     KcInputComponent,
@@ -46,7 +44,7 @@ export class CreatePinImportExistingStepComponent {
         [
           Validators.required,
           Validators.minLength(8),
-          Validators.pattern(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/)
+          Validators.pattern(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/),
         ],
       ],
       confirmPassword: [

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/component/import-switch/import-switch.component.html
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/component/import-switch/import-switch.component.html
@@ -30,15 +30,16 @@
   >
     <span class="import-switch__label">Private Key</span>
   </button>
-  <button
-    *ngIf="showImportFromFile()"
-    class="import-switch__option"
-    [class.import-switch__option--active]="
-      selectedMethod() === ImportSwitchMethod.BACKUP
-    "
-    (click)="methodChanged.emit(ImportSwitchMethod.BACKUP)"
-    type="button"
-  >
-    <span class="import-switch__label">Backup File</span>
-  </button>
+  @if (showImportFromFile()) {
+    <button
+      class="import-switch__option"
+      [class.import-switch__option--active]="
+        selectedMethod() === ImportSwitchMethod.BACKUP
+      "
+      (click)="methodChanged.emit(ImportSwitchMethod.BACKUP)"
+      type="button"
+    >
+      <span class="import-switch__label">Backup File</span>
+    </button>
+  }
 </div>

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/component/import-switch/import-switch.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/component/import-switch/import-switch.component.ts
@@ -1,10 +1,9 @@
 import { Component, input, output } from '@angular/core';
 import { ImportSwitchMethod } from './import-switch-method.enum';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-import-switch',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './import-switch.component.html',
   styleUrl: './import-switch.component.scss',
 })

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/import-switch-import-existing-step.component.html
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/import-switch-import-existing-step.component.html
@@ -7,20 +7,23 @@
   </div>
 
   <div class="flex column full-width gap-16">
-    <kc-button
-      *ngIf="!userHasWallets()"
-      [text]="'Scan QR Code'"
-      [prefixIcon]="'icon-qr'"
-      [isFullWidth]="true"
-      [variant]="'tertiary'"
-      (buttonClick)="onQrScanClick()"
-    ></kc-button>
+    @if (!userHasWallets()) {
+      <kc-button
+        [text]="'Scan QR Code'"
+        [prefixIcon]="'icon-qr'"
+        [isFullWidth]="true"
+        [variant]="'tertiary'"
+        (buttonClick)="onQrScanClick()"
+      ></kc-button>
+    }
 
-    <div class="flex align-items-center gap-12 full-width"  *ngIf="!userHasWallets()">
-      <div class="separator-line"></div>
-      <span class="separator-text typo-text-3 text-medium">- OR -</span>
-      <div class="separator-line"></div>
-    </div>
+    @if (!userHasWallets()) {
+      <div class="flex align-items-center gap-12 full-width">
+        <div class="separator-line"></div>
+        <span class="separator-text typo-text-3 text-medium">- OR -</span>
+        <div class="separator-line"></div>
+      </div>
+    }
 
     <app-import-switch
       class="full-width"

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/import-switch-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/import-switch-import-existing-step/import-switch-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, output, signal } from '@angular/core';
 import { KcButtonComponent, NotificationService } from 'kaspacom-ui';
 import { ImportSwitchComponent } from './component/import-switch/import-switch.component';
@@ -9,7 +8,7 @@ import { PasswordManagerService } from '../../../../../../../services/password-m
 
 @Component({
   selector: 'app-import-switch-import-existing-step',
-  imports: [CommonModule, KcButtonComponent, ImportSwitchComponent],
+  imports: [KcButtonComponent, ImportSwitchComponent],
   templateUrl: './import-switch-import-existing-step.component.html',
   styleUrl: './import-switch-import-existing-step.component.scss',
 })
@@ -26,7 +25,9 @@ export class ImportSwitchImportExistingStepComponent {
   private readonly notificationService = inject(NotificationService);
 
   importMethod = signal<ImportSwitchMethod>(ImportSwitchMethod.SEED_PHRASE);
-  userHasWallets = computed(() => this.passwordManagerService.isUserHasSavedPassword());
+  userHasWallets = computed(() =>
+    this.passwordManagerService.isUserHasSavedPassword(),
+  );
 
   constructor() {
     this.importMethod.set(
@@ -68,20 +69,20 @@ export class ImportSwitchImportExistingStepComponent {
     try {
       // Import the encrypted data using the same logic as backup file import
       const success = this.passwordManagerService.importFromEncryptedData(
-        backupData.trim()
+        backupData.trim(),
       );
-      
+
       if (!success) {
         this.notificationService.error(
           'Invalid Backup',
-          'Please check your backup QR code and try again.'
+          'Please check your backup QR code and try again.',
         );
         return;
       }
 
       this.notificationService.success(
         'Success',
-        'Backup imported! Redirecting to login...'
+        'Backup imported! Redirecting to login...',
       );
 
       // Reload the page to refresh the login state
@@ -92,7 +93,7 @@ export class ImportSwitchImportExistingStepComponent {
       console.error('Error importing backup from QR:', error);
       this.notificationService.error(
         'Import Failed',
-        'Unable to import backup. Please try again.'
+        'Unable to import backup. Please try again.',
       );
     }
   }

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/private-key-import-existing-step/private-key-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/private-key-import-existing-step/private-key-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   computed,
@@ -20,7 +19,6 @@ import { ImportSwitchMethod } from '../import-switch-import-existing-step/compon
 @Component({
   selector: 'app-private-key-import-existing-step',
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcButtonComponent,
     KcInputComponent,

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/seed-passphrase-import-existing-step/seed-passphrase-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/seed-passphrase-import-existing-step/seed-passphrase-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   computed,
@@ -20,7 +19,6 @@ import { ImportExistingFlowService } from '../../service/import-existing-flow.se
 @Component({
   selector: 'app-seed-passphrase-import-existing-step',
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcButtonComponent,
     KcInputComponent,

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/seed-phrase-import-existing-step/seed-phrase-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/seed-phrase-import-existing-step/seed-phrase-import-existing-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -26,7 +25,6 @@ import { ImportSwitchMethod } from '../import-switch-import-existing-step/compon
 @Component({
   selector: 'app-seed-phrase-import-existing-step',
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcButtonComponent,
     KcInputComponent,

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/success-import-existing-step/success-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/success-import-existing-step/success-import-existing-step.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import { Component, inject, output } from '@angular/core';
 import { Router } from '@angular/router';
 import { KcButtonComponent } from 'kaspacom-ui';
@@ -7,7 +7,7 @@ import { FlowPagesService } from '../../../../../../services/flow-pages.service'
 
 @Component({
   selector: 'app-success-import-existing-step',
-  imports: [CommonModule, KcButtonComponent, NgOptimizedImage],
+  imports: [KcButtonComponent, NgOptimizedImage],
   templateUrl: './success-import-existing-step.component.html',
   styleUrl: './success-import-existing-step.component.scss',
 })

--- a/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/create-password-new-wallet-step/create-password-new-wallet-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/create-password-new-wallet-step/create-password-new-wallet-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, computed, inject, output, signal } from '@angular/core';
 import {
   AbstractControl,
@@ -17,7 +16,6 @@ import { NewWalletFlowService } from '../../service/new-wallet-flow.service';
 @Component({
   selector: 'app-create-password-new-wallet-step',
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     KcInputComponent,
     KcButtonComponent,
@@ -41,7 +39,7 @@ export class CreatePasswordNewWalletStepComponent {
         [
           Validators.required,
           Validators.minLength(8),
-          Validators.pattern(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/)
+          Validators.pattern(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/),
         ],
       ],
       confirmPassword: [

--- a/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/verify-seed-phrase-new-wallet-step/verify-seed-phrase-new-wallet-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/verify-seed-phrase-new-wallet-step/verify-seed-phrase-new-wallet-step.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   OnInit,
@@ -8,10 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import {
-  KcButtonComponent,
-  KcInputComponent,
-} from 'kaspacom-ui';
+import { KcButtonComponent, KcInputComponent } from 'kaspacom-ui';
 import { NewWalletFlowService } from '../../service/new-wallet-flow.service';
 
 interface VerificationWordEntry {
@@ -22,12 +18,7 @@ interface VerificationWordEntry {
 
 @Component({
   selector: 'app-verify-seed-phrase-new-wallet-step',
-  imports: [
-    CommonModule,
-    FormsModule,
-    KcButtonComponent,
-    KcInputComponent,
-  ],
+  imports: [FormsModule, KcButtonComponent, KcInputComponent],
   templateUrl: './verify-seed-phrase-new-wallet-step.component.html',
   styleUrl: './verify-seed-phrase-new-wallet-step.component.scss',
 })

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
@@ -1,108 +1,132 @@
 <div class="network-selection-modal">
   <div class="modal-content">
-
     <!-- L1 Network -->
     <h3 class="network-group-title">L1 Network</h3>
     <div class="networks-list">
-      <div *ngFor="let network of l1Networks" class="network-item"
-        [class.selected]="isCurrentL1Network(network)"
-        role="button"
-        tabindex="0"
-        (click)="setL1Network(network)"
-        (keydown.enter)="setL1Network(network)"
-        (keydown.space)="onL1SpaceKey($event, network)">
-        <div class="network-icon">
-          <img [src]="network.icon" [alt]="network.shortName" class="chain-icon" />
+      @for (network of l1Networks; track network) {
+        <div
+          class="network-item"
+          [class.selected]="isCurrentL1Network(network)"
+          role="button"
+          tabindex="0"
+          (click)="setL1Network(network)"
+          (keydown.enter)="setL1Network(network)"
+          (keydown.space)="onL1SpaceKey($event, network)"
+        >
+          <div class="network-icon">
+            <img
+              [src]="network.icon"
+              [alt]="network.shortName"
+              class="chain-icon"
+            />
+          </div>
+          <div class="network-info">
+            <div class="network-name">{{ network.shortName }}</div>
+          </div>
+          <div class="network-status">
+            @if (isCurrentL1Network(network)) {
+              <kc-icon [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
+            }
+          </div>
         </div>
-        <div class="network-info">
-          <div class="network-name">{{ network.shortName }}</div>
-        </div>
-        <div class="network-status">
-          <kc-icon *ngIf="isCurrentL1Network(network)" [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
-        </div>
-      </div>
+      }
     </div>
 
     <!-- L2 Networks -->
     <h3 class="network-group-title">L2 Networks</h3>
     <div class="networks-list">
-      <div
-        *ngFor="let network of networks()"
-        class="network-item"
-        [class.selected]="isCurrentNetwork(network.chainId)"
-        [class.confirming-delete]="deletingChainId === network.chainId"
-        role="button"
-        tabindex="0"
-        (click)="setL2Network(network)"
-        (keydown.enter)="onNetworkEnterKey($event, network)"
-        (keydown.space)="onNetworkSpaceKey($event, network)">
-
-        <!-- Icon -->
-        <div class="network-icon">
-          @let networkIcon = getNetworkIcon(network);
-          @if (networkIcon) {
-            <img [src]="networkIcon" alt="" class="chain-icon" />
-          } @else {
-            <div class="chain-icon-fallback">
-              <span>{{ network.nativeCurrency.symbol.charAt(0) || '?' }}</span>
-            </div>
-          }
-        </div>
-
-        <!-- Name + price -->
-        <div class="network-info">
-          <div class="network-name">{{ getNetworkShortName(network) }}</div>
-          @let price = getNativePrice(network.chainId);
-          @if (price !== null) {
-            <div class="network-price">
-              {{ network.nativeCurrency.symbol }} · {{ formatPrice(price) }}
-            </div>
-          }
-        </div>
-
-        <!-- Status / delete -->
-        <div class="network-status">
-          @if (deletingChainId === network.chainId) {
-            <div class="delete-confirm-row" (click)="$event.stopPropagation()">
-              <button type="button" class="btn-confirm-delete" (click)="confirmDelete($event, network.chainId)">
-                Delete
-              </button>
-              <button type="button" class="btn-cancel-delete" (click)="cancelDelete($event)">
-                Keep
-              </button>
-            </div>
-          } @else {
-            @if (isCurrentNetwork(network.chainId)) {
-              <kc-icon [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
+      @for (network of networks(); track network) {
+        <div
+          class="network-item"
+          [class.selected]="isCurrentNetwork(network.chainId)"
+          [class.confirming-delete]="deletingChainId === network.chainId"
+          role="button"
+          tabindex="0"
+          (click)="setL2Network(network)"
+          (keydown.enter)="onNetworkEnterKey($event, network)"
+          (keydown.space)="onNetworkSpaceKey($event, network)"
+        >
+          <!-- Icon -->
+          <div class="network-icon">
+            @let networkIcon = getNetworkIcon(network);
+            @if (networkIcon) {
+              <img [src]="networkIcon" alt="" class="chain-icon" />
+            } @else {
+              <div class="chain-icon-fallback">
+                <span>{{
+                  network.nativeCurrency.symbol.charAt(0) || "?"
+                }}</span>
+              </div>
             }
-            @if (isCustomNetwork(network.chainId)) {
-              <button
-                type="button"
-                class="btn-delete-network"
-                title="Remove network"
-                [attr.aria-label]="'Remove ' + getNetworkShortName(network) + ' network'"
-                (click)="confirmDelete($event, network.chainId)">
-                <kc-icon [iconClass]="'icon-trash'" [size]="'sm'"></kc-icon>
-              </button>
+          </div>
+          <!-- Name + price -->
+          <div class="network-info">
+            <div class="network-name">{{ getNetworkShortName(network) }}</div>
+            @let price = getNativePrice(network.chainId);
+            @if (price !== null) {
+              <div class="network-price">
+                {{ network.nativeCurrency.symbol }} · {{ formatPrice(price) }}
+              </div>
             }
-          }
+          </div>
+          <!-- Status / delete -->
+          <div class="network-status">
+            @if (deletingChainId === network.chainId) {
+              <div
+                class="delete-confirm-row"
+                (click)="$event.stopPropagation()"
+              >
+                <button
+                  type="button"
+                  class="btn-confirm-delete"
+                  (click)="confirmDelete($event, network.chainId)"
+                >
+                  Delete
+                </button>
+                <button
+                  type="button"
+                  class="btn-cancel-delete"
+                  (click)="cancelDelete($event)"
+                >
+                  Keep
+                </button>
+              </div>
+            } @else {
+              @if (isCurrentNetwork(network.chainId)) {
+                <kc-icon [iconClass]="'icon-check'" [size]="'sm'"></kc-icon>
+              }
+              @if (isCustomNetwork(network.chainId)) {
+                <button
+                  type="button"
+                  class="btn-delete-network"
+                  title="Remove network"
+                  [attr.aria-label]="
+                    'Remove ' + getNetworkShortName(network) + ' network'
+                  "
+                  (click)="confirmDelete($event, network.chainId)"
+                >
+                  <kc-icon [iconClass]="'icon-trash'" [size]="'sm'"></kc-icon>
+                </button>
+              }
+            }
+          </div>
         </div>
-
-      </div>
+      }
     </div>
 
     <!-- Add Network -->
-    <div class="add-network-row"
+    <div
+      class="add-network-row"
       role="button"
       tabindex="0"
       (click)="onAddNetwork()"
       (keydown.enter)="onAddNetwork()"
-      (keydown.space)="onAddNetworkSpaceKey($event)">
+      (keydown.space)="onAddNetworkSpaceKey($event)"
+    >
       <div class="add-network-icon">
         <kc-icon [iconClass]="'icon-plus'" [size]="'sm'"></kc-icon>
       </div>
       <span class="add-network-label">Add custom network</span>
     </div>
-
   </div>
 </div>

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { FlowPagesService } from '../../services/flow-pages.service';
@@ -9,7 +9,10 @@ import { EIP1193ProviderChain } from '@kaspacom/wallet-messages';
 import { WalletService } from '../../../services/wallet.service';
 import { Router } from '@angular/router';
 import { CHAIN_ID_LOGOS } from './chain-id-logos';
-import { COINGECKO_PRICE_URL, NATIVE_TOKEN_COINGECKO_IDS } from './coingecko-native-ids';
+import {
+  COINGECKO_PRICE_URL,
+  NATIVE_TOKEN_COINGECKO_IDS,
+} from './coingecko-native-ids';
 import { L1NetworkConfigInterface } from '../../../../environments/environment.interface';
 import { RpcService } from '../../../services/kaspa-netwrok-services/rpc.service';
 import { KaspaNetworkConnectionManagerService } from '../../../services/kaspa-netwrok-services/kaspa-network-connection-manager.service';
@@ -18,7 +21,6 @@ import { AppWallet } from '../../../classes/AppWallet';
 
 const PRICE_CACHE_TTL_MS = 5 * 60 * 1000;
 
-
 interface PriceCacheEntry {
   priceUsd: number;
   fetchedAt: number;
@@ -26,7 +28,7 @@ interface PriceCacheEntry {
 
 @Component({
   selector: 'network-selection-modal',
-  imports: [CommonModule, KcIconComponent],
+  imports: [KcIconComponent],
   templateUrl: './network-selection-modal.component.html',
   styleUrl: './network-selection-modal.component.scss',
 })
@@ -48,7 +50,9 @@ export class NetworkSelectionModalComponent implements OnInit {
   // Reactive: re-derives whenever a custom chain is added or removed
   protected networks = computed<EIP1193ProviderChain[]>(() => {
     void this.ethereumWalletChainManager.getCustomChainsSignal()();
-    return Object.values(this.ethereumWalletChainManager.getAllChainsByChainId());
+    return Object.values(
+      this.ethereumWalletChainManager.getAllChainsByChainId(),
+    );
   });
 
   protected nativePrices = new Map<string, number>();
@@ -83,10 +87,12 @@ export class NetworkSelectionModalComponent implements OnInit {
     const uniqueSymbols = [...symbolToChainIds.keys()];
     if (!uniqueSymbols.length) return;
 
-    const geckoIdList = [...new Set(uniqueSymbols.map(s => NATIVE_TOKEN_COINGECKO_IDS[s]))];
+    const geckoIdList = [
+      ...new Set(uniqueSymbols.map((s) => NATIVE_TOKEN_COINGECKO_IDS[s])),
+    ];
     const geckoIds = geckoIdList.join(',');
     const now = Date.now();
-    const allCached = geckoIdList.every(id => {
+    const allCached = geckoIdList.every((id) => {
       const entry = this.priceCache.get(id);
       return entry && now - entry.fetchedAt < PRICE_CACHE_TTL_MS;
     });
@@ -101,7 +107,10 @@ export class NetworkSelectionModalComponent implements OnInit {
         for (const geckoId of geckoIdList) {
           const price = resp[geckoId]?.usd;
           if (price !== undefined) {
-            this.priceCache.set(geckoId, { priceUsd: price, fetchedAt: Date.now() });
+            this.priceCache.set(geckoId, {
+              priceUsd: price,
+              fetchedAt: Date.now(),
+            });
           }
         }
       } catch {
@@ -132,7 +141,8 @@ export class NetworkSelectionModalComponent implements OnInit {
 
   getNetworkIcon(network: EIP1193ProviderChain): string | null {
     return (
-      this.ethereumWalletChainManager.getChainEnvConfig(network.chainId)?.icon ||
+      this.ethereumWalletChainManager.getChainEnvConfig(network.chainId)
+        ?.icon ||
       CHAIN_ID_LOGOS[network.chainId.toLowerCase()] ||
       null
     );
@@ -147,7 +157,9 @@ export class NetworkSelectionModalComponent implements OnInit {
 
   isCurrentNetwork(networkId: string): boolean {
     return (
-      this.ethereumWalletChainManager.getCurrentChainSignal()()?.toLowerCase() === networkId.toLowerCase()
+      this.ethereumWalletChainManager
+        .getCurrentChainSignal()()
+        ?.toLowerCase() === networkId.toLowerCase()
     );
   }
 

--- a/src/app/v2/shared/ui/input/address-smart-input/address-smart-input.component.ts
+++ b/src/app/v2/shared/ui/input/address-smart-input/address-smart-input.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   Component,
   EventEmitter,
@@ -26,7 +25,6 @@ import {
   selector: 'app-address-smart-input',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     KcInputComponent,
     KcIconComponent,
@@ -148,10 +146,11 @@ export class AddressSmartInputComponent implements OnChanges {
       // KNS domain resolution - show resolved address section
       this.isResolving.set(false);
       this.isDomainCandidate.set(false);
-      
+
       if (result.effectiveAddress) {
         this.resolvedAddress.set(result.effectiveAddress);
-        if (result.resolvedDomain) this.resolvedDomain.set(result.resolvedDomain);
+        if (result.resolvedDomain)
+          this.resolvedDomain.set(result.resolvedDomain);
         this.resolveError.set('');
         this.displayIsValid.set(true);
         this.displayInvalidReason.set('');
@@ -168,7 +167,7 @@ export class AddressSmartInputComponent implements OnChanges {
       this.isDomainCandidate.set(false);
       this.resolvedAddress.set('');
       this.resolvedDomain.set('');
-      
+
       if (result.error) {
         // Address format validation error
         this.resolveError.set(result.error);

--- a/src/app/v2/shared/ui/input/checkbox/checkbox-input/checkbox-input.component.ts
+++ b/src/app/v2/shared/ui/input/checkbox/checkbox-input/checkbox-input.component.ts
@@ -1,9 +1,8 @@
-import { CommonModule } from '@angular/common';
 import { Component, input, output } from '@angular/core';
 
 @Component({
   selector: 'app-checkbox-input',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './checkbox-input.component.html',
   styleUrl: './checkbox-input.component.scss',
 })

--- a/src/app/v2/shared/ui/input/radio/radio-input/radio-input.component.ts
+++ b/src/app/v2/shared/ui/input/radio/radio-input/radio-input.component.ts
@@ -1,10 +1,9 @@
-import { CommonModule } from '@angular/common';
 import { Component, input, output } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-radio-input',
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './radio-input.component.html',
   styleUrl: './radio-input.component.scss',
 })

--- a/src/app/v2/shared/ui/kc-labeled-tabs/kc-labeled-tabs.component.ts
+++ b/src/app/v2/shared/ui/kc-labeled-tabs/kc-labeled-tabs.component.ts
@@ -1,5 +1,4 @@
 import { Component, computed, input, output } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 export interface TabItem {
   id: string;
@@ -9,25 +8,25 @@ export interface TabItem {
 
 @Component({
   selector: 'kc-labeled-tabs',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './kc-labeled-tabs.component.html',
   styleUrl: './kc-labeled-tabs.component.scss',
 })
 export class KcLabeledTabsComponent {
   tabs = input.required<TabItem[]>();
   selectedTabId = input<string>('');
-  
+
   selectedTabChange = output<string>();
 
   selectedTab = computed(() => {
     const tabs = this.tabs();
     const selectedId = this.selectedTabId();
-    
+
     if (!selectedId && tabs.length > 0) {
       return tabs[0];
     }
-    
-    return tabs.find(tab => tab.id === selectedId) || tabs[0];
+
+    return tabs.find((tab) => tab.id === selectedId) || tabs[0];
   });
 
   onTabClick(tabId: string) {
@@ -39,4 +38,4 @@ export class KcLabeledTabsComponent {
   isSelected(tabId: string): boolean {
     return this.selectedTab()?.id === tabId;
   }
-} 
+}

--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -1,7 +1,19 @@
-import { bootstrapApplication, BootstrapContext } from '@angular/platform-browser';
+import { provideZoneChangeDetection } from '@angular/core';
+import {
+  bootstrapApplication,
+  BootstrapContext,
+} from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { config } from './app/core/app.config.server';
 
-const bootstrap = (context: BootstrapContext) => bootstrapApplication(AppComponent, config, context);
+const bootstrap = (context: BootstrapContext) =>
+  bootstrapApplication(
+    AppComponent,
+    {
+      ...config,
+      providers: [provideZoneChangeDetection(), ...config.providers],
+    },
+    context,
+  );
 
 export default bootstrap;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"]
+    "useDefineForClassFields": false
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Summary
- Framework-only upgrade from Angular 20 to Angular 21 via `ng update @angular/core@21 @angular/cli@21` and `ng update @angular/cdk@21`, kept in dedicated schematics-generated commits.
- Mandatory schematic removed unnecessary `CommonModule` imports across 115 standalone components (Angular 21 no longer requires it for built-in directives/pipes).
- Bumps `angularx-qrcode` to `^21.0.5` and the old `@kaspacom/ui`/`kaspacom-ui` nested-Angular `overrides` (introduced in #265) to Angular 21 versions.
- Fixes one real breaking type-check error from the accompanying TypeScript 5.9 bump: `crypto.subtle.deriveKey`'s `salt` param needed an explicit `Uint8Array<ArrayBuffer>` annotation now that `Uint8Array` is generic over `ArrayBufferLike`.
- No optional migrations applied (e.g. `router-current-navigation`) — reserved for the "new Angular syntax" PR later in this stack.

Stacked on #265 (1/9). Part of the 9-PR Angular 19 → 21 + UI-kit migration stack. This is PR 2/9.

## Test plan
- [x] `ng build --configuration production` succeeds
- [x] `ng test` — 44/44 specs pass
- [ ] Manual smoke test in browser (not done in this session — flag if needed before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
