### PR TITLE
5/9 - Migrate KcBaseModalComponent to KcDialogComponent

### DIFF
--- a/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.html
+++ b/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.html
@@ -1,10 +1,5 @@
-@if (open()) {
-  <kc-base-modal
-    title="Settings"
-    [showCloseButton]="true"
-    [autoWidth]="false"
-    (close)="onClose()"
-  >
+<kc-dialog>
+  <ng-template #contentTemplate>
     <div class="settings-content" [formGroup]="settingsForm">
       <div class="form-field">
         <div class="slippage-row">
@@ -74,5 +69,5 @@
         (buttonClick)="onSave()"
       />
     </div>
-  </kc-base-modal>
-}
+  </ng-template>
+</kc-dialog>

--- a/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.scss
+++ b/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.scss
@@ -1,31 +1,3 @@
-:host {
-    ::ng-deep {
-        kc-base-modal {
-            .modal-container {
-                background-color: var(--vampire-black, #0d1316) !important;
-                border-color: var(--border-color, #1a2025) !important;
-            }
-
-            .modal-header {
-                background-color: var(--vampire-black, #0d1316) !important;
-                border-bottom-color: var(--border-color, #1a2025) !important;
-            }
-
-            .modal-title-text {
-                color: var(--color-text-primary, #fff) !important;
-            }
-
-            .modal-content {
-                background-color: var(--vampire-black, #0d1316) !important;
-            }
-
-            .close-button kc-icon {
-                color: var(--gray-60, #aaa) !important;
-            }
-        }
-    }
-}
-
 .settings-content {
     display: flex;
     flex-direction: column;
@@ -49,7 +21,7 @@
     align-items: flex-end;
     gap: 12px;
 
-    kc-input {
+    kc-number-input {
         flex: 1;
     }
 }

--- a/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.ts
+++ b/src/app/v2/pages/app/flows/swap/components/swap-settings-modal/swap-settings-modal.component.ts
@@ -1,12 +1,5 @@
-import {
-  Component,
-  computed,
-  inject,
-  OnChanges,
-  SimpleChanges,
-  input,
-  output,
-} from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 
 import {
   ReactiveFormsModule,
@@ -14,17 +7,27 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { KcBaseModalComponent } from 'kaspacom-ui';
-import { KcNumberInputComponent, KcButtonComponent } from '@kaspacom/ui-kit';
+import {
+  KcDialogComponent,
+  KcNumberInputComponent,
+  KcButtonComponent,
+} from '@kaspacom/ui-kit';
 import { FormErrorMessageComponent } from '../../../../../../shared/components/form-error/form-error.component';
 import type { SwapSettings } from '@kaspacom/swap-sdk';
+
+export interface SwapSettingsDialogData {
+  // Reserved keys read by KcDialogComponent itself off the same DIALOG_DATA.
+  title?: string;
+  showCloseButton?: boolean;
+  initialSettings?: Partial<SwapSettings>;
+}
 
 @Component({
   selector: 'app-swap-settings-modal',
   standalone: true,
   imports: [
     ReactiveFormsModule,
-    KcBaseModalComponent,
+    KcDialogComponent,
     KcNumberInputComponent,
     KcButtonComponent,
     FormErrorMessageComponent,
@@ -32,13 +35,12 @@ import type { SwapSettings } from '@kaspacom/swap-sdk';
   templateUrl: './swap-settings-modal.component.html',
   styleUrl: './swap-settings-modal.component.scss',
 })
-export class SwapSettingsModalComponent implements OnChanges {
+export class SwapSettingsModalComponent {
   private fb = inject(FormBuilder);
-
-  readonly open = input(false);
-  readonly initialSettings = input<Partial<SwapSettings>>();
-  readonly close = output<void>();
-  readonly save = output<SwapSettings>();
+  private dialogRef = inject(DialogRef<SwapSettings | undefined>);
+  private data = inject<SwapSettingsDialogData>(DIALOG_DATA, {
+    optional: true,
+  });
 
   settingsForm: FormGroup;
 
@@ -57,21 +59,11 @@ export class SwapSettingsModalComponent implements OnChanges {
   });
 
   constructor() {
-    this.settingsForm = this.createForm('0.5', '20');
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['initialSettings'] || changes['open']) {
-      const initialSettings = this.initialSettings();
-      if (this.open() && initialSettings) {
-        const maxSlippageValue = initialSettings.maxSlippage || '0.5';
-        const swapDeadlineValue = String(initialSettings.swapDeadline || 20);
-        this.settingsForm = this.createForm(
-          maxSlippageValue,
-          swapDeadlineValue,
-        );
-      }
-    }
+    const initialSettings = this.data?.initialSettings;
+    this.settingsForm = this.createForm(
+      initialSettings?.maxSlippage || '0.5',
+      String(initialSettings?.swapDeadline || 20),
+    );
   }
 
   private createForm(maxSlippage: string, swapDeadline: string): FormGroup {
@@ -99,7 +91,7 @@ export class SwapSettingsModalComponent implements OnChanges {
 
   onSave() {
     if (this.settingsForm.valid) {
-      this.save.emit({
+      this.dialogRef.close({
         maxSlippage: this.settingsForm.get('maxSlippage')?.value,
         swapDeadline: parseInt(
           this.settingsForm.get('swapDeadline')?.value,
@@ -107,9 +99,5 @@ export class SwapSettingsModalComponent implements OnChanges {
         ),
       });
     }
-  }
-
-  onClose() {
-    this.close.emit();
   }
 }

--- a/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.html
+++ b/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.html
@@ -1,10 +1,5 @@
-@if (open()) {
-  <kc-base-modal
-    title="Select a token"
-    [showCloseButton]="true"
-    [autoWidth]="false"
-    (close)="onClose()"
-  >
+<kc-dialog>
+  <ng-template #contentTemplate>
     <div class="token-selector-content">
       <kc-input
         placeholder="Search name, symbol, or address"
@@ -342,5 +337,5 @@
         }
       </div>
     </div>
-  </kc-base-modal>
-}
+  </ng-template>
+</kc-dialog>

--- a/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.scss
+++ b/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.scss
@@ -1,33 +1,3 @@
-:host {
-  ::ng-deep {
-    kc-base-modal {
-      .modal-container {
-        background-color: var(--vampire-black, #0d1316) !important;
-        border-color: var(--border-color, #1a2025) !important;
-        width: 520px !important;
-        max-width: 95vw !important;
-      }
-
-      .modal-header {
-        background-color: var(--vampire-black, #0d1316) !important;
-        border-bottom-color: var(--border-color, #1a2025) !important;
-      }
-
-      .modal-title-text {
-        color: var(--color-text-primary, #fff) !important;
-      }
-
-      .modal-content {
-        background-color: var(--vampire-black, #0d1316) !important;
-      }
-
-      .close-button kc-icon {
-        color: var(--gray-60, #aaa) !important;
-      }
-    }
-  }
-}
-
 .token-selector-content {
   display: flex;
   flex-direction: column;

--- a/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.ts
+++ b/src/app/v2/pages/app/flows/swap/components/token-selector-modal/token-selector-modal.component.ts
@@ -2,17 +2,21 @@ import {
   Component,
   OnInit,
   inject,
-  input,
   signal,
   computed,
   effect,
   untracked,
   DestroyRef,
-  output,
+  Signal,
 } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 
-import { KcBaseModalComponent } from 'kaspacom-ui';
-import { KcInputComponent, KcIconComponent, KcTooltipDirective } from '@kaspacom/ui-kit';
+import {
+  KcDialogComponent,
+  KcInputComponent,
+  KcIconComponent,
+  KcTooltipDirective,
+} from '@kaspacom/ui-kit';
 import { MessagePopupService } from '../../../../../../../services/message-popup.service';
 import type { Erc20Token } from '@kaspacom/swap-sdk';
 import { CommaFormatterPipe } from '../../../../../../../pipes/comma-formatter.pipe';
@@ -47,11 +51,20 @@ function isLocalStorageAvailable(): boolean {
   }
 }
 
+export interface TokenSelectorDialogData {
+  // Reserved keys read by KcDialogComponent itself off the same DIALOG_DATA.
+  title?: string;
+  showCloseButton?: boolean;
+  tokens: Signal<Erc20Token[]>;
+  isLoading: Signal<boolean>;
+  excludedToken: Signal<Erc20Token | null>;
+}
+
 @Component({
   selector: 'app-token-selector-modal',
   standalone: true,
   imports: [
-    KcBaseModalComponent,
+    KcDialogComponent,
     KcInputComponent,
     KcIconComponent,
     KcTooltipDirective,
@@ -66,6 +79,8 @@ export class TokenSelectorModalComponent implements OnInit {
   private defiApiService = inject(KaspaComDefiApiService);
   private chainManager = inject(EthereumWalletChainManager);
   private destroyRef = inject(DestroyRef);
+  private dialogRef = inject(DialogRef<Erc20Token | undefined>);
+  private data = inject<TokenSelectorDialogData>(DIALOG_DATA);
 
   hasChain = computed(() => !!this.chainManager.getCurrentChainSignal()());
 
@@ -104,12 +119,9 @@ export class TokenSelectorModalComponent implements OnInit {
     return `${HISTORY_STORAGE_KEY_PREFIX}-${network}-${env}`;
   });
 
-  open = input(false);
-  isLoading = input(false);
-  tokens = input<Erc20Token[]>([]);
-  excludedToken = input<Erc20Token | null>(null);
-  readonly close = output<void>();
-  readonly selectToken = output<Erc20Token>();
+  tokens = this.data.tokens;
+  isLoading = this.data.isLoading;
+  excludedToken = this.data.excludedToken;
 
   // Search state
   searchQuery = signal('');
@@ -126,56 +138,34 @@ export class TokenSelectorModalComponent implements OnInit {
   private destroyed = false;
   private searchRequestId = 0;
   private mostTradedRequestId = 0;
-  // Track which chain the cached mostTradedTokens were fetched for.
-  private mostTradedChainId: string | undefined = undefined;
+  private isFirstChainLoad = true;
 
   constructor() {
-    // Reload when the modal opens so timing issues on initial mount don't leave
-    // the section empty (the component is always in the DOM, ngOnInit fires once).
+    // Loads chain-scoped state on mount (the dialog only exists while open,
+    // so mount = open) and again whenever the chain changes while it stays
+    // open. On the first (mount) run the search box is cleared for a fresh
+    // start; on later chain-change runs, whatever the user typed is kept
+    // and re-searched against the new chain.
     effect(() => {
-      const isOpen = this.open();
+      const chainId = this.chainManager.getCurrentChainSignal()();
       untracked(() => {
-        if (!isOpen) {
-          if (this.searchDebounceTimer) {
-            clearTimeout(this.searchDebounceTimer);
-            this.searchDebounceTimer = null;
-          }
-          this.searchRequestId++;
-          this.mostTradedRequestId++;
-          this.mostTradedLoading.set(false);
-          this.searchResults.set([]);
-          this.searchLoading.set(false);
-          return;
-        }
-        this.searchQuery.set('');
-        this.searchResults.set([]);
+        const isFirstLoad = this.isFirstChainLoad;
+        this.isFirstChainLoad = false;
+
         if (this.searchDebounceTimer) {
           clearTimeout(this.searchDebounceTimer);
           this.searchDebounceTimer = null;
         }
-        this.loadSearchHistory();
-        const currentChainId = this.chainManager.getCurrentChainSignal()();
-        if (currentChainId) {
-          const chainChanged = currentChainId !== this.mostTradedChainId;
-          if (
-            (!this.mostTradedTokens().length || chainChanged) &&
-            !this.mostTradedLoading()
-          ) {
-            this.loadMostTradedTokens();
-          }
-        }
-      });
-    });
 
-    // When the chain changes while the modal is already open, refresh chain-scoped state.
-    effect(() => {
-      const chainId = this.chainManager.getCurrentChainSignal()();
-      untracked(() => {
-        if (!this.open()) return;
+        if (isFirstLoad) {
+          this.searchQuery.set('');
+          this.searchResults.set([]);
+        }
         const currentQuery = this.searchQuery().trim();
+
         this.resetChainScopedState();
-        if (!chainId) return;
         this.loadSearchHistory();
+        if (!chainId) return;
         this.loadMostTradedTokens();
         if (currentQuery) {
           const requestId = ++this.searchRequestId;
@@ -197,7 +187,6 @@ export class TokenSelectorModalComponent implements OnInit {
     this.searchResults.set([]);
     this.searchHistory.set([]);
     this.mostTradedTokens.set([]);
-    this.mostTradedChainId = undefined;
   }
   // User's own tokens (sorted by balance, minus excluded)
   userTokens = computed(() => {
@@ -256,11 +245,7 @@ export class TokenSelectorModalComponent implements OnInit {
 
   async onTokenSelect(token: Erc20Token): Promise<void> {
     this.addToHistory(token);
-    this.selectToken.emit(token);
-  }
-
-  onClose(): void {
-    this.close.emit();
+    this.dialogRef.close(token);
   }
 
   async copyAddress(event: Event, address: string): Promise<void> {
@@ -447,7 +432,6 @@ export class TokenSelectorModalComponent implements OnInit {
 
       if (!this.destroyed && requestId === this.mostTradedRequestId) {
         this.mostTradedTokens.set(Array.from(uniqueTokens.values()));
-        this.mostTradedChainId = chainIdAtFetch;
       }
     } catch (err) {
       console.warn('[TokenSelector] Failed to load most traded tokens:', err);

--- a/src/app/v2/pages/app/flows/swap/swap-flow-page.component.html
+++ b/src/app/v2/pages/app/flows/swap/swap-flow-page.component.html
@@ -6,7 +6,7 @@
       <span class="swap-title">Swap</span>
       <button
         class="settings-btn"
-        (click)="settingsOpen.set(true)"
+        (click)="openSettingsModal()"
         title="Settings"
       >
         <kc-icon [iconClass]="'icon-settings'" [size]="'sm'" />
@@ -162,20 +162,4 @@
       (buttonClick)="executeSwap()"
     />
   </div>
-
-  <app-token-selector-modal
-    [open]="!!tokenModalOpen()"
-    [tokens]="allTokens()"
-    [isLoading]="loadingTokens()"
-    [excludedToken]="tokenModalOpen() === 'from' ? toToken() : fromToken()"
-    (close)="tokenModalOpen.set(null)"
-    (selectToken)="onTokenSelect($event)"
-  />
-
-  <app-swap-settings-modal
-    [open]="settingsOpen()"
-    [initialSettings]="currentSettings()"
-    (close)="settingsOpen.set(false)"
-    (save)="onSettingsSave($event)"
-  />
 </div>

--- a/src/app/v2/pages/app/flows/swap/swap-flow-page.component.ts
+++ b/src/app/v2/pages/app/flows/swap/swap-flow-page.component.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
 import { FormsModule } from '@angular/forms';
 import type {
   Erc20Token,
@@ -40,8 +41,14 @@ import { EthereumWalletActionsService } from '../../../../../services/etherium-s
 import { EthereumWalletChainManager } from '../../../../../services/etherium-services/etherium-wallet-chain.manager';
 import { WalletService } from '../../../../../services/wallet.service';
 import { SwapContextService } from '../../../../services/swap-context.service';
-import { SwapSettingsModalComponent } from './components/swap-settings-modal/swap-settings-modal.component';
-import { TokenSelectorModalComponent } from './components/token-selector-modal/token-selector-modal.component';
+import {
+  SwapSettingsModalComponent,
+  SwapSettingsDialogData,
+} from './components/swap-settings-modal/swap-settings-modal.component';
+import {
+  TokenSelectorModalComponent,
+  TokenSelectorDialogData,
+} from './components/token-selector-modal/token-selector-modal.component';
 import {
   KAS_NATIVE_FEE_RESERVE,
   WALLET_APP_ID,
@@ -54,8 +61,6 @@ import {
     FormsModule,
     KcButtonComponent,
     KcIconComponent,
-    TokenSelectorModalComponent,
-    SwapSettingsModalComponent,
     CommaFormatterPipe,
     TokenLogoComponent,
   ],
@@ -73,6 +78,7 @@ export class SwapFlowPageComponent implements OnInit, OnDestroy {
   private ethereumWalletActionsService = inject(EthereumWalletActionsService);
   private swapContextService = inject(SwapContextService);
   private assetsManagerService = inject(AssetsManagerService);
+  private dialog = inject(Dialog);
 
   private readonly nativeTokenAddress =
     '0x0000000000000000000000000000000000000000';
@@ -92,7 +98,6 @@ export class SwapFlowPageComponent implements OnInit, OnDestroy {
 
   // Modals
   tokenModalOpen = signal<'from' | 'to' | null>(null);
-  settingsOpen = signal(false);
 
   // Internal State
   currentIsOutput = signal(false);
@@ -507,22 +512,43 @@ export class SwapFlowPageComponent implements OnInit, OnDestroy {
 
   openTokenModal(type: 'from' | 'to') {
     this.tokenModalOpen.set(type);
+    const excludedToken = computed(() =>
+      type === 'from' ? this.toToken() : this.fromToken(),
+    );
+    this.dialog
+      .open<Erc20Token | undefined, TokenSelectorDialogData>(
+        TokenSelectorModalComponent,
+        {
+          width: '520px',
+          data: {
+            title: 'Select a token',
+            showCloseButton: true,
+            tokens: this.allTokens,
+            isLoading: this.loadingTokens,
+            excludedToken,
+          },
+        },
+      )
+      .closed.subscribe((token) => {
+        this.tokenModalOpen.set(null);
+        if (token) {
+          this.onTokenSelect(token, type);
+        }
+      });
   }
 
-  onTokenSelect(token: Erc20Token) {
-    const type = this.tokenModalOpen();
+  onTokenSelect(token: Erc20Token, type: 'from' | 'to') {
     if (type === 'from') {
       if (this.toToken()?.address === token.address) {
         this.toToken.set(this.fromToken());
       }
       this.fromToken.set(token);
-    } else if (type === 'to') {
+    } else {
       if (this.fromToken()?.address === token.address) {
         this.fromToken.set(this.toToken());
       }
       this.toToken.set(token);
     }
-    this.tokenModalOpen.set(null);
 
     // Update with current input
     this.updateControllerAmount(this.fromAmountInput(), false);
@@ -558,6 +584,25 @@ export class SwapFlowPageComponent implements OnInit, OnDestroy {
     this.onFromAmountChange(amount);
   }
 
+  openSettingsModal() {
+    this.dialog
+      .open<SwapSettings | undefined, SwapSettingsDialogData>(
+        SwapSettingsModalComponent,
+        {
+          data: {
+            title: 'Settings',
+            showCloseButton: true,
+            initialSettings: this.currentSettings(),
+          },
+        },
+      )
+      .closed.subscribe((settings) => {
+        if (settings) {
+          this.onSettingsSave(settings);
+        }
+      });
+  }
+
   onSettingsSave(settings: SwapSettings) {
     this.currentSettings.set(settings);
     this.controller()?.setData({
@@ -566,7 +611,6 @@ export class SwapFlowPageComponent implements OnInit, OnDestroy {
         ...settings,
       },
     });
-    this.settingsOpen.set(false);
   }
 
   async executeSwap() {


### PR DESCRIPTION
## Summary
Migrates the last two `Kc*` usages left on the old library — `swap-settings-modal` and `token-selector-modal` — from `KcBaseModalComponent` to `@kaspacom/ui-kit`'s `KcDialogComponent`. Split out from PR 4/9 into its own PR because this is a real architecture change, not a prop-rename: the new dialog is a CDK `Dialog`-service-based component (`Dialog.open()` + `DialogRef`), not a declarative wrapper shown/hidden via an `[open]` input.

- Both modal components now wrap `<kc-dialog><ng-template #contentTemplate>...</ng-template></kc-dialog>`, read their initial data via `DIALOG_DATA`, and close via `DialogRef.close(result)` instead of `@Output` emitters. `title`/`showCloseButton` move from component `@Input`s to the same `DIALOG_DATA` object (`KcDialogComponent`'s own reserved keys read off that data).
- `TokenSelectorModalComponent`'s `tokens`/`isLoading`/`excludedToken` were live-updating `@Input`s from the parent while the modal stayed open. Since `DIALOG_DATA` is a static snapshot taken at `open()` time, these are now passed as the parent's actual `Signal` references (not their current values), so the modal keeps reading them reactively via `data.tokens()` etc. without needing a live binding.
- That component's two `effect()`s (one gated on `open()` for initial load, one for reacting to chain changes while open) merged into one: since the component now only exists while the dialog is open, "mount" and "the open-branch of the old effect" are the same event. An `isFirstChainLoad` flag preserves the old distinction between fresh-open behavior (clear the search box) and later in-session chain-change behavior (keep the query, re-search).
- `swap-flow-page.component.ts` opens both via `this.dialog.open(...)` and subscribes to `.closed` instead of rendering the modals inline with `[open]` bindings.
- Removed dead `::ng-deep kc-base-modal {...}` style overrides in both modals' scss (targeted the old modal's internal class names, which no longer exist) and fixed one selector left over from the kc-input → kc-number-input migration (PR 4) that no longer matched anything.

After this PR, `kaspacom-ui`/`@kaspacom/ui` are only used for `NotificationService`/`KcSnackbarComponent` (20 + 2 usages) — that's step 7 (notification system replacement).

Stacked on #268 (4/9). Part of the 9-PR Angular 19 → 21 + UI-kit migration stack. This is PR 5/9.

## Test plan
- [x] `ng build --configuration production` succeeds
- [x] `ng test` — 44/44 specs pass
- [ ] Manual smoke test in browser (not done in this session — **strongly recommend testing before merge**: this rewrites dialog open/close plumbing and a moderately complex reactive-effects component; test opening/closing both dialogs, picking a token, changing chain while the token dialog is open, and saving swap settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)