### PR TITLE
fix(onboarding): stop clipping onboarding content, add single page scroll

### DIFF
--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.scss
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.scss
@@ -123,6 +123,12 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    // .onboarding-v2__device (the row-flex parent) defaults to
+    // align-items: stretch, which — combined with its mobile `height: 100%`
+    // — forces this frame to that definite height regardless of its own
+    // min-height, so overflowing content clips/scrolls right here instead
+    // of growing the frame and reaching .onboarding-v2's scroll. Opt out.
+    align-self: flex-start;
     gap: 24px;
     width: min(440px, 100%);
     padding: 24px 20px;
@@ -136,7 +142,11 @@
     box-shadow: 0 40px 60px rgba(0, 0, 0, 0.55);
     // x-only: a definite vertical clip here would re-cut any step content
     // that grows past the frame before it can reach .onboarding-v2's scroll.
+    // overflow-y must stay explicit: leaving it unset while overflow-x is
+    // non-visible makes it compute to `auto` per spec, creating a second,
+    // competing scroll container instead of passing overflow up.
     overflow-x: hidden;
+    overflow-y: visible;
     backdrop-filter: blur(6px);
   }
 
@@ -286,13 +296,19 @@
     // overshoot (see slide.animation.ts's translateX steps), not to bound
     // vertical height — clipping the y-axis here cuts off tall step content
     // (e.g. the 12/24-word recovery grid) with no scrollbar to recover it.
+    // overflow-y must stay explicit: leaving it unset while overflow-x is
+    // non-visible makes it compute to `auto` per spec, creating extra
+    // competing scroll containers instead of passing overflow up to
+    // .onboarding-v2.
     overflow-x: hidden;
+    overflow-y: visible;
 
     ::ng-deep > div {
       display: flex;
       flex-direction: column;
       width: 100%;
       overflow-x: hidden;
+      overflow-y: visible;
 
       app-step-indicator {
         flex-shrink: 0;
@@ -305,6 +321,7 @@
         flex-direction: column;
         width: 100%;
         overflow-x: hidden;
+        overflow-y: visible;
 
         > * {
           display: flex;

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.scss
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.scss
@@ -2,14 +2,18 @@
 
 .onboarding-v2 {
   position: relative;
-  min-height: 100vh;
+  height: 100%;
   width: 100%;
   padding: 64px 24px;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  // "safe" keeps content anchored to the start (instead of clipping both
+  // ends) whenever it's taller than the viewport, so the overflow below
+  // can be reached by scrolling instead of being centered off both edges.
+  align-items: safe center;
+  justify-content: safe center;
   background: var(--background);
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   box-sizing: border-box;
 
   &__graph-canvas {
@@ -130,7 +134,9 @@
       rgba(13, 19, 22, 0.25) 100%
     );
     box-shadow: 0 40px 60px rgba(0, 0, 0, 0.55);
-    overflow: hidden;
+    // x-only: a definite vertical clip here would re-cut any step content
+    // that grows past the frame before it can reach .onboarding-v2's scroll.
+    overflow-x: hidden;
     backdrop-filter: blur(6px);
   }
 
@@ -190,7 +196,6 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
-    overflow: hidden;
   }
 
   &__panel-content--transitioning {
@@ -277,13 +282,17 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    // horizontal-only: these three levels exist to hide the slide-transition
+    // overshoot (see slide.animation.ts's translateX steps), not to bound
+    // vertical height — clipping the y-axis here cuts off tall step content
+    // (e.g. the 12/24-word recovery grid) with no scrollbar to recover it.
+    overflow-x: hidden;
 
     ::ng-deep > div {
       display: flex;
       flex-direction: column;
       width: 100%;
-      overflow: hidden;
+      overflow-x: hidden;
 
       app-step-indicator {
         flex-shrink: 0;
@@ -295,7 +304,7 @@
         display: flex;
         flex-direction: column;
         width: 100%;
-        overflow: hidden;
+        overflow-x: hidden;
 
         > * {
           display: flex;
@@ -468,7 +477,8 @@
       width: 100%;
       max-width: none;
       flex: 1;
-      height: 100%;
+      // min-height (a floor), not height (a cap) — content taller than the
+      // screen must be able to grow past it and scroll via .onboarding-v2.
       min-height: 100vh;
       min-height: 100dvh;
       padding: 32px 20px 24px;


### PR DESCRIPTION
## Summary
- Onboarding/login page had no scrollable region in its ancestor chain — `.onboarding-v2`, `.onboarding-v2__device-frame`, and the step-transition wrapper divs all used `overflow: hidden` (one with a hard-capping `height: 100%` instead of a floor-only `min-height`), so any content taller than the viewport (password field + validation error, the 12/24-word recovery phrase grid, etc.) was silently clipped with no way to reach it.
- Most visible in a short iframe embed, but reproducible in a normal short browser window too.
- Fix: give `.onboarding-v2` the single scroll container (`overflow-y: auto` + `safe` centering so overflow isn't clipped off both edges instead of scrolled to), and change every intermediate `overflow: hidden` down to `overflow-x: hidden` (they only exist to hide horizontal slide-transition overshoot), plus swap the capping `height: 100%` on mobile device-frame for a floor-only `min-height`.

## Test plan
- [x] Load `/onboarding` at a normal desktop window size — layout unchanged, still centered.
- [x] Shrink the browser window height (or embed in a short iframe) and confirm the login/unlock form (with a validation error shown) is fully reachable by scrolling.
- [x] Go through "Connect Existing Wallet" → 12-word recovery phrase step at a narrow/mobile width and confirm all word inputs + Continue button are reachable by scrolling, with no inner/double scrollbar.
- [x] Confirm step-to-step slide transitions still animate without a horizontal scrollbar flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)