### PR TITLE
Clarify and highlight the co-signer partial-spend completion section

### DIFF
--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2194,13 +2194,16 @@
           }
 
           @if (isMultiSigFunction(selectedFunction)) {
-            <details class="advanced-section">
-              <summary>Complete co-signer transaction</summary>
+            <details class="advanced-section cosigner-complete-section">
+              <summary
+                >Have a co-signer's partial transaction JSON? Click here to
+                complete it</summary
+              >
               <div class="adv-body">
                 <span class="text-gray-75 typo-text-2"
-                  >Paste the partial spend JSON received from the co-signer, or
-                  import it from a file. Your signature will be added and the
-                  transaction broadcast.</span
+                  >Paste the partial spend JSON received from the co-signer,
+                  or import it from a file. Your signature will be added and
+                  the transaction broadcast.</span
                 >
                 <textarea
                   class="contract-input"
@@ -2749,13 +2752,16 @@
         }
 
         @if (parsedInteractContract() && contractHasMultiSigFunction()) {
-          <details class="advanced-section">
-            <summary>Complete co-signer transaction</summary>
+          <details class="advanced-section cosigner-complete-section">
+            <summary
+              >Have a co-signer's partial transaction JSON? Click here to
+              complete it</summary
+            >
             <div class="adv-body">
               <span class="text-gray-75 typo-text-2"
-                >Paste the partial spend JSON received from the co-signer, or
-                import it from a file. Your signature will be added and the
-                transaction broadcast.</span
+                >Paste the partial spend JSON received from the co-signer,
+                or import it from a file. Your signature will be added and
+                the transaction broadcast.</span
               >
               <textarea
                 class="contract-input"

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.scss
@@ -714,6 +714,32 @@ $tpl-accents: (
 // keyframes) and .advanced-section base styles now live in
 // src/styles/shared-ui.scss.
 
+// Overrides .advanced-section's neutral, low-attention look for the
+// co-signer completion drawer: this is a primary action for anyone holding
+// a partial spend JSON, not a "power user" option, so it needs to read as a
+// call-to-action at a glance. Uses the same teal/kaspa accent as
+// .contract-summary (the panel's own info box) rather than yellow — the
+// page already has several yellow warning banners nearby (two-phase signing
+// notice, fee warning), so another yellow box here just adds to that noise
+// instead of standing out.
+.cosigner-complete-section {
+  border-color: var(--kaspa-20);
+  background: rgba(111, 199, 186, 0.08);
+  summary {
+    padding: 16px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--kaspa-20);
+    &:hover {
+      color: var(--kaspa-20);
+      opacity: 0.85;
+    }
+  }
+  &[open] summary {
+    border-bottom-color: var(--kaspa-20);
+  }
+}
+
 // .contract-input/.form-input base styles now live in
 // src/styles/shared-ui.scss; only the textarea-specific sizing stays local.
 .contract-input {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -5178,7 +5178,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   /**
    * Whether this contract has *any* multi-sig entrypoint — gates the
-   * "Complete co-signer transaction" section, which is only relevant for
+   * "Received a partial transaction from a co-signer?" section, which is only relevant for
    * contracts that can produce a partial spend in the first place (e.g. a
    * plain Dead Man's Switch or single-sig Escrow release has nothing for a
    * co-signer to complete).


### PR DESCRIPTION
## Summary
- The "Complete co-signer transaction" disclosure on the covenant action page was easy to overlook and its label didn't explain when it applies.
- Reworded the summary to state plainly when to use it: "Have a co-signer's partial transaction JSON? Click here to complete it."
- Restyled the section with the page's teal/kaspa accent (same as the contract-summary info box) instead of yellow, so it stands out as its own action rather than blending into the other yellow warning banners already shown near it (two-phase signing notice, fee warning).
- Applied consistently to both places this section appears (curated action form + legacy interact tab).

## Test plan
- [ ] Open a multi-sig (2-of-3) or escrow contract's withdraw action and confirm the co-signer completion section reads clearly and is visually distinct
- [ ] Confirm the same section in the legacy interact tab (contractHasMultiSigFunction) looks/reads the same
- [ ] Paste/import a partial spend JSON and confirm sign & broadcast still works