### PR TITLE
Full-page-per-action covenant interaction flow

### DIFF
--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.html
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.html
@@ -1,10 +1,12 @@
 @for (field of fields(); track fieldTrackBy($index, field)) {
   @switch (field.type) {
-    @case ('address') {
+    @case ("address") {
       <div class="form-group flex column gap-8">
         <app-address-smart-input
           [label]="field.label"
-          [placeholder]="field.placeholder || 'Enter wallet address or KNS domain'"
+          [placeholder]="
+            field.placeholder || 'Enter wallet address or KNS domain'
+          "
           [isFullWidth]="true"
           [isValid]="true"
           [invalidReason]="''"
@@ -19,7 +21,7 @@
         }
       </div>
     }
-    @case ('amount') {
+    @case ("amount") {
       <div class="form-group flex column gap-8">
         <kc-number-input
           [label]="field.label"
@@ -32,7 +34,9 @@
           @if (field.allowMax) {
             <div
               (click)="!isDisabled() && amountMaxClick.emit()"
-              [class]="isDisabled() ? 'max-text disabled' : 'max-text clickable'"
+              [class]="
+                isDisabled() ? 'max-text disabled' : 'max-text clickable'
+              "
               rightSideSlot
             >
               <span>Max</span>
@@ -44,7 +48,7 @@
         }
       </div>
     }
-    @case ('timestamp') {
+    @case ("timestamp") {
       <div class="form-group flex column gap-8">
         <app-covenant-date-time-input
           [label]="field.label"
@@ -58,35 +62,39 @@
         }
       </div>
     }
-    @case ('extra-int') {
+    @case ("extra-int") {
       <div class="form-group flex column gap-8">
         <kc-number-input
           [label]="field.label"
           [placeholder]="'Enter ' + field.paramName + ' value'"
           [isDisabled]="isDisabled()"
           [ngModel]="extraArgValues()[field.paramName] || ''"
-          (valueChange)="extraArgChange.emit({ name: field.paramName, value: $event })"
+          (valueChange)="
+            extraArgChange.emit({ name: field.paramName, value: $event })
+          "
         ></kc-number-input>
         @if (field.description) {
           <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
         }
       </div>
     }
-    @case ('extra-bool') {
+    @case ("extra-bool") {
       <div class="form-group flex column gap-8">
         <kc-number-input
           [label]="field.label"
           [placeholder]="'Enter ' + field.paramName + ' value (0 or 1)'"
           [isDisabled]="isDisabled()"
           [ngModel]="extraArgValues()[field.paramName] || ''"
-          (valueChange)="extraArgChange.emit({ name: field.paramName, value: $event })"
+          (valueChange)="
+            extraArgChange.emit({ name: field.paramName, value: $event })
+          "
         ></kc-number-input>
         @if (field.description) {
           <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
         }
       </div>
     }
-    @case ('banner') {
+    @case ("banner") {
       <div
         class="p-12 rounded-lg"
         [style]="
@@ -96,7 +104,11 @@
         "
       >
         <span
-          [class]="field.tone === 'warning' ? 'text-yellow typo-text-2' : 'text-gray-75 typo-text-2'"
+          [class]="
+            field.tone === 'warning'
+              ? 'text-yellow typo-text-2'
+              : 'text-gray-75 typo-text-2'
+          "
           >{{ field.text }}</span
         >
       </div>

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.html
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.html
@@ -1,0 +1,105 @@
+@for (field of fields(); track fieldTrackBy($index, field)) {
+  @switch (field.type) {
+    @case ('address') {
+      <div class="form-group flex column gap-8">
+        <app-address-smart-input
+          [label]="field.label"
+          [placeholder]="field.placeholder || 'Enter wallet address or KNS domain'"
+          [isFullWidth]="true"
+          [isValid]="true"
+          [invalidReason]="''"
+          [isDisabled]="isDisabled()"
+          [value]="addressValue()"
+          (valueChange)="addressChange.emit($event)"
+          (resolved)="addressResolved.emit($event)"
+          (qrClick)="addressQrClick.emit()"
+        ></app-address-smart-input>
+        @if (field.description) {
+          <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
+        }
+      </div>
+    }
+    @case ('amount') {
+      <div class="form-group flex column gap-8">
+        <kc-number-input
+          [label]="field.label"
+          [placeholder]="'0'"
+          [min]="field.min || '0'"
+          [isDisabled]="isDisabled()"
+          [ngModel]="amountValue()"
+          (valueChange)="amountChange.emit($event)"
+        >
+          @if (field.allowMax) {
+            <div
+              (click)="!isDisabled() && amountMaxClick.emit()"
+              [class]="isDisabled() ? 'max-text disabled' : 'max-text clickable'"
+              rightSideSlot
+            >
+              <span>Max</span>
+            </div>
+          }
+        </kc-number-input>
+        @if (field.description) {
+          <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
+        }
+      </div>
+    }
+    @case ('timestamp') {
+      <div class="form-group flex column gap-8">
+        <app-covenant-date-time-input
+          [label]="field.label"
+          [value]="timestampValue()"
+          [isDisabled]="isDisabled()"
+          [isValid]="true"
+          (valueChange)="timestampChange.emit($event)"
+        ></app-covenant-date-time-input>
+        @if (field.description) {
+          <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
+        }
+      </div>
+    }
+    @case ('extra-int') {
+      <div class="form-group flex column gap-8">
+        <kc-number-input
+          [label]="field.label"
+          [placeholder]="'Enter ' + field.paramName + ' value'"
+          [isDisabled]="isDisabled()"
+          [ngModel]="extraArgValues()[field.paramName] || ''"
+          (valueChange)="extraArgChange.emit({ name: field.paramName, value: $event })"
+        ></kc-number-input>
+        @if (field.description) {
+          <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
+        }
+      </div>
+    }
+    @case ('extra-bool') {
+      <div class="form-group flex column gap-8">
+        <kc-number-input
+          [label]="field.label"
+          [placeholder]="'Enter ' + field.paramName + ' value (0 or 1)'"
+          [isDisabled]="isDisabled()"
+          [ngModel]="extraArgValues()[field.paramName] || ''"
+          (valueChange)="extraArgChange.emit({ name: field.paramName, value: $event })"
+        ></kc-number-input>
+        @if (field.description) {
+          <span class="text-gray-60 typo-text-2">{{ field.description }}</span>
+        }
+      </div>
+    }
+    @case ('banner') {
+      <div
+        class="p-12 rounded-lg"
+        [style]="
+          field.tone === 'warning'
+            ? 'background: rgba(255, 193, 7, 0.08); border: 1px solid rgba(255, 193, 7, 0.2);'
+            : 'background: rgba(111, 199, 186, 0.08); border: 1px solid rgba(111, 199, 186, 0.2);'
+        "
+      >
+        <span
+          [class]="field.tone === 'warning' ? 'text-yellow typo-text-2' : 'text-gray-75 typo-text-2'"
+          >{{ field.text }}</span
+        >
+      </div>
+    }
+  }
+}

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-fields/contract-action-fields.component.ts
@@ -1,0 +1,56 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { KcNumberInputComponent } from '@kaspacom/ui-kit';
+import { AddressResolutionResult } from '../../../../../../../services/address-resolution.service';
+import { AddressSmartInputComponent } from '../../../../../../shared/ui/input/address-smart-input/address-smart-input.component';
+import { CovenantDateTimeInputComponent } from '../../covenant-date-time-input.component';
+import { ActionField } from '../../contract-action-fields.config';
+
+@Component({
+  selector: 'app-contract-action-fields',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    KcNumberInputComponent,
+    AddressSmartInputComponent,
+    CovenantDateTimeInputComponent,
+  ],
+  templateUrl: './contract-action-fields.component.html',
+  styleUrl: './contract-action-fields.component.scss',
+})
+export class ContractActionFieldsComponent {
+  fields = input<ActionField[]>([]);
+  isDisabled = input<boolean>(false);
+
+  addressValue = input<string>('');
+  amountValue = input<string>('');
+  timestampValue = input<string>('');
+  extraArgValues = input<Record<string, string>>({});
+
+  addressChange = output<string>();
+  addressResolved = output<AddressResolutionResult>();
+  addressQrClick = output<void>();
+  // kc-number-input's valueChange emits `unknown` — matches the `any`-typed
+  // handlers (onTopUpAmountChange, onExtraArgValueChange, etc.) it feeds
+  // elsewhere in this flow.
+  amountChange = output<any>();
+  amountMaxClick = output<void>();
+  timestampChange = output<string>();
+  extraArgChange = output<{ name: string; value: any }>();
+
+  fieldTrackBy(_index: number, field: ActionField): string {
+    switch (field.type) {
+      case 'address':
+      case 'amount':
+      case 'timestamp':
+        return field.key;
+      case 'extra-int':
+      case 'extra-bool':
+        return field.paramName;
+      case 'banner':
+        return field.text;
+    }
+  }
+}

--- a/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
+++ b/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
@@ -1,0 +1,178 @@
+export type ActionFieldType =
+  | 'address'
+  | 'amount'
+  | 'timestamp'
+  | 'extra-int'
+  | 'extra-bool'
+  | 'banner';
+
+interface ActionFieldBase {
+  type: ActionFieldType;
+  description?: string;
+}
+
+export interface AddressActionField extends ActionFieldBase {
+  type: 'address';
+  key: 'outputAddress';
+  label: string;
+  placeholder?: string;
+}
+
+export interface AmountActionField extends ActionFieldBase {
+  type: 'amount';
+  key: 'outputAmount' | 'topUpAmount';
+  label: string;
+  allowMax?: boolean;
+  min?: string;
+}
+
+export interface TimestampActionField extends ActionFieldBase {
+  type: 'timestamp';
+  key: 'dmsNewExpiry';
+  label: string;
+}
+
+export interface ExtraIntActionField extends ActionFieldBase {
+  type: 'extra-int';
+  paramName: string;
+  label: string;
+}
+
+export interface ExtraBoolActionField extends ActionFieldBase {
+  type: 'extra-bool';
+  paramName: string;
+  label: string;
+}
+
+export interface BannerActionField extends ActionFieldBase {
+  type: 'banner';
+  tone: 'info' | 'warning';
+  text: string;
+}
+
+export type ActionField =
+  | AddressActionField
+  | AmountActionField
+  | TimestampActionField
+  | ExtraIntActionField
+  | ExtraBoolActionField
+  | BannerActionField;
+
+export interface ActionFieldConfigEntry {
+  fields: ActionField[];
+  /**
+   * Suppresses the generic ABI extra-arg loop (extraArgsForFunction()) for
+   * this action — set true where an extra arg is already covered by `fields`
+   * (escrow arbitrate's amountToSeller) or isn't collectible generically
+   * (DMS keepAlive), matching extraArgsForFunction()'s own exclusions.
+   */
+  suppressGenericExtraArgs?: boolean;
+}
+
+export type ContractActionFieldConfig = Record<
+  string /* normalized contract name */,
+  Record<string /* fnName */, ActionFieldConfigEntry>
+>;
+
+const TOP_UP_FIELDS: ActionField[] = [
+  {
+    type: 'amount',
+    key: 'topUpAmount',
+    label: 'Top up amount (KAS)',
+  },
+  {
+    type: 'banner',
+    tone: 'info',
+    text: 'The current covenant UTXO will be spent and recreated as output 0 with the same covenant ID. The new covenant amount will be the current balance plus the top-up amount before any contract-paid fee deduction.',
+  },
+];
+
+const WITHDRAW_FIELDS: ActionField[] = [
+  { type: 'address', key: 'outputAddress', label: 'Send to' },
+  {
+    type: 'amount',
+    key: 'outputAmount',
+    label: 'Withdraw amount (KAS)',
+    allowMax: true,
+  },
+];
+
+export const CONTRACT_ACTION_FIELDS: ContractActionFieldConfig = {
+  DeadManSwitch: {
+    keepAlive: {
+      fields: [
+        {
+          type: 'timestamp',
+          key: 'dmsNewExpiry',
+          label: 'New check-in deadline',
+          description:
+            'Pick when the heir should become able to claim if you do not refresh again.',
+        },
+        {
+          type: 'banner',
+          tone: 'info',
+          text: "A new Dead Man's Switch contract will be generated with the same owner and heir but the updated expiry. Funds will move to the new contract in the same transaction. The covenant lineage is preserved.",
+        },
+      ],
+      suppressGenericExtraArgs: true,
+    },
+    claim: {
+      // No amount field: leaving a remainder locked in the same DMS script
+      // would let the (presumably unresponsive) owner call keepAlive on it —
+      // DMS keepAlive has no deadline check — permanently blocking the heir
+      // from ever claiming it. The heir always claims the full balance.
+      fields: [
+        { type: 'address', key: 'outputAddress', label: 'Send to' },
+        {
+          type: 'banner',
+          tone: 'info',
+          text: 'Claiming always transfers the full locked balance — partial claims are not allowed, so the owner cannot re-arm the deadline on a leftover balance.',
+        },
+      ],
+    },
+    topUp: { fields: TOP_UP_FIELDS },
+    changeHeir: {
+      fields: [
+        {
+          type: 'address',
+          key: 'outputAddress',
+          label: 'New Heir Wallet',
+          placeholder: 'Enter heir wallet address or KNS domain',
+        },
+        {
+          type: 'banner',
+          tone: 'info',
+          text: 'Funds stay locked in the covenant. Only the heir wallet changes.',
+        },
+      ],
+    },
+  },
+  TimeLockVault: {
+    spend: { fields: WITHDRAW_FIELDS },
+    recover: { fields: WITHDRAW_FIELDS },
+    topUp: { fields: TOP_UP_FIELDS },
+  },
+  MultiSigVault: {
+    spend12: { fields: WITHDRAW_FIELDS },
+    spend13: { fields: WITHDRAW_FIELDS },
+    spend23: { fields: WITHDRAW_FIELDS },
+    topUp: { fields: TOP_UP_FIELDS },
+  },
+  EscrowWithArbiter: {
+    release: { fields: WITHDRAW_FIELDS },
+    refund: { fields: WITHDRAW_FIELDS },
+    topUp: { fields: TOP_UP_FIELDS },
+    arbitrate: {
+      fields: [
+        {
+          type: 'amount',
+          key: 'outputAmount',
+          label: 'Amount to seller (KAS)',
+          description:
+            'The remaining balance is automatically sent to the buyer. Arbitrate always pays out both sides.',
+        },
+      ],
+      suppressGenericExtraArgs: true,
+    },
+  },
+};

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -637,7 +637,7 @@
     <!-- ═══════════════ MY CONTRACTS ═══════════════ -->
     @if (activeTab() === "my-contracts" || activeTab() === "detail") {
       <div class="flex column gap-20">
-        @if (activeTab() === "detail") {
+        @if (activeTab() === "detail" && actionPageView() === "list") {
           <div
             class="detail-route-header flex justify-content-between align-items-center gap-12 wrap"
           >
@@ -655,7 +655,9 @@
               >
             }
           </div>
+        }
 
+        @if (activeTab() === "detail") {
           @if (dashboardError()) {
             <div class="banner warn">
               <svg
@@ -1140,7 +1142,10 @@
           <!-- Detail panel -->
         }
 
-        @if (selectedDetail()) {
+        @if (
+          selectedDetail() &&
+          (activeTab() !== "detail" || actionPageView() === "list")
+        ) {
           <div class="flex column gap-16">
             @if (
               selectedDetail()!.entry.status === "tracking-incomplete" ||
@@ -1378,106 +1383,113 @@
             <div class="detail-cols">
               <!-- LEFT: actions + participants -->
               <div class="detail-col">
-                <div class="panel">
-                  <div class="action-panel-head">
-                    <h4
-                      class="text-white"
-                      style="margin: 0; font-size: 14px; font-weight: 600"
-                    >
-                      Available actions
-                    </h4>
-                    @if (
-                      getCurrentRoleLabel(selectedDetail()!.entry.participants);
-                      as role
-                    ) {
-                      <span class="role-pill">You are {{ role }}</span>
-                    }
-                  </div>
-                  <p class="text-gray-60 typo-text-2" style="margin: 0 0 14px">
-                    The wallet enables only the action available for your role
-                    and the contract's current state. Manual JSON interaction
-                    lives in Advanced.
-                  </p>
-                  <div class="action-list">
-                    @if (selectedDetail()!.entry.status !== "spent") {
-                      @if (!actionsPanelReady()) {
-                        <div class="action-list-skeleton">
-                          <div class="sk-row"></div>
-                          <div class="sk-row"></div>
-                        </div>
-                      } @else if (
-                        getAvailableActions(selectedDetail()!);
-                        as availableActions
+                @if (actionPageView() === "list") {
+                  <div class="panel">
+                    <div class="action-panel-head">
+                      <h4
+                        class="text-white"
+                        style="margin: 0; font-size: 14px; font-weight: 600"
+                      >
+                        Available actions
+                      </h4>
+                      @if (
+                        getCurrentRoleLabel(
+                          selectedDetail()!.entry.participants
+                        );
+                        as role
                       ) {
-                        @if (availableActions.length > 0) {
-                          @for (
-                            action of availableActions;
-                            track action.fnName
-                          ) {
+                        <span class="role-pill">You are {{ role }}</span>
+                      }
+                    </div>
+                    <p
+                      class="text-gray-60 typo-text-2"
+                      style="margin: 0 0 14px"
+                    >
+                      The wallet enables only the action available for your
+                      role and the contract's current state. Manual JSON
+                      interaction lives in Advanced.
+                    </p>
+                    <div class="action-list">
+                      @if (selectedDetail()!.entry.status !== "spent") {
+                        @if (!actionsPanelReady()) {
+                          <div class="action-list-skeleton">
+                            <div class="sk-row"></div>
+                            <div class="sk-row"></div>
+                          </div>
+                        } @else if (
+                          getAvailableActions(selectedDetail()!);
+                          as availableActions
+                        ) {
+                          @if (availableActions.length > 0) {
+                            @for (
+                              action of availableActions;
+                              track action.fnName
+                            ) {
+                              <button
+                                class="action-item"
+                                [class.primary]="action.enabled"
+                                [disabled]="!action.enabled"
+                                (click)="
+                                  action.enabled &&
+                                    selectDetailAction(action.fnName)
+                                "
+                              >
+                                <kc-icon
+                                  [iconClass]="action.iconClass"
+                                  [size]="'sm'"
+                                ></kc-icon>
+                                <span class="ai-text">
+                                  <span class="ai-title">{{
+                                    action.label
+                                  }}</span>
+                                  <span class="ai-hint">{{
+                                    action.enabled
+                                      ? action.description
+                                      : action.disabledReason
+                                  }}</span>
+                                </span>
+                                @if (!action.enabled) {
+                                  <kc-icon
+                                    class="ai-lock"
+                                    [iconClass]="'icon-lock'"
+                                    [size]="'xs'"
+                                  ></kc-icon>
+                                }
+                              </button>
+                            }
+                          } @else {
                             <button
                               class="action-item"
-                              [class.primary]="action.enabled"
-                              [disabled]="!action.enabled"
-                              (click)="
-                                action.enabled &&
-                                  selectDetailAction(action.fnName)
-                              "
+                              (click)="selectDetailAction()"
                             >
-                              <kc-icon
-                                [iconClass]="action.iconClass"
-                                [size]="'sm'"
-                              ></kc-icon>
-                              <span class="ai-text">
-                                <span class="ai-title">{{
-                                  action.label
-                                }}</span>
-                                <span class="ai-hint">{{
-                                  action.enabled
-                                    ? action.description
-                                    : action.disabledReason
-                                }}</span>
-                              </span>
-                              @if (!action.enabled) {
-                                <kc-icon
-                                  class="ai-lock"
-                                  [iconClass]="'icon-lock'"
-                                  [size]="'xs'"
-                                ></kc-icon>
-                              }
+                              <svg
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              >
+                                <path d="M12 20h9" />
+                                <path
+                                  d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"
+                                />
+                              </svg>
+                              <span class="ai-text"
+                                ><span class="ai-title"
+                                  >Manual interaction</span
+                                ><span class="ai-hint"
+                                  >This contract type has no curated actions —
+                                  choose a function and sign manually</span
+                                ></span
+                              >
                             </button>
                           }
-                        } @else {
-                          <button
-                            class="action-item"
-                            (click)="selectDetailAction()"
-                          >
-                            <svg
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-width="2"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                            >
-                              <path d="M12 20h9" />
-                              <path
-                                d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"
-                              />
-                            </svg>
-                            <span class="ai-text"
-                              ><span class="ai-title"
-                                >Manual interaction</span
-                              ><span class="ai-hint"
-                                >This contract type has no curated actions —
-                                choose a function and sign manually</span
-                              ></span
-                            >
-                          </button>
                         }
                       }
-                    }
+                    </div>
                   </div>
-                </div>
+                }
 
                 @if (partialSpendJsonForDetail(); as pendingSpendJson) {
                   <div
@@ -2016,16 +2028,362 @@
       </div>
     }
 
+    <!-- ═══════════════ CURATED ACTION — FULL-PAGE FORM ═══════════════ -->
+    @if (
+      activeTab() === "detail" &&
+      detailPanelTab() === "action" &&
+      actionPageView() === "form" &&
+      selectedDetail() &&
+      selectedDetail()!.entry.status === "active" &&
+      interactContractJson() &&
+      getSelectedActionFieldConfig();
+      as selectedActionFields
+    ) {
+      <div class="panel flex column gap-20" id="contract-action-panel">
+        <button
+          class="back-button p-8 typo-text-2"
+          (click)="goBackToActionList()"
+        >
+          ← Back to actions
+        </button>
+
+        @if (parsedInteractContract()) {
+          <div class="contract-summary p-16 flex column gap-12">
+            <h3 class="text-white typo-text-1 fw-bold interact-contract-title">
+              {{ parsedInteractContract()!.contract_name || "Contract" }}
+            </h3>
+            <div class="flex column gap-8">
+              <div class="flex align-items-center gap-4">
+                <span class="text-gray-60 typo-text-2">Locked amount</span
+                ><kc-icon
+                  [iconClass]="'icon-info'"
+                  [size]="'xs'"
+                  kcTooltip="Total KAS locked in this covenant UTXO"
+                  tooltipPosition="top-center"
+                ></kc-icon>
+              </div>
+              <span class="text-white typo-text-1 fw-bold"
+                >{{ interactInputAmountKas() }} KAS</span
+              >
+            </div>
+            @if (interactOutpointTxid) {
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-2">Transaction</span>
+                <div class="flex align-items-center gap-8">
+                  <a
+                    [href]="getExplorerLink(interactOutpointTxid)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue typo-text-2 text-truncate"
+                    >{{ truncate(interactOutpointTxid, 24) }}</a
+                  ><app-copy-button
+                    [value]="interactOutpointTxid"
+                    [size]="'sm'"
+                  ></app-copy-button>
+                </div>
+              </div>
+            }
+            @if (currentWallet()) {
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-2">Your account</span
+                ><span class="text-white typo-text-2">{{
+                  currentWallet()!.getDisplayName()
+                }}</span>
+              </div>
+            }
+          </div>
+
+          <div class="form-group flex column gap-8">
+            <h3 class="text-white typo-text-1 fw-bold">
+              {{
+                getSelectedActionMeta(selectedDetail()!)?.label ||
+                  getFunctionLabel(selectedFunction)
+              }}
+            </h3>
+            <span class="text-gray-60 typo-text-2">{{
+              getSelectedActionMeta(selectedDetail()!)?.description ||
+                getFunctionDescription(selectedFunction)
+            }}</span>
+            @if (isMultiSigFunction(selectedFunction)) {
+              <div
+                class="p-12 rounded-lg"
+                style="
+                  background: rgba(255, 193, 7, 0.1);
+                  border: 1px solid rgba(255, 193, 7, 0.3);
+                "
+              >
+                <span class="text-yellow typo-text-2"
+                  >Two-phase signing: clicking the button will sign your part
+                  and generate a partial spend JSON. Send it to the co-signer
+                  to complete.</span
+                >
+              </div>
+            }
+          </div>
+
+          <app-contract-action-fields
+            [fields]="selectedActionFields.fields"
+            [isDisabled]="isInteracting()"
+            [addressValue]="interactOutputAddress"
+            [amountValue]="
+              isTopUpFunction(selectedFunction)
+                ? topUpAmount
+                : interactOutputAmount
+            "
+            [timestampValue]="dmsNewExpiry"
+            [extraArgValues]="extraArgValues"
+            (addressChange)="onGenericAddressChange($event)"
+            (addressResolved)="onGenericAddressResolved($event)"
+            (addressQrClick)="onGenericAddressQrClick()"
+            (amountChange)="onGenericAmountChange($event)"
+            (amountMaxClick)="onGenericAmountMaxClick()"
+            (timestampChange)="onGenericTimestampChange($event)"
+            (extraArgChange)="onGenericExtraArgChange($event)"
+          ></app-contract-action-fields>
+
+          @if (!selectedActionFields.suppressGenericExtraArgs) {
+            @for (arg of extraArgsForFunction(); track arg.name) {
+              <div class="form-group flex column gap-8">
+                <kc-number-input
+                  [label]="arg.name + ' (' + arg.type_name + ')'"
+                  [placeholder]="'Enter ' + arg.name + ' value'"
+                  [isDisabled]="isInteracting()"
+                  [ngModel]="extraArgValues[arg.name] || ''"
+                  (valueChange)="onExtraArgValueChange(arg.name, $event)"
+                ></kc-number-input>
+              </div>
+            }
+          }
+
+          @if (partialSpendJson()) {
+            <div
+              class="flex column gap-8 p-12 rounded-lg"
+              style="
+                background: rgba(255, 193, 7, 0.08);
+                border: 1px solid rgba(255, 193, 7, 0.2);
+              "
+            >
+              <span class="text-yellow typo-text-1 fw-bold"
+                >Partial spend created</span
+              >
+              <span class="text-gray-75 typo-text-2"
+                >Your signature has been added. Copy the JSON below and send
+                it to the co-signer to complete the transaction.</span
+              >
+              <textarea
+                class="contract-input"
+                rows="4"
+                readonly
+                [value]="partialSpendJson()!"
+              ></textarea>
+              <kc-button
+                [text]="'Copy partial spend JSON'"
+                [isFullWidth]="true"
+                (buttonClick)="copyPartialSpend()"
+              ></kc-button>
+              <kc-button
+                [text]="'Download JSON file'"
+                [variant]="'secondary'"
+                [isFullWidth]="true"
+                (buttonClick)="downloadPartialSpend()"
+              ></kc-button>
+            </div>
+          }
+
+          @if (isMultiSigFunction(selectedFunction)) {
+            <details class="advanced-section">
+              <summary>Complete co-signer transaction</summary>
+              <div class="adv-body">
+                <span class="text-gray-75 typo-text-2"
+                  >Paste the partial spend JSON received from the co-signer, or
+                  import it from a file. Your signature will be added and the
+                  transaction broadcast.</span
+                >
+                <textarea
+                  class="contract-input"
+                  rows="4"
+                  placeholder="Paste partial spend JSON from co-signer"
+                  [(ngModel)]="importPartialJson"
+                  [disabled]="isCompletingPartial()"
+                ></textarea>
+                <kc-button
+                  [text]="'Import JSON file'"
+                  [variant]="'secondary'"
+                  [isDisabled]="isCompletingPartial()"
+                  [isFullWidth]="true"
+                  (buttonClick)="importPartialSpendFromFile()"
+                ></kc-button>
+                <kc-button
+                  [text]="
+                    isCompletingPartial() ? 'Completing...' : 'Sign & broadcast'
+                  "
+                  [isDisabled]="isCompletingPartial() || !importPartialJson"
+                  [isFullWidth]="true"
+                  (buttonClick)="completePartialSpend()"
+                ></kc-button>
+                @if (partialCompleteError()) {
+                  <div class="error-message">{{ partialCompleteError() }}</div>
+                }
+                @if (partialCompleteResult()) {
+                  <div class="result-panel">
+                    <h3 class="text-white typo-text-1 fw-bold">
+                      Transaction sent
+                    </h3>
+                    <div class="flex column gap-4">
+                      <span class="text-gray-60 typo-text-1">Transaction</span>
+                      <div class="flex align-items-center gap-8">
+                        <a
+                          [href]="getExplorerLink(partialCompleteResult()!.txid)"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-blue typo-text-2 text-truncate"
+                          >{{ partialCompleteResult()!.txid }}</a
+                        ><app-copy-button
+                          [value]="partialCompleteResult()!.txid"
+                          [size]="'sm'"
+                        ></app-copy-button>
+                      </div>
+                    </div>
+                  </div>
+                }
+              </div>
+            </details>
+          }
+
+          @if (interactError()) {
+            <div class="error-message">{{ interactError() }}</div>
+          }
+          @if (interactResult()) {
+            <div class="result-panel">
+              <h3 class="text-white typo-text-1 fw-bold">Transaction sent</h3>
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-1">Action</span
+                ><span class="text-white typo-text-2">{{
+                  getFunctionLabel(interactResult()!.functionName)
+                }}</span>
+              </div>
+              <div class="flex column gap-4">
+                <span class="text-gray-60 typo-text-1">Transaction</span>
+                <div class="flex align-items-center gap-8">
+                  <a
+                    [href]="getExplorerLink(interactResult()!.txid)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue typo-text-2 text-truncate"
+                    >{{ interactResult()!.txid }}</a
+                  ><app-copy-button
+                    [value]="interactResult()!.txid"
+                    [size]="'sm'"
+                  ></app-copy-button>
+                </div>
+              </div>
+            </div>
+          }
+
+          <div class="form-group flex align-items-center gap-8">
+            <label class="flex align-items-center gap-8 cursor-pointer m-0"
+              ><input
+                type="checkbox"
+                class="cursor-pointer"
+                [(ngModel)]="useSenderFee"
+                [disabled]="
+                  isInteracting() || isMultiSigFunction(selectedFunction)
+                "
+              /><span class="text-white typo-text-2"
+                >Use wallet to pay for fees</span
+              ></label
+            >
+            <kc-icon
+              [iconClass]="'icon-info'"
+              [size]="'xs'"
+              [kcTooltip]="
+                isMultiSigFunction(selectedFunction)
+                  ? 'Disabled for multi-sig signing. The contract must pay fees because wallet fee inputs would change the transaction after signatures are created.'
+                  : isTopUpFunction(selectedFunction)
+                    ? 'When enabled, fees are paid from wallet change. When disabled, fees are deducted from the top-up output.'
+                    : 'If enabled, transaction fees will be paid from your wallet balance instead of the contract funds.'
+              "
+              tooltipPosition="top-center"
+            ></kc-icon>
+            @if (isTopUpFunction(selectedFunction)) {
+              <span class="text-gray-60 typo-text-2">
+                Selected:
+                {{
+                  useSenderFee
+                    ? "wallet pays fees"
+                    : "fees come from the top-up output"
+                }}
+              </span>
+            }
+          </div>
+          @if (isMultiSigFunction(selectedFunction)) {
+            <div
+              class="p-12 rounded-lg"
+              style="
+                background: rgba(255, 193, 7, 0.08);
+                border: 1px solid rgba(255, 193, 7, 0.2);
+              "
+            >
+              <span class="text-yellow typo-text-2"
+                >Multi-sig transactions must pay fees from the contract
+                funds. Wallet-paid fees add inputs and would invalidate the
+                partial signatures.</span
+              >
+            </div>
+          }
+          @if (isTopUpFunction(selectedFunction)) {
+            <div
+              class="p-12 rounded-lg"
+              style="
+                background: rgba(255, 193, 7, 0.08);
+                border: 1px solid rgba(255, 193, 7, 0.2);
+              "
+            >
+              <span class="text-yellow typo-text-2">
+                If wallet-paid fees are off, the top-up amount must be larger
+                than the transaction fee so the recreated covenant output
+                remains larger than the current covenant UTXO.
+              </span>
+            </div>
+          }
+
+          <kc-button
+            [text]="
+              isInteracting() ? 'Processing...' : getFunctionLabel(selectedFunction)
+            "
+            [isDisabled]="
+              isInteracting() || !interactContractJson() || !interactOutpointTxid
+            "
+            [isFullWidth]="true"
+            (buttonClick)="interactContract()"
+          ></kc-button>
+        }
+      </div>
+    }
+
     <!-- ═══════════════ INTERACT (advanced / manual — carried over) ═══════════════ -->
+    <!-- Also doubles as the action-page fallback for contracts with no
+         curated field config (see getSelectedActionFieldConfig()) — those
+         still need the raw ABI-driven function picker + inline fields. -->
     @if (
       activeTab() === "interact" ||
       (activeTab() === "detail" &&
         detailPanelTab() === "action" &&
+        actionPageView() === "form" &&
+        !getSelectedActionFieldConfig() &&
         selectedDetail() &&
         selectedDetail()!.entry.status === "active" &&
         interactContractJson())
     ) {
       <div class="panel flex column gap-20" id="contract-action-panel">
+        @if (activeTab() === "detail") {
+          <button
+            class="back-button p-8 typo-text-2"
+            (click)="goBackToActionList()"
+          >
+            ← Back to actions
+          </button>
+        }
         @if (activeTab() === "interact") {
           <div class="form-group flex column gap-8">
             <label class="field-label">Select contract</label>

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -1029,7 +1029,7 @@
                       }}</span>
                       @if (
                         contract.covenantId &&
-                        getCovenantExplorerLink(contract.covenantId);
+                          getCovenantExplorerLink(contract.covenantId);
                         as covenantLink
                       ) {
                         <a
@@ -1043,7 +1043,9 @@
                       } @else {
                         <span
                           class="card-id-value"
-                          [title]="contract.covenantId || contract.currentAddress"
+                          [title]="
+                            contract.covenantId || contract.currentAddress
+                          "
                           >{{
                             truncate(
                               contract.covenantId ||
@@ -1339,7 +1341,10 @@
                   <div class="identifier">
                     <span class="identifier-label">Covenant ID</span>
                     <div class="identifier-value-row">
-                      @if (getCovenantExplorerLink(covenantId); as covenantLink) {
+                      @if (
+                        getCovenantExplorerLink(covenantId);
+                        as covenantLink
+                      ) {
                         <a
                           class="identifier-value"
                           [href]="covenantLink"
@@ -1405,9 +1410,9 @@
                       class="text-gray-60 typo-text-2"
                       style="margin: 0 0 14px"
                     >
-                      The wallet enables only the action available for your
-                      role and the contract's current state. Manual JSON
-                      interaction lives in Advanced.
+                      The wallet enables only the action available for your role
+                      and the contract's current state. Manual JSON interaction
+                      lives in Advanced.
                     </p>
                     <div class="action-list">
                       @if (selectedDetail()!.entry.status !== "spent") {
@@ -1476,8 +1481,7 @@
                                 />
                               </svg>
                               <span class="ai-text"
-                                ><span class="ai-title"
-                                  >Manual interaction</span
+                                ><span class="ai-title">Manual interaction</span
                                 ><span class="ai-hint"
                                   >This contract type has no curated actions —
                                   choose a function and sign manually</span
@@ -1501,17 +1505,16 @@
                   >
                     <h4
                       class="text-yellow"
-                      style="
-                        margin: 0 0 8px;
-                        font-size: 14px;
-                        font-weight: 600;
-                      "
+                      style="margin: 0 0 8px; font-size: 14px; font-weight: 600"
                     >
                       Pending signature
                     </h4>
-                    <p class="text-gray-75 typo-text-2" style="margin: 0 0 12px">
-                      Your signature has been added. Copy this JSON and send
-                      it to the co-signer to complete the transaction.
+                    <p
+                      class="text-gray-75 typo-text-2"
+                      style="margin: 0 0 12px"
+                    >
+                      Your signature has been added. Copy this JSON and send it
+                      to the co-signer to complete the transaction.
                     </p>
                     <textarea
                       class="contract-input"
@@ -1783,9 +1786,7 @@
                       target="_blank"
                       rel="noopener noreferrer"
                       class="text-blue typo-text-2 text-mono"
-                      >{{
-                        truncate(indexerImportPreview()!.covenantId, 28)
-                      }}</a
+                      >{{ truncate(indexerImportPreview()!.covenantId, 28) }}</a
                     >
                   } @else {
                     <span class="text-white typo-text-2 text-mono">{{
@@ -2031,12 +2032,12 @@
     <!-- ═══════════════ CURATED ACTION — FULL-PAGE FORM ═══════════════ -->
     @if (
       activeTab() === "detail" &&
-      detailPanelTab() === "action" &&
-      actionPageView() === "form" &&
-      selectedDetail() &&
-      selectedDetail()!.entry.status === "active" &&
-      interactContractJson() &&
-      getSelectedActionFieldConfig();
+        detailPanelTab() === "action" &&
+        actionPageView() === "form" &&
+        selectedDetail() &&
+        selectedDetail()!.entry.status === "active" &&
+        interactContractJson() &&
+        getSelectedActionFieldConfig();
       as selectedActionFields
     ) {
       <div class="panel flex column gap-20" id="contract-action-panel">
@@ -2114,8 +2115,8 @@
               >
                 <span class="text-yellow typo-text-2"
                   >Two-phase signing: clicking the button will sign your part
-                  and generate a partial spend JSON. Send it to the co-signer
-                  to complete.</span
+                  and generate a partial spend JSON. Send it to the co-signer to
+                  complete.</span
                 >
               </div>
             }
@@ -2167,8 +2168,8 @@
                 >Partial spend created</span
               >
               <span class="text-gray-75 typo-text-2"
-                >Your signature has been added. Copy the JSON below and send
-                it to the co-signer to complete the transaction.</span
+                >Your signature has been added. Copy the JSON below and send it
+                to the co-signer to complete the transaction.</span
               >
               <textarea
                 class="contract-input"
@@ -2233,7 +2234,9 @@
                       <span class="text-gray-60 typo-text-1">Transaction</span>
                       <div class="flex align-items-center gap-8">
                         <a
-                          [href]="getExplorerLink(partialCompleteResult()!.txid)"
+                          [href]="
+                            getExplorerLink(partialCompleteResult()!.txid)
+                          "
                           target="_blank"
                           rel="noopener noreferrer"
                           class="text-blue typo-text-2 text-truncate"
@@ -2325,9 +2328,9 @@
               "
             >
               <span class="text-yellow typo-text-2"
-                >Multi-sig transactions must pay fees from the contract
-                funds. Wallet-paid fees add inputs and would invalidate the
-                partial signatures.</span
+                >Multi-sig transactions must pay fees from the contract funds.
+                Wallet-paid fees add inputs and would invalidate the partial
+                signatures.</span
               >
             </div>
           }
@@ -2349,10 +2352,14 @@
 
           <kc-button
             [text]="
-              isInteracting() ? 'Processing...' : getFunctionLabel(selectedFunction)
+              isInteracting()
+                ? 'Processing...'
+                : getFunctionLabel(selectedFunction)
             "
             [isDisabled]="
-              isInteracting() || !interactContractJson() || !interactOutpointTxid
+              isInteracting() ||
+              !interactContractJson() ||
+              !interactOutpointTxid
             "
             [isFullWidth]="true"
             (buttonClick)="interactContract()"

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -2217,8 +2217,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // scrollIntoView to leave room for it, without us having to guess
       // which ancestor is the actual scroll container.
       const headerHeight =
-        document.querySelector<HTMLElement>('.wrapper__header')
-          ?.offsetHeight ?? 0;
+        document.querySelector<HTMLElement>('.wrapper__header')?.offsetHeight ??
+        0;
       panel.style.scrollMarginTop = `${headerHeight + 12}px`;
       panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
@@ -2233,7 +2233,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       const registryEntry = this.syncRegistryEntryForDashboardAction(entry);
       this.selectedContractId.set(registryEntry.id);
       this.selectContractFromRegistry();
-      this.selectDefaultFunctionForContract(entry.contractName);
+      const hasEnabledDefault = this.selectDefaultFunctionForContract(entry);
+      if (!silent && !hasEnabledDefault) {
+        // openDashboardAction() optimistically opens straight to the action
+        // form before this resolves. Nothing the current role/state can
+        // actually submit was found, so land on the guarded action list
+        // instead of a form for a function that isn't really available.
+        this.detailPanelTab.set('action');
+        this.actionPageView.set('list');
+      }
       return true;
     }
 
@@ -2282,11 +2290,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       if (imported) {
         this.selectedContractId.set(imported.id);
         this.selectContractFromRegistry();
-        this.selectDefaultFunctionForContract(entry.contractName);
+        const hasEnabledDefault = this.selectDefaultFunctionForContract(entry);
         if (!silent) {
           this.activeTab.set('detail');
           this.detailPanelTab.set('action');
-          this.actionPageView.set('form');
+          this.actionPageView.set(hasEnabledDefault ? 'form' : 'list');
         }
         return true;
       }
@@ -2678,7 +2686,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   /** The curated label/description for the currently selected action, for the full-page form's header. */
-  getSelectedActionMeta(detail: ContractDetailState): AvailableAction | undefined {
+  getSelectedActionMeta(
+    detail: ContractDetailState,
+  ): AvailableAction | undefined {
     return this.getAvailableActions(detail).find(
       (action) => action.fnName === this.selectedFunction,
     );
@@ -2715,20 +2725,48 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     return null;
   }
 
-  private selectDefaultFunctionForContract(contractName: string) {
-    const normalized = this.normalizeContractName(contractName);
-    const preferred: Record<string, string[]> = {
-      DeadManSwitch: ['keepAlive', 'changeHeir', 'topUp', 'claim'],
-      TimeLockVault: ['spend', 'recover'],
-      MultiSigVault: ['spend12', 'spend13', 'spend23'],
-      EscrowWithArbiter: ['release', 'refund', 'arbitrate'],
+  /**
+   * Picks which entrypoint the action form defaults to. Ordering alone isn't
+   * enough — the old version just took the first ABI-preferred function that
+   * existed on-chain, with no regard for who's actually allowed to call it,
+   * so e.g. a DMS heir could be dropped straight onto keepAlive (Owner-only)
+   * or a multisig signer 3 onto spend12 (needs signer 1 or 2). Instead this
+   * reorders the preferred list per current role, then only picks among
+   * entries getAvailableActions() reports as actually enabled for this
+   * wallet/state — the same guard the "Available actions" list itself uses.
+   * Returns false when nothing is enabled, so callers can fall back to
+   * showing that guarded list instead of a form for an action that isn't
+   * really available.
+   */
+  private selectDefaultFunctionForContract(
+    entry: ContractDashboardEntry,
+  ): boolean {
+    const normalized = this.normalizeContractName(entry.contractName);
+    const currentRoles = this.currentWalletRoles(entry.participants);
+    const preferredOrders: Record<string, string[]> = {
+      DeadManSwitch: currentRoles.includes('Owner')
+        ? ['keepAlive', 'changeHeir', 'topUp', 'claim']
+        : ['claim', 'keepAlive', 'changeHeir', 'topUp'],
+      TimeLockVault: currentRoles.includes('Recovery')
+        ? ['recover', 'spend', 'topUp']
+        : ['spend', 'recover', 'topUp'],
+      MultiSigVault: ['spend12', 'spend13', 'spend23', 'topUp'],
+      EscrowWithArbiter: currentRoles.includes('Arbiter')
+        ? ['arbitrate', 'release', 'refund', 'topUp']
+        : ['release', 'refund', 'arbitrate', 'topUp'],
     };
-    const available = this.availableFunctions();
+
+    const actions = this.getAvailableActions({ entry, actions: [], utxos: [] });
+    const enabledNames = new Set(
+      actions.filter((action) => action.enabled).map((action) => action.fnName),
+    );
+    const order = preferredOrders[normalized] || [];
     const target =
-      (preferred[normalized] || []).find((name) =>
-        available.some((fn) => fn.name === name),
-      ) || available[0]?.name;
-    if (target) this.selectFunction(target);
+      order.find((name) => enabledNames.has(name)) ||
+      actions.find((action) => action.enabled)?.fnName;
+    if (!target) return false;
+    this.selectFunction(target);
+    return true;
   }
 
   onIndexerImportQueryChange(value: any) {
@@ -3717,7 +3755,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         // reject it here with a clear message instead of letting it panic.
         if (amountToSellerSompi >= inputAmount) {
           this.interactError.set(
-            'Amount to seller must be less than the full contract balance. Arbitrate always pays out both sides, so the buyer\'s output can\'t be zero.',
+            "Amount to seller must be less than the full contract balance. Arbitrate always pays out both sides, so the buyer's output can't be zero.",
           );
           return;
         }
@@ -3843,10 +3881,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           return;
         }
         const withdrawalAmount = BigInt(Math.floor(outputAmountKas * 1e8));
-        if (
-          functionName === 'transfer' &&
-          compiled.contract_name === 'KCC20'
-        ) {
+        if (functionName === 'transfer' && compiled.contract_name === 'KCC20') {
           try {
             extraArgsOverride = {
               recipient: Uint8Array.from(
@@ -5426,7 +5461,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // bytes gets misread as a second push opcode, splicing in a bogus
     // "pubkey" ahead of the real next one and shifting the buyer/seller
     // indices this function's callers rely on.
-    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2; ) {
+    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2;) {
       if (scriptBytes[i] === 0x20) {
         const pkHex = Array.from(scriptBytes.slice(i + 1, i + 33))
           .map((b) => b.toString(16).padStart(2, '0'))

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -82,6 +82,11 @@ import { ApprovalFlowService } from '../../../../services/approval-flow.service'
 import { AddressSmartInputComponent } from '../../../../shared/ui/input/address-smart-input/address-smart-input.component';
 import { CovenantDateTimeInputComponent } from './covenant-date-time-input.component';
 import { WalletProfileOrbComponent } from '../../../../shared/ui/wallet-profile-orb/wallet-profile-orb.component';
+import {
+  ActionFieldConfigEntry,
+  CONTRACT_ACTION_FIELDS,
+} from './contract-action-fields.config';
+import { ContractActionFieldsComponent } from './components/contract-action-fields/contract-action-fields.component';
 
 type TabName =
   | 'deploy'
@@ -94,6 +99,8 @@ type ContractDetailTab = 'details' | 'action';
 type CreateMode = 'template' | 'custom';
 type ContractsTransientState = {
   activeTab?: TabName;
+  detailPanelTab?: ContractDetailTab;
+  actionPageView?: 'list' | 'form';
   selectedFunction?: string;
   interactContractJson?: string;
   interactOutpointTxid?: string;
@@ -196,6 +203,7 @@ type DeployIndexerState = {
     AddressSmartInputComponent,
     CovenantDateTimeInputComponent,
     WalletProfileOrbComponent,
+    ContractActionFieldsComponent,
   ],
   templateUrl: './contracts-page.component.html',
   styleUrl: './contracts-page.component.scss',
@@ -348,8 +356,28 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * ready as each one's writes land out of order.
    */
   private detailRequestToken = 0;
+  /**
+   * Tracks which non-silent openContractDetail()/prepareDashboardAction()
+   * call is allowed to clear selectedDetailLoading. detailRequestToken is
+   * bumped by EVERY call including silent background refreshes (e.g. the
+   * loadContracts() polling loop), so gating the loading-flag reset on
+   * `requestToken === this.detailRequestToken` let a silent call that
+   * started after a non-silent one strand the flag at true forever — the
+   * non-silent call's own reset would never fire since its token no longer
+   * matched, and the silent call never touches the flag at all. This
+   * separate token is only ever written by non-silent calls, so it isn't
+   * disturbed by concurrent silent ones.
+   */
+  private loadingRequestToken = 0;
   selectedDetailError = signal<string | null>(null);
   detailPanelTab = signal<ContractDetailTab>('details');
+  /**
+   * Whether the "action" panel shows the curated action list or one
+   * selected action's full-page form — mutually exclusive with the list
+   * once an action is picked, unlike detailPanelTab which just toggles
+   * whether this whole panel appears below the always-visible details.
+   */
+  actionPageView = signal<'list' | 'form'>('list');
   detailRouteId = signal<string | null>(null);
   detailRouteNotFound = signal(false);
   pendingUrlImport = signal<string | null>(null);
@@ -665,6 +693,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     if (!state) return;
 
     if (state.activeTab) this.activeTab.set(state.activeTab);
+    if (state.detailPanelTab) this.detailPanelTab.set(state.detailPanelTab);
+    if (state.actionPageView) this.actionPageView.set(state.actionPageView);
     if (state.selectedFunction !== undefined)
       this.selectedFunction = state.selectedFunction;
     if (state.interactContractJson !== undefined)
@@ -1996,6 +2026,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const isCurrentRequest = () => requestToken === this.detailRequestToken;
 
     if (!silent) {
+      this.loadingRequestToken = requestToken;
       this.selectedDetailLoading.set(true);
       this.selectedDetail.set({ entry, actions: [], utxos: [] });
       if (this.detailRouteId() || this.activeTab() === 'detail') {
@@ -2101,7 +2132,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         );
       }
     } finally {
-      if (isCurrentRequest() && !silent) {
+      if (requestToken === this.loadingRequestToken && !silent) {
         this.selectedDetailLoading.set(false);
         if (!skipScrollToTop) this.scrollContractsContentToTop();
       }
@@ -2139,6 +2170,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   async openDashboardAction(entry: ContractDashboardEntry) {
     this.detailPanelTab.set('action');
+    this.actionPageView.set('form');
     this.activeTab.set('detail');
     await this.openContractDetail(entry, { skipScrollToTop: true });
     this.scrollToActionPanel();
@@ -2155,6 +2187,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    */
   selectDetailAction(fnName?: string) {
     this.detailPanelTab.set('action');
+    this.actionPageView.set('form');
     if (fnName) {
       if (this.availableFunctions().some((fn) => fn.name === fnName)) {
         this.selectFunction(fnName);
@@ -2211,6 +2244,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         'Actions are disabled because the indexer reports multiple active UTXOs for this covenant. Open details and choose a specific UTXO once the wallet supports UTXO selection.',
       );
       this.detailPanelTab.set('details');
+      this.actionPageView.set('list');
       return false;
     }
 
@@ -2223,7 +2257,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     }
 
     try {
-      if (!silent) this.selectedDetailLoading.set(true);
+      if (!silent) {
+        this.loadingRequestToken = requestToken;
+        this.selectedDetailLoading.set(true);
+      }
       const response = await this.fetchIndexerCovenant(identifier);
       const preview = await this.buildIndexerImportPreview(response);
       if (requestToken !== this.detailRequestToken) return false;
@@ -2249,6 +2286,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         if (!silent) {
           this.activeTab.set('detail');
           this.detailPanelTab.set('action');
+          this.actionPageView.set('form');
         }
         return true;
       }
@@ -2258,7 +2296,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         error?.message || 'Import this contract before using wallet actions.',
       );
     } finally {
-      if (requestToken === this.detailRequestToken && !silent) {
+      if (requestToken === this.loadingRequestToken && !silent) {
         this.selectedDetailLoading.set(false);
       }
     }
@@ -2341,15 +2379,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   navigateToContractDetail(entry: ContractDashboardEntry) {
     this.detailPanelTab.set('details');
+    this.actionPageView.set('list');
     this.activeTab.set('detail');
     void this.openContractDetail(entry);
-  }
-
-  setContractDetailTab(tab: ContractDetailTab) {
-    if (tab === 'action' && this.selectedDetail()?.entry.status === 'spent')
-      return;
-    this.detailPanelTab.set(tab);
-    this.scrollContractsContentToTop();
   }
 
   backToContractsList() {
@@ -2634,6 +2666,40 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         disabledReason: disabledReason ?? undefined,
       };
     });
+  }
+
+  /** Field-layout config for a curated action's full-page form, keyed the same way as actionMetaTable. */
+  getActionFieldConfig(
+    contractName: string,
+    fnName: string,
+  ): ActionFieldConfigEntry | null {
+    const normalized = this.normalizeContractName(contractName);
+    return CONTRACT_ACTION_FIELDS[normalized]?.[fnName] ?? null;
+  }
+
+  /** The curated label/description for the currently selected action, for the full-page form's header. */
+  getSelectedActionMeta(detail: ContractDetailState): AvailableAction | undefined {
+    return this.getAvailableActions(detail).find(
+      (action) => action.fnName === this.selectedFunction,
+    );
+  }
+
+  /**
+   * Field config for whatever function is currently selected. Null for
+   * generic/custom contracts with no curated actionMetaTable entry — those
+   * keep rendering the old manual/ABI-driven chain instead of this form.
+   *
+   * Plain method (not computed()) for the same reason as extraArgsForFunction():
+   * selectedFunction is a plain string, not a signal, so a computed() would
+   * not re-evaluate when it changes.
+   */
+  getSelectedActionFieldConfig(): ActionFieldConfigEntry | null {
+    const contract = this.parsedInteractContract();
+    if (!contract || !this.selectedFunction) return null;
+    return this.getActionFieldConfig(
+      contract.contract_name,
+      this.selectedFunction,
+    );
   }
 
   /** Disables a MultiSig spend action unless the current wallet is one of its required signer pair. */
@@ -3871,7 +3937,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         const partialJson = JSON.stringify(partial, null, 2);
         this.partialSpendJson.set(partialJson);
         this.flowPagesService.saveTransientState('contracts', {
-          activeTab: 'interact',
+          activeTab: this.activeTab(),
+          detailPanelTab: this.detailPanelTab(),
+          actionPageView: this.actionPageView(),
           selectedFunction: functionName,
           interactContractJson: contractJson,
           interactOutpointTxid: this.interactOutpointTxid,
@@ -4859,6 +4927,17 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // Withdrawal function: default output to user's wallet, clear amount
       this.interactOutputAddress = this.currentWallet()?.getAddress() || '';
       this.interactOutputAmount = '';
+      // Curated actions whose field config omits an amount field (e.g. DMS
+      // claim) always withdraw the full balance — there's no input for the
+      // user to fill in, so fill it in for them instead of leaving it empty.
+      // (getSelectedActionFieldConfig() already reflects `name` — it was
+      // just assigned to selectedFunction above.)
+      const config = this.getSelectedActionFieldConfig();
+      const hasAmountField =
+        config?.fields.some((f) => f.type === 'amount') ?? true;
+      if (!hasAmountField) {
+        this.fillMaxOutputAmount();
+      }
     } else if (this.isDmsKeepAlive()) {
       // DMS keepAlive — output address will be the new DMS contract, computed later
       this.interactOutputAddress = '';
@@ -4883,6 +4962,23 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         }
       }
     }
+  }
+
+  /**
+   * Return from a curated action's full-page form back to the action list —
+   * resets the per-action transient fields (mirroring the reset block in
+   * selectFunction()) plus the function selection itself. Leaves the loaded
+   * contract JSON/outpoint untouched since it's the same contract.
+   */
+  goBackToActionList() {
+    this.actionPageView.set('list');
+    this.selectedFunction = '';
+    this.interactError.set(null);
+    this.interactResult.set(null);
+    this.partialSpendJson.set(null);
+    this.extraArgValues = {};
+    this.dmsNewExpiry = '';
+    this.topUpAmount = '';
   }
 
   /**
@@ -5032,6 +5128,43 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactOutputAmount =
       value === null || value === undefined ? '' : String(value);
     this.interactError.set(null);
+  }
+
+  // ─── Generic action-page field delegators ──────────────────────────────
+  // ContractActionFieldsComponent doesn't know which contract/action is
+  // active — it just forwards raw value changes here, and these route to
+  // the same state/handlers the fields already used inline.
+
+  onGenericAddressChange(value: string) {
+    this.onInteractOutputAddressChange(value);
+  }
+
+  onGenericAddressResolved(result: any) {
+    this.onInteractOutputAddressResolved(result);
+  }
+
+  onGenericAddressQrClick() {
+    this.onInteractOutputQrClick();
+  }
+
+  onGenericAmountChange(value: string) {
+    if (this.isTopUpFunction(this.selectedFunction)) {
+      this.onTopUpAmountChange(value);
+    } else {
+      this.onInteractOutputAmountChange(value);
+    }
+  }
+
+  onGenericAmountMaxClick() {
+    this.fillMaxOutputAmount();
+  }
+
+  onGenericTimestampChange(value: string) {
+    this.dmsNewExpiry = value || '';
+  }
+
+  onGenericExtraArgChange(event: { name: string; value: string }) {
+    this.onExtraArgValueChange(event.name, event.value);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replaces the single scrollable "action" panel (available-actions list + inline field branches for whichever action was picked) with a real per-action full-page flow: **My Contracts → contract details (with available-actions list) → dedicated full page for the selected action**, each with its own back button. Clicking a card's suggested action jumps straight into that action's page, skipping the details list.
- Field layout per (contract type, action) is now data-driven via `contract-action-fields.config.ts`, rendered by a new generic `ContractActionFieldsComponent` instead of a long hand-written `@if` chain. The raw "Advanced" interact tab and the manual fallback for non-curated contracts are untouched.
- `DeadManSwitch.claim` drops its amount field — claiming is always the full balance (leaving a remainder would let the owner call `keepAlive` on it, since that has no deadline check, permanently blocking the heir).
- The co-signer partial-spend JSON completion box is now scoped to actual two-phase multi-sig actions (`spend12/13/23`, `release`) instead of showing on every action page.
- Fixes a request-token race where a silent background refresh (`loadContracts()` polling) could strand `selectedDetailLoading` at `true` forever, leaving the available-actions panel stuck on its loading skeleton until a full page reload.

## Test plan
- [x] `ng build` (already verified clean locally)
- [x] For each of the 4 contract types (DeadManSwitch, TimeLockVault, MultiSigVault, EscrowWithArbiter), open a deployed instance and click through every curated action, confirming only that action's page renders (no details/participants/timeline bleeding through) and "Back to actions" returns cleanly
- [x] Confirm `claim` shows no amount field and always sends the full balance
- [x] Confirm the co-signer JSON box only appears on `spend12/13/23`/`release`
- [x] Multi-sig round trip through the approval flow returns to the same action page
- [x] Raw "Advanced" interact tab and "Manual interaction" fallback for non-curated contracts still work unchanged
- [x] Open a contract from a My Contracts card's suggested-action button and confirm no more "stuck empty" available-actions panel requiring a refresh
