### PR TITLE
KCW-88 - Polish Wallet UI and Covenants View

### DIFF
--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
@@ -5,7 +5,7 @@
   width: 100%;
   min-height: 0;
   color: var(--text-primary, #ffffff);
-  font-family: 'Poppins', 'Roboto', sans-serif;
+  font-family: "Poppins", "Roboto", sans-serif;
   padding: 32px 20px 20px 20px;
   // Remove overflow-y: auto to prevent double scroll
   // Let the parent flow-page-body handle all scrolling
@@ -17,7 +17,7 @@
   text-align: center;
   margin-bottom: 32px;
   animation: fadeInUp 0.6s ease-out;
-  
+
   // Apply gradient text to the success title
   .success-title {
     background: var(--gradient-1);
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   .success-icon {
     width: 334px;
     height: 226px;
@@ -62,7 +62,7 @@
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.3s ease;
-  
+
   &:hover {
     border-color: rgba(111, 199, 186, 0.3);
     background: rgba(255, 255, 255, 0.05);
@@ -74,7 +74,7 @@
   align-items: center;
   gap: 12px;
   flex: 1;
-  
+
   .spoiler-label {
     font-size: 0.9rem;
     color: var(--text-secondary, #a0a0a0);
@@ -86,7 +86,7 @@
   display: flex;
   align-items: center;
   transition: transform 0.3s ease;
-  
+
   kc-icon {
     transition: transform 0.3s ease;
   }
@@ -145,7 +145,7 @@
 
   .detail-value {
     color: var(--text-primary, #ffffff);
-    font-family: 'SF Mono', 'Monaco', monospace;
+    font-family: "SF Mono", "Monaco", monospace;
     font-size: 0.85rem;
     text-align: right;
     flex: 1;
@@ -226,18 +226,17 @@
   }
 }
 
-
 // High contrast mode support
 @media (prefers-contrast: high) {
   .details-grid {
     border-color: #6fc7ba;
   }
-  
+
   .detail-item {
     border-bottom-color: rgba(111, 199, 186, 0.3);
   }
-  
+
   .details-spoiler-toggle {
     border-color: #6fc7ba;
   }
-} 
+}

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
@@ -163,6 +163,13 @@
   animation: fadeInUp 0.6s ease-out 0.4s both;
 }
 
+.pending-confirmation-message {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  text-align: center;
+  color: var(--text-secondary, #a0a0a0);
+}
+
 // Animations
 @keyframes fadeInUp {
   from {

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -84,11 +84,17 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
 
       <!-- Action Button -->
       <div class="action-button">
+        @if (pendingConfirmationMessage()) {
+          <p class="pending-confirmation-message">
+            {{ pendingConfirmationMessage() }}
+          </p>
+        }
         <kc-button
-          [text]="'Done'"
+          [text]="isAwaitingConfirmation() ? 'Confirming...' : 'Done'"
           variant="primary"
           size="m"
           [isFullWidth]="true"
+          [isDisabled]="isAwaitingConfirmation()"
           (buttonClick)="onDone()"
           class="done-button"
         />
@@ -149,6 +155,25 @@ export class ApprovalSuccessPageComponent {
   actionDisplay = computed(() =>
     this.completedActionOverviewService.getActionDisplay(this.actionResult()),
   );
+
+  /**
+   * Covenant actions (TopUp, withdraw, keepAlive, etc.) resolve as "success"
+   * here well before the covenant indexer's own listing catches up — closing
+   * this page immediately let the user land on "My Contracts" while it still
+   * showed the pre-action amount. The contracts page mirrors its indexer poll
+   * into ApprovalFlowService.pendingConfirmation; only gate on it for
+   * covenant actions, since every other action type never sets it.
+   */
+  isAwaitingConfirmation = computed(
+    () =>
+      this.isCovenantActionResult(this.actionResult()) &&
+      this.approvalFlowService.pendingConfirmation()?.status === 'checking',
+  );
+
+  pendingConfirmationMessage = computed(() => {
+    if (!this.isCovenantActionResult(this.actionResult())) return null;
+    return this.approvalFlowService.pendingConfirmation()?.message ?? null;
+  });
 
   toggleDetails() {
     this.showDetails = !this.showDetails;

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2273,26 +2273,43 @@
                 (qrClick)="onInteractOutputQrClick()"
               ></app-address-smart-input>
             </div>
-            <div class="form-group flex column gap-8">
-              <kc-number-input
-                [label]="'Withdraw amount (KAS)'"
-                [placeholder]="'0'"
-                [min]="'0'"
-                [isDisabled]="isInteracting()"
-                [ngModel]="interactOutputAmount"
-                (valueChange)="onInteractOutputAmountChange($event)"
+            @if (isDmsClaim()) {
+              <div
+                class="p-12 rounded-lg"
+                style="
+                  background: rgba(111, 199, 186, 0.08);
+                  border: 1px solid rgba(111, 199, 186, 0.2);
+                "
               >
-                <div
-                  (click)="!isInteracting() && fillMaxOutputAmount()"
-                  [class]="
-                    isInteracting() ? 'max-text disabled' : 'max-text clickable'
-                  "
-                  rightSideSlot
+                <span class="text-gray-75 typo-text-2"
+                  >Claiming sends the entire contract balance to this address
+                  — Dead Man's Switch claims can't be partial.</span
                 >
-                  <span>Max</span>
-                </div>
-              </kc-number-input>
-            </div>
+              </div>
+            } @else {
+              <div class="form-group flex column gap-8">
+                <kc-number-input
+                  [label]="'Withdraw amount (KAS)'"
+                  [placeholder]="'0'"
+                  [min]="'0'"
+                  [isDisabled]="isInteracting()"
+                  [ngModel]="interactOutputAmount"
+                  (valueChange)="onInteractOutputAmountChange($event)"
+                >
+                  <div
+                    (click)="!isInteracting() && fillMaxOutputAmount()"
+                    [class]="
+                      isInteracting()
+                        ? 'max-text disabled'
+                        : 'max-text clickable'
+                    "
+                    rightSideSlot
+                  >
+                    <span>Max</span>
+                  </div>
+                </kc-number-input>
+              </div>
+            }
           }
 
           @if (
@@ -2364,7 +2381,7 @@
           }
         }
 
-        @if (parsedInteractContract()) {
+        @if (parsedInteractContract() && contractHasMultiSigFunction()) {
           <details class="advanced-section">
             <summary>Complete co-signer transaction</summary>
             <div class="adv-body">

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2418,6 +2418,16 @@
                       ></app-copy-button>
                     </div>
                   </div>
+                  @if (interactIndexerState()) {
+                    <div class="flex column gap-4">
+                      <span class="text-gray-60 typo-text-1"
+                        >Indexer status</span
+                      >
+                      <span class="text-white typo-text-2">{{
+                        interactIndexerState()!.message
+                      }}</span>
+                    </div>
+                  }
                 </div>
               }
             </div>
@@ -2451,6 +2461,14 @@
                 ></app-copy-button>
               </div>
             </div>
+            @if (interactIndexerState()) {
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-1">Indexer status</span>
+                <span class="text-white typo-text-2">{{
+                  interactIndexerState()!.message
+                }}</span>
+              </div>
+            }
           </div>
         }
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -353,7 +353,9 @@
                     <div class="flex column gap-4">
                       <kc-input
                         [label]="field.label"
-                        [placeholder]="'Paste address, public key, or 32-byte hash'"
+                        [placeholder]="
+                          'Paste address, public key, or 32-byte hash'
+                        "
                         [type]="'text'"
                         [isValid]="isTemplateFieldValid(field)"
                         [isDisabled]="isDeploying()"
@@ -1027,7 +1029,7 @@
                       }}</span>
                       @if (
                         contract.covenantId &&
-                        getCovenantExplorerLink(contract.covenantId);
+                          getCovenantExplorerLink(contract.covenantId);
                         as covenantLink
                       ) {
                         <a
@@ -1041,7 +1043,9 @@
                       } @else {
                         <span
                           class="card-id-value"
-                          [title]="contract.covenantId || contract.currentAddress"
+                          [title]="
+                            contract.covenantId || contract.currentAddress
+                          "
                           >{{
                             truncate(
                               contract.covenantId ||
@@ -1334,7 +1338,10 @@
                   <div class="identifier">
                     <span class="identifier-label">Covenant ID</span>
                     <div class="identifier-value-row">
-                      @if (getCovenantExplorerLink(covenantId); as covenantLink) {
+                      @if (
+                        getCovenantExplorerLink(covenantId);
+                        as covenantLink
+                      ) {
                         <a
                           class="identifier-value"
                           [href]="covenantLink"
@@ -1428,9 +1435,7 @@
                                 [size]="'sm'"
                               ></kc-icon>
                               <span class="ai-text">
-                                <span class="ai-title">{{
-                                  action.label
-                                }}</span>
+                                <span class="ai-title">{{ action.label }}</span>
                                 <span class="ai-hint">{{
                                   action.enabled
                                     ? action.description
@@ -1465,8 +1470,7 @@
                               />
                             </svg>
                             <span class="ai-text"
-                              ><span class="ai-title"
-                                >Manual interaction</span
+                              ><span class="ai-title">Manual interaction</span
                               ><span class="ai-hint"
                                 >This contract type has no curated actions —
                                 choose a function and sign manually</span
@@ -1489,17 +1493,16 @@
                   >
                     <h4
                       class="text-yellow"
-                      style="
-                        margin: 0 0 8px;
-                        font-size: 14px;
-                        font-weight: 600;
-                      "
+                      style="margin: 0 0 8px; font-size: 14px; font-weight: 600"
                     >
                       Pending signature
                     </h4>
-                    <p class="text-gray-75 typo-text-2" style="margin: 0 0 12px">
-                      Your signature has been added. Copy this JSON and send
-                      it to the co-signer to complete the transaction.
+                    <p
+                      class="text-gray-75 typo-text-2"
+                      style="margin: 0 0 12px"
+                    >
+                      Your signature has been added. Copy this JSON and send it
+                      to the co-signer to complete the transaction.
                     </p>
                     <textarea
                       class="contract-input"
@@ -1771,9 +1774,7 @@
                       target="_blank"
                       rel="noopener noreferrer"
                       class="text-blue typo-text-2 text-mono"
-                      >{{
-                        truncate(indexerImportPreview()!.covenantId, 28)
-                      }}</a
+                      >{{ truncate(indexerImportPreview()!.covenantId, 28) }}</a
                     >
                   } @else {
                     <span class="text-white typo-text-2 text-mono">{{
@@ -2282,8 +2283,8 @@
                 "
               >
                 <span class="text-gray-75 typo-text-2"
-                  >Claiming sends the entire contract balance to this address
-                  — Dead Man's Switch claims can't be partial.</span
+                  >Claiming sends the entire contract balance to this address —
+                  Dead Man's Switch claims can't be partial.</span
                 >
               </div>
             } @else {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -129,7 +129,11 @@ type IndexerImportPreview = {
 
 type ContractDashboardSource = 'indexer' | 'local' | 'both';
 type ContractDashboardFilter =
-  'all' | 'deadman' | 'timelock' | 'multisig' | 'escrow';
+  | 'all'
+  | 'deadman'
+  | 'timelock'
+  | 'multisig'
+  | 'escrow';
 // Status dimension, composed on top of the template-type filter above.
 type ContractStatusFilter = 'all' | 'active' | 'history';
 
@@ -2194,8 +2198,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // scrollIntoView to leave room for it, without us having to guess
       // which ancestor is the actual scroll container.
       const headerHeight =
-        document.querySelector<HTMLElement>('.wrapper__header')
-          ?.offsetHeight ?? 0;
+        document.querySelector<HTMLElement>('.wrapper__header')?.offsetHeight ??
+        0;
       panel.style.scrollMarginTop = `${headerHeight + 12}px`;
       panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
@@ -3825,7 +3829,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         // reject it here with a clear message instead of letting it panic.
         if (amountToSellerSompi >= inputAmount) {
           this.interactError.set(
-            'Amount to seller must be less than the full contract balance. Arbitrate always pays out both sides, so the buyer\'s output can\'t be zero.',
+            "Amount to seller must be less than the full contract balance. Arbitrate always pays out both sides, so the buyer's output can't be zero.",
           );
           return;
         }
@@ -3970,10 +3974,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           return;
         }
         const withdrawalAmount = BigInt(Math.floor(outputAmountKas * 1e8));
-        if (
-          functionName === 'transfer' &&
-          compiled.contract_name === 'KCC20'
-        ) {
+        if (functionName === 'transfer' && compiled.contract_name === 'KCC20') {
           try {
             extraArgsOverride = {
               recipient: Uint8Array.from(

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -1362,7 +1362,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   /**
    * Load contracts from registry and check on-chain status
    */
-  async loadContracts() {
+  async loadContracts(options: { skipOnChainStatusRefresh?: boolean } = {}) {
     this.dashboardLoading.set(true);
     this.dashboardError.set(null);
     if (this.activeTab() !== 'detail') {
@@ -1373,8 +1373,14 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const filtered = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(filtered);
 
-    // Check on-chain status for each contract
-    await this.refreshContractStatuses(filtered);
+    // Check on-chain status for each contract. Skipped during action-indexing
+    // polling (trackActionIndexing()): the acted-on contract's status/amount
+    // is already applied optimistically to the local registry by the action
+    // itself, so repeating an RPC UTXO lookup across every local contract on
+    // each poll tick is redundant traffic, not new information.
+    if (!options.skipOnChainStatusRefresh) {
+      await this.refreshContractStatuses(filtered);
+    }
 
     const updatedLocal = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(updatedLocal);
@@ -3602,7 +3608,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         }
 
         if (seenSettled) {
-          await this.loadContracts();
+          await this.loadContracts({ skipOnChainStatusRefresh: true });
           if (this.dashboardCaughtUpWithLocal(registryEntryId)) {
             this.setActionIndexerState({
               txid,

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -136,11 +136,7 @@ type IndexerImportPreview = {
 
 type ContractDashboardSource = 'indexer' | 'local' | 'both';
 type ContractDashboardFilter =
-  | 'all'
-  | 'deadman'
-  | 'timelock'
-  | 'multisig'
-  | 'escrow';
+  'all' | 'deadman' | 'timelock' | 'multisig' | 'escrow';
 // Status dimension, composed on top of the template-type filter above.
 type ContractStatusFilter = 'all' | 'active' | 'history';
 
@@ -4975,7 +4971,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   shareableContractOptions = computed<DropdownOption[]>(() =>
     this.shareableContracts().map((contract) => ({
       value: contract.id,
-      label: `${contract.displayName}-${contract.covenantId}`,
+      label: `${contract.displayName} - ${contract.covenantId}`,
     })),
   );
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -2217,7 +2217,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     silent = false,
   ): Promise<boolean> {
     if (entry.registryEntry) {
-      const registryEntry = this.syncRegistryEntryForDashboardAction(entry);
+      const registryEntry =
+        await this.syncRegistryEntryForDashboardAction(entry);
+      if (requestToken !== this.detailRequestToken) return false;
       this.selectedContractId.set(registryEntry.id);
       this.selectContractFromRegistry();
       this.selectDefaultFunctionForContract(
@@ -2291,17 +2293,56 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return false;
   }
 
-  private syncRegistryEntryForDashboardAction(
+  /**
+   * detail.utxos comes from the indexer's getCovenantUtxos(), which can lag
+   * behind a very recent local action the same way listCovenants() does (see
+   * trackActionIndexing()). Trusting it blindly to move the registry's
+   * outpoint can clobber a correct, fresher local outpoint with a stale,
+   * already-spent one — the next spend then fails at broadcast time with
+   * "Covenant outpoint ... was not found". Check live via RPC whether the
+   * currently stored outpoint is still on-chain first; if it is, prefer it
+   * (and its live amount) over the indexer's possibly-stale UTXO.
+   */
+  private async findLiveContractUtxo(
+    registryEntry: ContractRegistryEntry,
+  ): Promise<{ amountSompi: string } | undefined> {
+    const rpc = this.rpcService.getRpc();
+    if (!rpc) return undefined;
+    try {
+      const response = await rpc.getUtxosByAddresses([
+        registryEntry.contractAddress,
+      ]);
+      const utxos = response.entries || [];
+      const found = utxos.find(
+        (u: any) =>
+          u.outpoint?.transactionId === registryEntry.outpoint.txid &&
+          Number(u.outpoint?.index ?? -1) === registryEntry.outpoint.vout,
+      );
+      return found ? { amountSompi: found.amount.toString() } : undefined;
+    } catch (err) {
+      console.warn('[Contracts] Live outpoint check failed:', err);
+      return undefined;
+    }
+  }
+
+  private async syncRegistryEntryForDashboardAction(
     entry: ContractDashboardEntry,
-  ): ContractRegistryEntry {
+  ): Promise<ContractRegistryEntry> {
     const registryEntry = entry.registryEntry!;
+    const liveUtxo = await this.findLiveContractUtxo(registryEntry);
+
     const detail = this.selectedDetail();
-    const activeUtxo = detail?.utxos.length === 1 ? detail.utxos[0] : undefined;
+    const indexerUtxo =
+      !liveUtxo && detail?.utxos.length === 1 ? detail.utxos[0] : undefined;
+
     const amountSompi = String(
-      activeUtxo?.amountSompi ?? entry.amountSompi ?? registryEntry.amountSompi,
+      liveUtxo?.amountSompi ??
+        indexerUtxo?.amountSompi ??
+        entry.amountSompi ??
+        registryEntry.amountSompi,
     );
     const contractAddress =
-      activeUtxo?.address ||
+      indexerUtxo?.address ||
       entry.currentAddress ||
       registryEntry.contractAddress;
 
@@ -2319,10 +2360,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           : registryEntry.status,
     };
 
-    if (activeUtxo?.txidHex && activeUtxo.vout !== undefined) {
+    if (indexerUtxo?.txidHex && indexerUtxo.vout !== undefined) {
       updates.outpoint = {
-        txid: activeUtxo.txidHex,
-        vout: Number(activeUtxo.vout),
+        txid: indexerUtxo.txidHex,
+        vout: Number(indexerUtxo.vout),
       };
     }
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -4975,7 +4975,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   shareableContractOptions = computed<DropdownOption[]>(() =>
     this.shareableContracts().map((contract) => ({
       value: contract.id,
-      label: contract.displayName,
+      label: `${contract.displayName}-${contract.covenantId}`,
     })),
   );
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -2210,7 +2210,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       const registryEntry = this.syncRegistryEntryForDashboardAction(entry);
       this.selectedContractId.set(registryEntry.id);
       this.selectContractFromRegistry();
-      this.selectDefaultFunctionForContract(entry.contractName);
+      this.selectDefaultFunctionForContract(
+        entry.contractName,
+        entry.participants,
+      );
       return true;
     }
 
@@ -2255,7 +2258,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       if (imported) {
         this.selectedContractId.set(imported.id);
         this.selectContractFromRegistry();
-        this.selectDefaultFunctionForContract(entry.contractName);
+        this.selectDefaultFunctionForContract(
+          entry.contractName,
+          entry.participants,
+        );
         if (!silent) {
           this.activeTab.set('detail');
           this.detailPanelTab.set('action');
@@ -2660,7 +2666,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return null;
   }
 
-  private selectDefaultFunctionForContract(contractName: string) {
+  private selectDefaultFunctionForContract(
+    contractName: string,
+    participants: Array<{ label: string; value: string }> = [],
+  ) {
     const normalized = this.normalizeContractName(contractName);
     const preferred: Record<string, string[]> = {
       DeadManSwitch: ['keepAlive', 'changeHeir', 'topUp', 'claim'],
@@ -2668,11 +2677,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       MultiSigVault: ['spend12', 'spend13', 'spend23'],
       EscrowWithArbiter: ['release', 'refund', 'arbitrate'],
     };
+    let order = preferred[normalized] || [];
+    if (normalized === 'DeadManSwitch') {
+      // keepAlive/changeHeir/topUp are owner-only, but availableFunctions()
+      // isn't role-filtered, so they're always "available" here too — the
+      // heir clicking the dashboard's "Claim" action would otherwise silently
+      // land on "Keep alive" (first in the list above) instead of "Claim" —
+      // mirror getNextActionLabel()'s owner-vs-heir split so the selected
+      // function actually matches what the card told the user to expect.
+      if (!this.currentWalletRoles(participants).includes('Owner')) {
+        order = ['claim', ...order.filter((name) => name !== 'claim')];
+      }
+    }
     const available = this.availableFunctions();
     const target =
-      (preferred[normalized] || []).find((name) =>
-        available.some((fn) => fn.name === name),
-      ) || available[0]?.name;
+      order.find((name) => available.some((fn) => fn.name === name)) ||
+      available[0]?.name;
     if (target) this.selectFunction(target);
   }
 
@@ -3910,6 +3930,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           outputAddress,
         );
         return;
+      } else if (this.isDmsClaim()) {
+        // DMS claim always transfers the entire balance to the heir — there's
+        // no continuation output for a remainder to go to, since the
+        // Dead Man's Switch relationship ends once claimed. Ignore whatever
+        // amount the user may have typed and use the full input amount
+        // instead of routing through buildWithdrawalOutputs's partial path.
+        if (!outputAddress) {
+          this.interactError.set('Output address is required');
+          return;
+        }
+        outputs = [
+          {
+            address: outputAddress,
+            amount: inputAmount,
+          },
+        ];
       } else if (this.functionRequiresOutput(functionName)) {
         if (
           compiled.contract_name === 'DeadManSwitch' &&
@@ -4970,6 +5006,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Returns true when the current function is DMS claim. Claim always
+   * transfers the full balance to the heir — there's no continuation output,
+   * so unlike a regular withdrawal it can't be partial.
+   */
+  isDmsClaim(): boolean {
+    const contract = this.parsedInteractContract();
+    if (!contract || this.selectedFunction !== 'claim') return false;
+    return (contract.contract_name || '')
+      .toLowerCase()
+      .replace(/[\s_-]/g, '')
+      .includes('deadman');
+  }
+
+  /**
    * Check if the selected function requires multiple signers (two-phase signing)
    */
   isMultiSigFunction(fnName: string): boolean {
@@ -4978,6 +5028,19 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const abiEntry = contract.abi.find((e) => e.name === fnName);
     if (!abiEntry) return false;
     return abiEntry.inputs.filter((i) => i.type_name === 'sig').length > 1;
+  }
+
+  /**
+   * Whether this contract has *any* multi-sig entrypoint — gates the
+   * "Complete co-signer transaction" section, which is only relevant for
+   * contracts that can produce a partial spend in the first place (e.g. a
+   * plain Dead Man's Switch or single-sig Escrow release has nothing for a
+   * co-signer to complete).
+   */
+  contractHasMultiSigFunction(): boolean {
+    return this.availableFunctions().some((fn) =>
+      this.isMultiSigFunction(fn.name),
+    );
   }
 
   /**

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -78,7 +78,10 @@ import {
 } from '../../../../../types/wallet-action-result';
 import { FlowPagesService } from '../../../../services/flow-pages.service';
 import { WideWorkspaceService } from '../../../../services/wide-workspace.service';
-import { ApprovalFlowService } from '../../../../services/approval-flow.service';
+import {
+  ApprovalFlowService,
+  PendingActionConfirmation,
+} from '../../../../services/approval-flow.service';
 import { AddressSmartInputComponent } from '../../../../shared/ui/input/address-smart-input/address-smart-input.component';
 import { CovenantDateTimeInputComponent } from './covenant-date-time-input.component';
 import { WalletProfileOrbComponent } from '../../../../shared/ui/wallet-profile-orb/wallet-profile-orb.component';
@@ -180,6 +183,12 @@ type DeployIndexerState = {
   covenantId?: string;
 };
 
+type ActionIndexerState = {
+  txid: string;
+  status: 'checking' | 'indexed' | 'not-indexed' | 'unavailable';
+  message: string;
+};
+
 @Component({
   selector: 'app-contracts-page',
   imports: [
@@ -273,6 +282,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   } | null>(null);
   deployIndexerState = signal<DeployIndexerState | null>(null);
   deployError = signal<string | null>(null);
+  interactIndexerState = signal<ActionIndexerState | null>(null);
   isDeploying = signal(false);
 
   // Computed parsed contract from deploy JSON
@@ -2441,6 +2451,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.selectedFunction = '';
     this.interactError.set(null);
     this.interactResult.set(null);
+    this.interactIndexerState.set(null);
     this.partialSpendJson.set(null);
     this.partialCompleteError.set(null);
     this.partialCompleteResult.set(null);
@@ -3525,6 +3536,148 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * Poll the indexer for a non-deploy covenant action (TopUp, withdraw,
+   * keepAlive, changeHeir, partial-spend completion, etc.) and only settle
+   * "My Contracts" once the merged dashboard entry's amount/status agrees
+   * with what we already applied to the local registry.
+   *
+   * getTransactionSettlementStatus() alone isn't enough: it can report
+   * `indexed: true` (the tx was seen) while the separate listCovenants()
+   * listing that mergeDashboardEntries() trusts as the source of truth for
+   * status/amount still lags behind — calling loadContracts() at that point
+   * re-overwrites our optimistic registry update with the listing's stale
+   * (pre-tx) values, the exact staleness this method exists to avoid. We
+   * can't compare txids to detect that lag: mergeDashboardEntries() takes
+   * `latestTxid` from the indexer entry, and indexerSummaryToDashboard()
+   * always sets that to the covenant's genesis/deploy txid (there's no
+   * "latest action txid" in the indexer's summary payload), so it would
+   * never match a post-deploy action's txid even once the listing is fresh.
+   * Comparing amount/status against the local entry sidesteps that.
+   */
+  private async trackActionIndexing(
+    txid: string,
+    registryEntryId?: string,
+  ): Promise<void> {
+    this.setActionIndexerState({
+      txid,
+      status: 'checking',
+      message: 'Waiting for the indexer to see this transaction...',
+    });
+
+    let seenSettled = false;
+
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      try {
+        if (!seenSettled) {
+          const status =
+            await this.covenantIndexerService.getTransactionSettlementStatus(
+              txid,
+            );
+          seenSettled = status.indexed;
+        }
+
+        if (seenSettled) {
+          await this.loadContracts();
+          if (this.dashboardCaughtUpWithLocal(registryEntryId)) {
+            this.setActionIndexerState({
+              txid,
+              status: 'indexed',
+              message: 'Indexed. My Contracts now reflects this change.',
+            });
+            return;
+          }
+          this.setActionIndexerState({
+            txid,
+            status: 'checking',
+            message: `Transaction confirmed — waiting for the contract list to catch up (${attempt}/8)...`,
+          });
+        } else {
+          this.setActionIndexerState({
+            txid,
+            status: 'checking',
+            message: `Waiting for indexer confirmation (${attempt}/8)...`,
+          });
+        }
+      } catch (error: any) {
+        console.warn('[Contracts] Action indexing check failed:', error);
+        this.setActionIndexerState({
+          txid,
+          status: 'unavailable',
+          message:
+            error?.message ||
+            'Indexer status is unavailable. The transaction was still broadcast.',
+        });
+        return;
+      }
+
+      await this.delay(2500);
+    }
+
+    this.setActionIndexerState({
+      txid,
+      status: 'not-indexed',
+      message:
+        'Broadcast, but My Contracts may not reflect this change yet. Refresh in a moment.',
+    });
+  }
+
+  /**
+   * Updates the contracts page's own indexer-status display and mirrors it
+   * into ApprovalFlowService.pendingConfirmation — the approval success
+   * page's "Done" button reads that to stay disabled until the indexer has
+   * actually caught up, instead of letting the user dismiss the success
+   * screen and navigate to "My Contracts" while it's still stale.
+   */
+  private setActionIndexerState(state: ActionIndexerState) {
+    this.interactIndexerState.set(state);
+
+    const statusMap: Record<
+      ActionIndexerState['status'],
+      PendingActionConfirmation['status']
+    > = {
+      checking: 'checking',
+      indexed: 'confirmed',
+      unavailable: 'unavailable',
+      'not-indexed': 'timed-out',
+    };
+    this.approvalFlowService.setPendingConfirmation({
+      status: statusMap[state.status],
+      message: state.message,
+    });
+  }
+
+  /**
+   * Has the merged dashboard entry caught up with the optimistic update we
+   * already applied to the local registry entry? Without a registry entry to
+   * compare against (e.g. an import flow with no local id) there's nothing
+   * more to wait for, so we treat that as already caught up.
+   */
+  private dashboardCaughtUpWithLocal(registryEntryId?: string): boolean {
+    if (!registryEntryId) return true;
+
+    const localEntry = this.registryService
+      .getAllContracts()
+      .find((contract) => contract.id === registryEntryId);
+    if (!localEntry) return true;
+
+    const target = this.dashboardContracts().find(
+      (candidate) => candidate.registryEntry?.id === registryEntryId,
+    );
+    if (!target) return false;
+
+    if (localEntry.status === 'spent') return target.status === 'spent';
+
+    try {
+      return (
+        BigInt(target.amountSompi || '0') ===
+        BigInt(localEntry.amountSompi || '0')
+      );
+    } catch {
+      return target.amountSompi === localEntry.amountSompi;
+    }
+  }
+
   onInteractContractSelect(value: any) {
     this.selectedContractId.set(value || '');
     this.selectContractFromRegistry();
@@ -3554,6 +3707,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   async interactContract() {
     this.interactError.set(null);
     this.interactResult.set(null);
+    this.interactIndexerState.set(null);
 
     const wallet = this.currentWallet();
     if (!wallet) {
@@ -3701,7 +3855,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
               spendTxid: result.txid,
               lastChecked: Date.now(),
             });
-            this.loadContracts();
+            void this.trackActionIndexing(
+              result.txid,
+              this.selectedContractId(),
+            );
           }
           return;
         }
@@ -3966,7 +4123,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.interactOutpointTxid = result.txid;
           this.interactOutpointVout = '0';
         }
-        this.loadContracts();
+        void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {
       this.interactError.set(error?.message || 'Failed to execute contract');
@@ -4136,7 +4293,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactInputAmount = inputAmount.toString();
     this.dmsNewExpiry = '';
 
-    this.loadContracts();
+    void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
   private async executeDmsChangeHeir(
@@ -4239,7 +4396,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactOutputAddress = '';
     this.interactResolvedOutputAddress = null;
 
-    this.loadContracts();
+    void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
   private async compileDmsContinuation(values: {
@@ -4847,6 +5004,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // Clear stale interaction state
     this.interactError.set(null);
     this.interactResult.set(null);
+    this.interactIndexerState.set(null);
     this.partialSpendJson.set(null);
     this.extraArgValues = {};
     this.dmsNewExpiry = '';
@@ -5136,6 +5294,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   async completePartialSpend() {
     this.partialCompleteError.set(null);
     this.partialCompleteResult.set(null);
+    this.interactIndexerState.set(null);
 
     const wallet = this.currentWallet();
     if (!wallet) {
@@ -5199,7 +5358,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
             lastChecked: Date.now(),
           });
         }
-        this.loadContracts();
+        void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {
       this.partialCompleteError.set(

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -444,6 +444,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   interactOutputAddress = '';
   interactResolvedOutputAddress: string | null = null;
 
+  // Set in ngOnDestroy() so trackActionIndexing()'s poll loop can bail out
+  // instead of updating signals/services and scheduling more RPC/indexer
+  // traffic after the component is gone.
+  private destroyed = false;
+
   // Lookup form
   lookupContractJson = '';
   interactOutputAmount = '';
@@ -667,6 +672,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.destroyed = true;
     this.wideWorkspaceService.deactivate();
     this.routeSubscription?.unsubscribe();
   }
@@ -2331,9 +2337,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const registryEntry = entry.registryEntry!;
     const liveUtxo = await this.findLiveContractUtxo(registryEntry);
 
+    // findLiveContractUtxo() awaits an RPC call, during which the user could
+    // navigate to a different contract's detail view — re-check identity
+    // before trusting selectedDetail().utxos, or a different contract's UTXO
+    // could get applied to this registry entry.
     const detail = this.selectedDetail();
     const indexerUtxo =
-      !liveUtxo && detail?.utxos.length === 1 ? detail.utxos[0] : undefined;
+      !liveUtxo && detail?.entry.id === entry.id && detail.utxos.length === 1
+        ? detail.utxos[0]
+        : undefined;
 
     const amountSompi = String(
       liveUtxo?.amountSompi ??
@@ -3639,17 +3651,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     let seenSettled = false;
 
     for (let attempt = 1; attempt <= 8; attempt++) {
+      if (this.destroyed) return;
       try {
         if (!seenSettled) {
           const status =
             await this.covenantIndexerService.getTransactionSettlementStatus(
               txid,
             );
+          if (this.destroyed) return;
           seenSettled = status.indexed;
         }
 
         if (seenSettled) {
           await this.loadContracts({ skipOnChainStatusRefresh: true });
+          if (this.destroyed) return;
           if (this.dashboardCaughtUpWithLocal(registryEntryId)) {
             this.setActionIndexerState({
               txid,
@@ -3683,6 +3698,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       }
 
       await this.delay(2500);
+      if (this.destroyed) return;
     }
 
     this.setActionIndexerState({

--- a/src/app/v2/pages/app/flows/wallet-management/wallet-management-page/wallet-management-page.component.scss
+++ b/src/app/v2/pages/app/flows/wallet-management/wallet-management-page/wallet-management-page.component.scss
@@ -66,7 +66,8 @@
     align-items: center;
     gap: 16px;
 
-    .more-options-icon, .update-icon {
+    .more-options-icon,
+    .update-icon {
       cursor: pointer;
       transition: all 0.2s ease;
 
@@ -165,15 +166,21 @@
   justify-content: center;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.15),
+    0 2px 4px rgba(0, 0, 0, 0.1);
   z-index: 100;
 
   &:hover {
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2), 0 3px 6px rgba(0, 0, 0, 0.15);
+    box-shadow:
+      0 6px 16px rgba(0, 0, 0, 0.2),
+      0 3px 6px rgba(0, 0, 0, 0.15);
   }
 
   &:active {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow:
+      0 2px 8px rgba(0, 0, 0, 0.15),
+      0 1px 3px rgba(0, 0, 0, 0.1);
   }
 
   ::ng-deep .icon {
@@ -218,18 +225,22 @@
   &.selected {
     position: relative;
     border: 1px solid transparent;
-    background: rgba(#6FC7BA, 0.1);
+    background: rgba(#6fc7ba, 0.1);
 
     &::before {
-      content: '';
+      content: "";
       position: absolute;
       inset: -1px;
       padding: 1px;
       background: var(--gradient-1);
       border-radius: inherit;
-      mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
       mask-composite: xor;
-      -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      -webkit-mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
       -webkit-mask-composite: xor;
       pointer-events: none;
     }
@@ -340,7 +351,7 @@
       border-radius: 12px;
       cursor: pointer;
       transition: all 0.2s ease;
-      
+
       &:hover {
         background: rgba(255, 165, 0, 0.15);
         border-color: rgba(255, 165, 0, 0.4);
@@ -349,12 +360,12 @@
       .pending-count {
         font-size: 12px;
         font-weight: 600;
-        color: #FFA500;
+        color: #ffa500;
         line-height: 1;
       }
 
       ::ng-deep .spinner {
-        color: #FFA500;
+        color: #ffa500;
         width: 12px !important;
         height: 12px !important;
       }
@@ -443,7 +454,7 @@
   &__title {
     font-size: 14px;
     font-weight: 600;
-    color: #FFA500;
+    color: #ffa500;
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }

--- a/src/app/v2/pages/app/flows/wallet-management/wallet-management-page/wallet-management-page.component.scss
+++ b/src/app/v2/pages/app/flows/wallet-management/wallet-management-page/wallet-management-page.component.scss
@@ -13,7 +13,6 @@
   justify-content: space-between;
   padding: 16px 0 24px 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  margin-bottom: 24px;
 
   .header-left {
     display: flex;

--- a/src/app/v2/services/approval-flow.service.ts
+++ b/src/app/v2/services/approval-flow.service.ts
@@ -27,6 +27,11 @@ export type L2PriorityInfo = {
   gasLimit: bigint;
 };
 
+export type PendingActionConfirmation = {
+  status: 'checking' | 'confirmed' | 'unavailable' | 'timed-out';
+  message: string;
+};
+
 export type ApprovalPageResultParams = {
   isApproved: boolean;
   priorityFee?: bigint;
@@ -84,6 +89,18 @@ export class ApprovalFlowService {
   // Public computed for components to observe completion
   completion = computed(() => this.completionSignal());
 
+  // Lets a flow (e.g. contracts page) report that the backend an action
+  // depends on (the covenant indexer) hasn't caught up yet, so the success
+  // page can hold the user on it instead of letting them navigate away
+  // believing the change is already reflected everywhere.
+  private pendingConfirmationSignal =
+    signal<PendingActionConfirmation | null>(null);
+  pendingConfirmation = computed(() => this.pendingConfirmationSignal());
+
+  setPendingConfirmation(state: PendingActionConfirmation | null) {
+    this.pendingConfirmationSignal.set(state);
+  }
+
   /**
    * Shows approval dialog using the appropriate display mode
    */
@@ -108,6 +125,7 @@ export class ApprovalFlowService {
 
     this.currentApprovalConfigSignal.set(config);
     this.currentApprovalInstanceId = ++this.approvalInstanceCounter;
+    this.pendingConfirmationSignal.set(null);
 
     return new Promise((resolve) => {
       this.currentResolve = resolve;
@@ -213,6 +231,7 @@ export class ApprovalFlowService {
   closeApproval() {
     // Clear completion signal
     this.completionSignal.set(null);
+    this.pendingConfirmationSignal.set(null);
     this.cleanupApproval();
 
     // Cancel any pending detach-reject timer — the approval is being closed

--- a/src/app/v2/services/approval-flow.service.ts
+++ b/src/app/v2/services/approval-flow.service.ts
@@ -93,8 +93,9 @@ export class ApprovalFlowService {
   // depends on (the covenant indexer) hasn't caught up yet, so the success
   // page can hold the user on it instead of letting them navigate away
   // believing the change is already reflected everywhere.
-  private pendingConfirmationSignal =
-    signal<PendingActionConfirmation | null>(null);
+  private pendingConfirmationSignal = signal<PendingActionConfirmation | null>(
+    null,
+  );
   pendingConfirmation = computed(() => this.pendingConfirmationSignal());
 
   setPendingConfirmation(state: PendingActionConfirmation | null) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @use "styles/legacy-tokens" as *;
 @use "@kaspacom/ui-kit/tokens/index.scss" as kcTokens;
+@use "styles/design-system/font.style.scss";
 @use "styles/common";
 @use "styles/responsive";
 @use "styles/shared-ui";


### PR DESCRIPTION
## Summary
- **Global typography classes were silently broken.** The `@kaspacom/ui-kit` migration removed the old package's global stylesheet import, which used to be what made `.typo-title-*` / `.typo-text-*` / `.typo-header-*` etc. classes available app-wide. The local partial that defines them (`styles/design-system/font.style.scss`) was never re-added to `styles.scss`, so those classes have been silently resolving to nothing across ~50 templates. Symptom: headings fall back to unstyled browser defaults instead of the intended sizes — e.g. "The Official KaspaCom Wallet" and "Welcome back" / "Welcome to KaspaCom Wallet" on the onboarding page rendered oversized. Fix: add back `@use "styles/design-system/font.style.scss";` in `styles.scss`.
- **Doubled vertical gap in the wallet management panel.** In `wallet-management-page.component.scss`, `.page-content` already applies `gap: 24px` between its flex children, but `.custom-header` also had its own `margin-bottom: 24px` stacked on top, doubling the space above the "ACCOUNTS" section title to 48px. Removed the redundant margin so spacing is driven by the single `gap` declaration.
- **Covenant contract actions (TopUp/withdraw/keepAlive/changeHeir/partial-spend) showed stale data on "My Contracts" right after succeeding.** Every action refreshed the contracts list immediately after broadcasting, but `mergeDashboardEntries()` always trusts the indexer's bulk `listCovenants()` listing for a matched contract's amount/status — and that listing lags behind the broadcast tx. The immediate refresh clobbered the correct optimistic local update with the indexer's stale pre-tx data, so a card wouldn't show the new balance/status until the user opened the contract's detail view (which fetches that one covenant directly instead of going through the lagging bulk listing).
  - Added `trackActionIndexing()` (extending the existing deploy-only indexer-wait pattern to all five action paths), which polls the indexer after broadcast and only refreshes "My Contracts" once the merged dashboard entry's amount/status agrees with what was already applied to the local registry. (Comparing txids doesn't work here: the indexer's summary payload has no "latest action txid" field, so it always reports the covenant's genesis/deploy txid — a pre-existing gap in `indexerSummaryToDashboard()`.)
  - The approval flow's "Done" button now mirrors this polling state (via a new `pendingConfirmation` signal on `ApprovalFlowService`) and stays disabled with a live status message until the indexer has caught up, so users can no longer dismiss the success screen and land on "My Contracts" before it's accurate.
- **Dead Man's Switch claim flow was broken.** Three related issues in the claim path:
  - Claiming showed an editable "Withdraw amount" field as if a partial claim were possible, but the contract only supports transferring the entire balance to the heir — there's no continuation output for a remainder to go to. Entering a partial amount produced a transaction the contract script rejects. Added a dedicated `isDmsClaim()` case that always uses the full balance, and replaced the amount input with a static notice for this function.
  - Clicking the "Claim" action from a "My Contracts" dashboard card silently selected "Keep alive" instead once redirected to the action tab. `selectDefaultFunctionForContract()` picked from a fixed per-contract-type priority list (`keepAlive` first for Dead Man's Switch) without regard for the caller's role, and `availableFunctions()` isn't role-filtered, so `keepAlive` always "won" even for a heir who can't call it. Now passes the entry's participants through and promotes `claim` to the front for non-owner wallets, matching the owner/heir split `getNextActionLabel()` already uses for the card's label.
  - The "Complete co-signer transaction" (partial spend) section appeared for every contract type, including Dead Man's Switch and TimeLockVault, neither of which has any multi-sig entrypoint at all. Gated it on a new `contractHasMultiSigFunction()` check so it only shows for contracts (Escrow, MultiSigVault) that can actually produce a partial spend.
- **"Share a contract" dropdown couldn't distinguish contracts of the same type.** The dropdown listed each shareable contract by its type alone (e.g. "Time Lock"), so a wallet with two Time Locks showed two identical, unselectable-looking options. The label now appends the covenant ID, e.g. "Time Lock-abc123".

## Test plan
- [x] `ng build --configuration production` succeeds (verified the one remaining budget warning on `contracts-page.component.scss` is pre-existing and unrelated)
- [x] Visually confirm onboarding page headings render at intended size
- [x] Visually confirm the wallet management "Workspace" panel spacing looks correct
- [x] Spot check a few other pages using `.typo-*` classes for visual regressions now that the classes are live again
- [x] TopUp/withdraw/keepAlive/changeHeir a covenant contract and confirm the "My Contracts" card reflects the new amount/status without needing to open contract details, and that the approval success page's "Done" button briefly shows "Confirming..." before becoming clickable
- [x] As a Dead Man's Switch heir, click "Claim" from the My Contracts card and confirm the action tab lands on "Claim" (not "Keep alive"), the amount field is replaced by the full-balance notice, and the co-signer section is hidden
- [x] Confirm the co-signer section still appears for Escrow and MultiSigVault contracts
- [x] Confirm the "Share a contract" dropdown now shows type + covenant ID for each entry


https://github.com/user-attachments/assets/f0083d5d-b29e-4c64-96ee-11fd74ada44f
