### PR TITLE
Fix indexer-tracking bail-out surviving approval overlay + Skip waiting link

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -123,8 +123,11 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
-        # Covers the chromium / webkit / firefox projects in the matrix above.
-        run: npx playwright install --with-deps chromium webkit firefox
+        # Only the project this matrix leg runs needs installing — pulling
+        # all three (and their apt deps) on every leg was blowing most of
+        # the 20-minute job timeout on redundant installs before a single
+        # test ran.
+        run: npx playwright install --with-deps ${{ matrix.project }}
 
       - name: Run @smoke on ${{ matrix.project }}
         run: npx playwright test --grep @smoke --project=${{ matrix.project }}

--- a/src/app/v2/guard/auth.guard.ts
+++ b/src/app/v2/guard/auth.guard.ts
@@ -23,15 +23,21 @@ export class AuthGuard implements CanActivate {
     const userData = localStorage.getItem(LOCAL_STORAGE_KEYS.USER_DATA); // replace with your actual key
 
     const fullPath = state.url;
+    // Compare path only: fullPath includes the query string (e.g. returnUrl),
+    // which would otherwise make '/onboarding?returnUrl=...' fail to match
+    // '/onboarding' and re-trigger the redirect, looping forever.
+    const path = fullPath.split('?')[0];
 
     const onboardingPaths = ['/onboarding', '/onboarding-v2'];
 
     if (!userData) {
-      if (onboardingPaths.includes(fullPath)) {
+      if (onboardingPaths.includes(path)) {
         return true;
       }
 
-      this.router.navigate(['/onboarding']);
+      this.router.navigate(['/onboarding'], {
+        queryParams: { returnUrl: fullPath },
+      });
       return false;
     }
 
@@ -44,15 +50,17 @@ export class AuthGuard implements CanActivate {
     }
 
     if (!isLogged) {
-      if (onboardingPaths.includes(fullPath)) {
+      if (onboardingPaths.includes(path)) {
         return true;
       }
 
-      this.router.navigate(['/onboarding']);
+      this.router.navigate(['/onboarding'], {
+        queryParams: { returnUrl: fullPath },
+      });
       return false;
     }
 
-    if (isLogged && onboardingPaths.includes(fullPath)) {
+    if (isLogged && onboardingPaths.includes(path)) {
       this.router.navigate(['/app/home']);
       return false;
     }

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.scss
@@ -170,6 +170,22 @@
   color: var(--text-secondary, #a0a0a0);
 }
 
+.skip-confirmation-link {
+  display: block;
+  margin: 12px auto 0;
+  padding: 4px;
+  background: none;
+  border: none;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #a0a0a0);
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text-primary, #ffffff);
+  }
+}
+
 // Animations
 @keyframes fadeInUp {
   from {

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -98,6 +98,11 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
           (buttonClick)="onDone()"
           class="done-button"
         />
+        @if (isAwaitingConfirmation()) {
+          <button type="button" class="skip-confirmation-link" (click)="onDone()">
+            Skip waiting
+          </button>
+        }
       </div>
     </div>
   `,

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -99,7 +99,11 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
           class="done-button"
         />
         @if (isAwaitingConfirmation()) {
-          <button type="button" class="skip-confirmation-link" (click)="onDone()">
+          <button
+            type="button"
+            class="skip-confirmation-link"
+            (click)="onDone()"
+          >
             Skip waiting
           </button>
         }

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -104,7 +104,7 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
           <button
             type="button"
             class="skip-confirmation-link"
-            (click)="onDone()"
+            (click)="onDone(true)"
           >
             Skip waiting
           </button>
@@ -190,7 +190,7 @@ export class ApprovalSuccessPageComponent {
     this.showDetails = !this.showDetails;
   }
 
-  onDone() {
+  onDone(skipWaiting = false) {
     // Covenant actions are dispatched from the contracts page, which stays
     // mounted behind the approval overlay with the action result rendered on
     // it — navigating to home would destroy that view, so only close the
@@ -201,6 +201,15 @@ export class ApprovalSuccessPageComponent {
 
       // Navigate to homepage with the correct tab
       this.router.navigate(['/app/home'], { queryParams: { tab } });
+    }
+
+    // "Skip waiting" is only rendered while isAwaitingConfirmation() is
+    // true, i.e. an action-indexing poll is still in flight — opt the next
+    // Contracts load out of blocking on it. The disabled-until-indexed
+    // "Done" path never needs this: it can't be clicked until the poll has
+    // already settled.
+    if (skipWaiting) {
+      this.approvalFlowService.skipActionIndexing();
     }
 
     // Close the approval flow

--- a/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
+++ b/src/app/v2/pages/app/flows/approval/approval-flow-page/components/approval-success-page.component.ts
@@ -90,11 +90,13 @@ import { WalletActionService } from '../../../../../../../services/wallet-action
           </p>
         }
         <kc-button
-          [text]="isAwaitingConfirmation() ? 'Confirming...' : 'Done'"
+          text="Done"
           variant="primary"
           size="m"
           [isFullWidth]="true"
           [isDisabled]="isAwaitingConfirmation()"
+          [isLoading]="isAwaitingConfirmation()"
+          loadingText="Confirming..."
           (buttonClick)="onDone()"
           class="done-button"
         />

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -1390,7 +1390,9 @@
             <div class="detail-cols">
               <!-- LEFT: actions + participants -->
               <div class="detail-col">
-                @if (actionPageView() === "list") {
+                @if (
+                  actionPageView() === "list" && !hideActionsAfterCompletion()
+                ) {
                   <div class="panel">
                     <div class="action-panel-head">
                       <h4

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -115,6 +115,7 @@ type ContractsTransientState = {
   partialSpendJson?: string;
   interactResult?: { txid: string; functionName: string };
   hideActionsAfterCompletion?: boolean;
+  landOnContractId?: string;
 };
 
 type IndexerImportPreview = {
@@ -408,6 +409,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    *    form instead of landing on details.
    */
   hideActionsAfterCompletion = signal(false);
+  /**
+   * Registry id of the contract to open straight to details for, restored
+   * from transient state by restoreTransientState() and consumed once by
+   * loadContracts()'s tail — see markActionCompleteForDetailsLanding(). A
+   * freshly re-created instance otherwise has no route id and no
+   * selectedDetail, so it would land on the plain "My Contracts" list
+   * instead of the contract the user just finished acting on.
+   */
+  private pendingLandOnContractId?: string;
   selectedDetailError = signal<string | null>(null);
   detailPanelTab = signal<ContractDetailTab>('details');
   /**
@@ -759,6 +769,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.interactResult.set(state.interactResult);
     if (state.hideActionsAfterCompletion)
       this.hideActionsAfterCompletion.set(true);
+    if (state.landOnContractId)
+      this.pendingLandOnContractId = state.landOnContractId;
 
     this.flowPagesService.saveTransientState('contracts', undefined);
   }
@@ -1506,6 +1518,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       );
       if (refreshed) {
         await this.openContractDetail(refreshed, { silent: true });
+      }
+    } else if (this.pendingLandOnContractId) {
+      // Land on the contract an action just completed on — see
+      // pendingLandOnContractId's doc comment. One-shot: clear it regardless
+      // of whether a match was found, so it doesn't stick around and hijack
+      // some later, unrelated load.
+      const contractId = this.pendingLandOnContractId;
+      this.pendingLandOnContractId = undefined;
+      const target = this.dashboardContracts().find(
+        (entry) => entry.registryEntry?.id === contractId,
+      );
+      if (target) {
+        this.activeTab.set('detail');
+        await this.openContractDetail(target);
       }
     }
   }
@@ -3878,12 +3904,16 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
 
   /**
    * Call right after a covenant action succeeds — see
-   * hideActionsAfterCompletion's doc comment for what this does and why.
+   * hideActionsAfterCompletion's and pendingLandOnContractId's doc comments
+   * for what this does and why. `registryEntryId` is the acted-on contract
+   * (this.selectedContractId() at the call site) — omit it if there's no
+   * local registry entry to land back on.
    */
-  private markActionCompleteForDetailsLanding(): void {
+  private markActionCompleteForDetailsLanding(registryEntryId?: string): void {
     this.hideActionsAfterCompletion.set(true);
     this.flowPagesService.saveTransientState('contracts', {
       hideActionsAfterCompletion: true,
+      landOnContractId: registryEntryId || undefined,
     } satisfies ContractsTransientState);
   }
 
@@ -4147,7 +4177,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
               spendTxid: result.txid,
               lastChecked: Date.now(),
             });
-            this.markActionCompleteForDetailsLanding();
+            this.markActionCompleteForDetailsLanding(this.selectedContractId());
             void this.trackActionIndexing(
               result.txid,
               this.selectedContractId(),
@@ -4431,7 +4461,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.interactOutpointTxid = result.txid;
           this.interactOutpointVout = '0';
         }
-        this.markActionCompleteForDetailsLanding();
+        this.markActionCompleteForDetailsLanding(this.selectedContractId());
         void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {
@@ -4602,7 +4632,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactInputAmount = inputAmount.toString();
     this.dmsNewExpiry = '';
 
-    this.markActionCompleteForDetailsLanding();
+    this.markActionCompleteForDetailsLanding(this.selectedContractId());
     void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
@@ -4706,7 +4736,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactOutputAddress = '';
     this.interactResolvedOutputAddress = null;
 
-    this.markActionCompleteForDetailsLanding();
+    this.markActionCompleteForDetailsLanding(this.selectedContractId());
     void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
@@ -5761,7 +5791,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
             lastChecked: Date.now(),
           });
         }
-        this.markActionCompleteForDetailsLanding();
+        this.markActionCompleteForDetailsLanding(this.selectedContractId());
         void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -835,7 +835,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         'That address matches multiple wallet-supported covenants. Open by covenant ID or deploy transaction to choose the exact contract.',
       );
     }
-    const row = exactRow || supportedRows[0];
+    // A hex id/txid/script-hash query must resolve to an exact match — falling
+    // back to "the only row the fuzzy search returned" risks silently
+    // substituting an unrelated covenant (e.g. while the real one is still
+    // indexer-lagged and its direct lookup above failed).
+    const row = exactRow || (isHexIdentifier ? undefined : supportedRows[0]);
     const identifier =
       row?.covenantIdHex || row?.scriptHashHex || row?.genesisTxidHex;
     if (identifier) {
@@ -847,14 +851,18 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       (result) =>
         (result.kind === 'covenant' || result.kind === 'transaction') &&
         !!result.id &&
-        /^[0-9a-fA-F]{64}$/.test(result.id),
+        /^[0-9a-fA-F]{64}$/.test(result.id) &&
+        (!isHexIdentifier ||
+          this.normalizeIdentity(result.id) === normalizedQuery),
     );
     if (concrete?.id) {
       return await this.fetchIndexerCovenant(concrete.id);
     }
 
     throw new Error(
-      'No importable wallet-supported covenant found for that query.',
+      isHexIdentifier
+        ? 'This covenant is not indexed yet. It may still be catching up with the network — try again shortly.'
+        : 'No importable wallet-supported covenant found for that query.',
     );
   }
 
@@ -2193,6 +2201,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   async openDashboardAction(entry: ContractDashboardEntry) {
+    // Same reasoning as navigateToContractDetail(): this can also be reached
+    // directly from a My Contracts card, so drop any stale route-driven id.
+    this.detailRouteId.set(null);
     this.detailPanelTab.set('action');
     this.actionPageView.set('form');
     this.activeTab.set('detail');
@@ -2457,6 +2468,10 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   navigateToContractDetail(entry: ContractDashboardEntry) {
+    // Drop any stale route-driven id (e.g. left over from an earlier direct
+    // URL visit) — otherwise a loadContracts() still in flight from the tab
+    // switch re-opens it via its own tail logic and clobbers this entry.
+    this.detailRouteId.set(null);
     this.detailPanelTab.set('details');
     this.actionPageView.set('list');
     this.activeTab.set('detail');

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -4466,14 +4466,15 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     registryEntryId?: string,
   ): Promise<void> {
     let resolveCompletion!: () => void;
-    this.approvalFlowService.setActionIndexingCompletion(
-      new Promise<void>((resolve) => (resolveCompletion = resolve)),
+    const completion = new Promise<void>(
+      (resolve) => (resolveCompletion = resolve),
     );
+    this.approvalFlowService.setActionIndexingCompletion(completion);
     try {
       await this.trackActionIndexingCore(txid, registryEntryId);
     } finally {
       resolveCompletion();
-      this.approvalFlowService.setActionIndexingCompletion(null);
+      this.approvalFlowService.clearActionIndexingCompletion(completion);
     }
   }
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -468,11 +468,6 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   interactOutputAddress = '';
   interactResolvedOutputAddress: string | null = null;
 
-  // Set in ngOnDestroy() so trackActionIndexing()'s poll loop can bail out
-  // instead of updating signals/services and scheduling more RPC/indexer
-  // traffic after the component is gone.
-  private destroyed = false;
-
   // Lookup form
   lookupContractJson = '';
   interactOutputAmount = '';
@@ -696,7 +691,6 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.destroyed = true;
     this.wideWorkspaceService.deactivate();
     this.routeSubscription?.unsubscribe();
   }
@@ -3731,20 +3725,20 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     let seenSettled = false;
 
     for (let attempt = 1; attempt <= 8; attempt++) {
-      if (this.destroyed) return;
+      if (this.bailIfLeftContractsFlow()) return;
       try {
         if (!seenSettled) {
           const status =
             await this.covenantIndexerService.getTransactionSettlementStatus(
               txid,
             );
-          if (this.destroyed) return;
+          if (this.bailIfLeftContractsFlow()) return;
           seenSettled = status.indexed;
         }
 
         if (seenSettled) {
           await this.loadContracts({ skipOnChainStatusRefresh: true });
-          if (this.destroyed) return;
+          if (this.bailIfLeftContractsFlow()) return;
           if (this.dashboardCaughtUpWithLocal(registryEntryId)) {
             this.setActionIndexerState({
               txid,
@@ -3778,7 +3772,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       }
 
       await this.delay(2500);
-      if (this.destroyed) return;
+      if (this.bailIfLeftContractsFlow()) return;
     }
 
     this.setActionIndexerState({
@@ -3787,6 +3781,33 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       message:
         'Broadcast, but My Contracts may not reflect this change yet. Refresh in a moment.',
     });
+  }
+
+  /**
+   * The flow-page outlet actually destroys ContractsPageComponent the
+   * instant the approval success screen is layered on top of it (see
+   * isContractsWide's comment in app-wrapper.component.ts) — it does NOT
+   * stay mounted behind the overlay. Bailing on that destruction, as this
+   * used to do via a component-local `destroyed` flag, made trackActionIndexing()
+   * abandon the poll (and flush pendingConfirmation to 'unavailable')
+   * immediately after every covenant action, before the indexer had any
+   * chance to catch up — the success page's "Done" button was effectively
+   * always enabled and the "Skip waiting" link never appeared.
+   *
+   * 'contracts' stays in the flow-page stack while merely covered by the
+   * overlay (isPageInStack() is true), so use that instead to tell "covered
+   * but coming back" apart from "actually left" (e.g. navigated fully away
+   * via backToContractsList()) — only the latter should flush a terminal
+   * state so pendingConfirmation doesn't get stuck at 'checking' forever.
+   */
+  private bailIfLeftContractsFlow(): boolean {
+    if (this.flowPagesService.isPageInStack('contracts')) return false;
+    this.approvalFlowService.setPendingConfirmation({
+      status: 'unavailable',
+      message:
+        'Left the contracts page before indexing finished. The transaction was still broadcast.',
+    });
+    return true;
   }
 
   /**
@@ -5657,7 +5678,19 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           json,
         },
       })
-      .closed.subscribe(() => this.backToContractsList());
+      .closed.subscribe(() => {
+        // The transient state saved before opening this dialog has done its
+        // job (surfacing the partial JSON) — clear it before navigating back.
+        // For a contract opened via a direct link, backToContractsList()
+        // below does a full route navigation that destroys and recreates
+        // this component; left uncleared, the recreated instance's
+        // restoreTransientState() would restore the old detail/action-form
+        // view instead of the "My Contracts" list it's resetting to, and
+        // that view has no selectedDetail loaded — leaving the user stuck on
+        // a blank page instead of the list.
+        this.flowPagesService.saveTransientState('contracts', undefined);
+        this.backToContractsList();
+      });
   }
 
   /**

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -136,7 +136,11 @@ type IndexerImportPreview = {
 
 type ContractDashboardSource = 'indexer' | 'local' | 'both';
 type ContractDashboardFilter =
-  'all' | 'deadman' | 'timelock' | 'multisig' | 'escrow';
+  | 'all'
+  | 'deadman'
+  | 'timelock'
+  | 'multisig'
+  | 'escrow';
 // Status dimension, composed on top of the template-type filter above.
 type ContractStatusFilter = 'all' | 'active' | 'history';
 
@@ -5763,7 +5767,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // bytes gets misread as a second push opcode, splicing in a bogus
     // "pubkey" ahead of the real next one and shifting the buyer/seller
     // indices this function's callers rely on.
-    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2;) {
+    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2; ) {
       if (scriptBytes[i] === 0x20) {
         const pkHex = Array.from(scriptBytes.slice(i + 1, i + 33))
           .map((b) => b.toString(16).padStart(2, '0'))

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -418,6 +418,19 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * instead of the contract the user just finished acting on.
    */
   private pendingLandOnContractId?: string;
+  /**
+   * Set in ngOnDestroy(). This component is torn down by the flow-page
+   * outlet whenever it hosts the "contracts" flow page (see
+   * bailIfLeftContractsFlow()'s doc comment) — but it's also directly
+   * routed at /app/contracts and /app/contracts/:contractId (see
+   * logged.routes.ts), and in that hosting mode the approval overlay layers
+   * on top via the flow-page outlet without ever destroying this instance,
+   * so isPageInStack('contracts') is permanently false (this page was never
+   * pushed onto that stack) even though the user never left. Gating the
+   * bail on this flag too means "not in the flow-page stack" only counts as
+   * "left" once this specific instance has actually been destroyed.
+   */
+  private destroyed = false;
   selectedDetailError = signal<string | null>(null);
   detailPanelTab = signal<ContractDetailTab>('details');
   /**
@@ -734,6 +747,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.destroyed = true;
     this.wideWorkspaceService.deactivate();
     this.routeSubscription?.unsubscribe();
   }
@@ -909,10 +923,40 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * Switch tab
    */
   switchTab(tab: TabName) {
+    if (tab === 'deploy' && this.deployResult()) {
+      this.resetDeployWizard();
+    }
     this.activeTab.set(tab);
     if (tab === 'my-contracts') {
       this.loadContracts();
     }
+  }
+
+  /**
+   * A completed deploy leaves activeTemplate/generatedContractJson/
+   * deployResult populated so the success details stay visible on the
+   * "Review & deploy" step — but when this component is router-hosted (see
+   * `destroyed`'s doc comment) the approval overlay never tears this
+   * instance down, so none of that resets on its own. Without this,
+   * deliberately returning to Create lands back on that same last step
+   * instead of the template picker. Called from switchTab() when the user
+   * clicks back into Create with a finished deploy still showing.
+   */
+  private resetDeployWizard(): void {
+    this.createMode.set('template');
+    this.activeTemplate.set(null);
+    this.generatedContractJson.set(null);
+    this.templateError.set(null);
+    this.deployError.set(null);
+    this.deployResult.set(null);
+    this.deployIndexerState.set(null);
+    this.deployContractTouched = false;
+    this.deployContractError.set('');
+    this.deployContractJson.set('');
+    this.templateFormValues = {};
+    this.templateFieldTouched = {};
+    this.templateFieldErrors = {};
+    this.templateResolvedAddresses = {};
   }
 
   /** 'detail' belongs to the My Contracts section for tab-highlighting purposes. */
@@ -3908,9 +3952,19 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * for what this does and why. `registryEntryId` is the acted-on contract
    * (this.selectedContractId() at the call site) — omit it if there's no
    * local registry entry to land back on.
+   *
+   * Also flips detailPanelTab/actionPageView back to the plain details view
+   * directly on `this`, not just via the transient state the flow-page
+   * hosting mode restores into a fresh instance. When this component is
+   * router-hosted (see `destroyed`'s doc comment) it's never torn down by
+   * the approval overlay, so this same instance is what the user sees
+   * again — without this, it would still be sitting on whatever action
+   * form (e.g. "Claim") they just submitted.
    */
   private markActionCompleteForDetailsLanding(registryEntryId?: string): void {
     this.hideActionsAfterCompletion.set(true);
+    this.detailPanelTab.set('details');
+    this.actionPageView.set('list');
     this.flowPagesService.saveTransientState('contracts', {
       hideActionsAfterCompletion: true,
       landOnContractId: registryEntryId || undefined,
@@ -3933,8 +3987,17 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * but coming back" apart from "actually left" (e.g. navigated fully away
    * via backToContractsList()) — only the latter should flush a terminal
    * state so pendingConfirmation doesn't get stuck at 'checking' forever.
+   *
+   * That alone isn't enough when this component is router-hosted (see
+   * `destroyed`'s doc comment): isPageInStack('contracts') is then always
+   * false, since this page was never pushed onto that stack in the first
+   * place, even though the routed instance stays mounted the whole time.
+   * Require this instance to have actually been destroyed too, so the
+   * routed hosting mode never bails just because it isn't (and never was)
+   * a flow page.
    */
   private bailIfLeftContractsFlow(): boolean {
+    if (!this.destroyed) return false;
     if (this.flowPagesService.isPageInStack('contracts')) return false;
     this.approvalFlowService.setPendingConfirmation({
       status: 'unavailable',

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -114,6 +114,7 @@ type ContractsTransientState = {
   topUpAmount?: string;
   partialSpendJson?: string;
   interactResult?: { txid: string; functionName: string };
+  hideActionsAfterCompletion?: boolean;
 };
 
 type IndexerImportPreview = {
@@ -383,6 +384,30 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
    * disturbed by concurrent silent ones.
    */
   private loadingRequestToken = 0;
+  /**
+   * True right after a covenant action succeeds, until the user explicitly
+   * navigates again (navigateToContractDetail()/openDashboardAction()).
+   * Carried across the destroy/recreate cycle via transient state (see
+   * restoreTransientState()) — the flow-page outlet destroys and recreates
+   * this component the instant the approval overlay covers and uncovers it,
+   * so a plain in-memory flag wouldn't survive from the action to the
+   * "Done" click.
+   *
+   * Two effects while true:
+   *  - the template hides the "Available actions" panel (see
+   *    contracts-page.component.html) so landing back on a contract after
+   *    finishing an action shows plain details, not an immediate prompt to
+   *    take another one — that panel is otherwise shown unconditionally
+   *    whenever actionPageView() is 'list', with no other state to
+   *    distinguish "just finished acting on this" from "opened it fresh".
+   *  - openContractDetail() skips its auto-jump into an available action's
+   *    form (the `!hasEnabledDefault` branch of prepareDashboardAction) —
+   *    without it, the route subscription's own openDetailFromRoute() call
+   *    on the freshly re-created instance (and every subsequent background
+   *    refresh from the indexing poll) could still jump straight into a
+   *    form instead of landing on details.
+   */
+  hideActionsAfterCompletion = signal(false);
   selectedDetailError = signal<string | null>(null);
   detailPanelTab = signal<ContractDetailTab>('details');
   /**
@@ -732,6 +757,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.partialSpendJson.set(state.partialSpendJson);
     if (state.interactResult !== undefined)
       this.interactResult.set(state.interactResult);
+    if (state.hideActionsAfterCompletion)
+      this.hideActionsAfterCompletion.set(true);
 
     this.flowPagesService.saveTransientState('contracts', undefined);
   }
@@ -1412,6 +1439,16 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       this.selectedDetailError.set(null);
     }
 
+    // A fresh instance (e.g. re-created after the approval overlay covered
+    // and then uncovered this page — see ApprovalFlowService.waitForActionIndexing)
+    // otherwise has no idea an action-indexing poll from the previous instance
+    // is still in flight, and its own first load races ahead of it, showing
+    // stale data. `skipOnChainStatusRefresh` is only ever passed by that same
+    // poll's own internal calls, so gating on its absence can't deadlock.
+    if (!options.skipOnChainStatusRefresh) {
+      await this.approvalFlowService.waitForActionIndexing();
+    }
+
     const filtered = this.getCurrentWalletLocalContracts();
     this.registryContracts.set(filtered);
 
@@ -2056,6 +2093,12 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     const skipScrollToTop = options?.skipScrollToTop ?? false;
     const requestToken = ++this.detailRequestToken;
     const isCurrentRequest = () => requestToken === this.detailRequestToken;
+    // Stays true across every background/route-driven call in the settling
+    // window after an action (there can be several — the indexing poll keeps
+    // refreshing until it catches up) — only an explicit user navigation
+    // (navigateToContractDetail()/openDashboardAction()) clears it. See the
+    // field's doc comment.
+    const suppressAutoActionOpen = this.hideActionsAfterCompletion();
 
     if (!silent) {
       this.loadingRequestToken = requestToken;
@@ -2131,7 +2174,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       });
       if (
         (this.detailRouteId() || this.activeTab() === 'detail') &&
-        updatedEntry.status === 'active'
+        updatedEntry.status === 'active' &&
+        !suppressAutoActionOpen
       ) {
         await this.prepareDashboardAction(updatedEntry, requestToken, silent);
         if (!isCurrentRequest()) return;
@@ -2154,7 +2198,8 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
         );
         if (
           (this.detailRouteId() || this.activeTab() === 'detail') &&
-          entry.status === 'active'
+          entry.status === 'active' &&
+          !suppressAutoActionOpen
         ) {
           await this.prepareDashboardAction(entry, requestToken, silent);
         }
@@ -2207,6 +2252,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.detailPanelTab.set('action');
     this.actionPageView.set('form');
     this.activeTab.set('detail');
+    // A deliberate request to act — any suppression left over from an
+    // earlier action's settling window no longer applies.
+    this.hideActionsAfterCompletion.set(false);
     await this.openContractDetail(entry, { skipScrollToTop: true });
     this.scrollToActionPanel();
   }
@@ -2475,6 +2523,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.detailPanelTab.set('details');
     this.actionPageView.set('list');
     this.activeTab.set('detail');
+    // A deliberate fresh navigation — any suppression left over from an
+    // earlier action's settling window no longer applies.
+    this.hideActionsAfterCompletion.set(false);
     void this.openContractDetail(entry);
   }
 
@@ -2488,6 +2539,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.detailRouteId.set(null);
     this.detailRouteNotFound.set(false);
     this.activeTab.set('my-contracts');
+    // Leaving the detail view entirely — don't let suppression leak into
+    // whichever contract's detail is opened next.
+    this.hideActionsAfterCompletion.set(false);
   }
 
   private async openDetailFromRoute(routeId: string) {
@@ -3739,6 +3793,22 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     txid: string,
     registryEntryId?: string,
   ): Promise<void> {
+    let resolveCompletion!: () => void;
+    this.approvalFlowService.setActionIndexingCompletion(
+      new Promise<void>((resolve) => (resolveCompletion = resolve)),
+    );
+    try {
+      await this.trackActionIndexingCore(txid, registryEntryId);
+    } finally {
+      resolveCompletion();
+      this.approvalFlowService.setActionIndexingCompletion(null);
+    }
+  }
+
+  private async trackActionIndexingCore(
+    txid: string,
+    registryEntryId?: string,
+  ): Promise<void> {
     this.setActionIndexerState({
       txid,
       status: 'checking',
@@ -3773,13 +3843,13 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.setActionIndexerState({
             txid,
             status: 'checking',
-            message: `Transaction confirmed — waiting for the contract list to catch up (${attempt}/8)...`,
+            message: 'Transaction confirmed — waiting for confirmation...',
           });
         } else {
           this.setActionIndexerState({
             txid,
             status: 'checking',
-            message: `Waiting for indexer confirmation (${attempt}/8)...`,
+            message: 'Waiting for confirmation...',
           });
         }
       } catch (error: any) {
@@ -3804,6 +3874,17 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       message:
         'Broadcast, but My Contracts may not reflect this change yet. Refresh in a moment.',
     });
+  }
+
+  /**
+   * Call right after a covenant action succeeds — see
+   * hideActionsAfterCompletion's doc comment for what this does and why.
+   */
+  private markActionCompleteForDetailsLanding(): void {
+    this.hideActionsAfterCompletion.set(true);
+    this.flowPagesService.saveTransientState('contracts', {
+      hideActionsAfterCompletion: true,
+    } satisfies ContractsTransientState);
   }
 
   /**
@@ -4066,6 +4147,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
               spendTxid: result.txid,
               lastChecked: Date.now(),
             });
+            this.markActionCompleteForDetailsLanding();
             void this.trackActionIndexing(
               result.txid,
               this.selectedContractId(),
@@ -4349,6 +4431,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           this.interactOutpointTxid = result.txid;
           this.interactOutpointVout = '0';
         }
+        this.markActionCompleteForDetailsLanding();
         void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {
@@ -4519,6 +4602,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactInputAmount = inputAmount.toString();
     this.dmsNewExpiry = '';
 
+    this.markActionCompleteForDetailsLanding();
     void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
@@ -4622,6 +4706,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     this.interactOutputAddress = '';
     this.interactResolvedOutputAddress = null;
 
+    this.markActionCompleteForDetailsLanding();
     void this.trackActionIndexing(result.txid, this.selectedContractId());
   }
 
@@ -5676,6 +5761,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
             lastChecked: Date.now(),
           });
         }
+        this.markActionCompleteForDetailsLanding();
         void this.trackActionIndexing(result.txid, this.selectedContractId());
       }
     } catch (error: any) {
@@ -5782,7 +5868,7 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
     // bytes gets misread as a second push opcode, splicing in a bogus
     // "pubkey" ahead of the real next one and shifting the buyer/seller
     // indices this function's callers rely on.
-    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2; ) {
+    for (let i = 0; i <= scriptBytes.length - 33 && found.length < 2;) {
       if (scriptBytes[i] === 0x20) {
         const pkHex = Array.from(scriptBytes.slice(i + 1, i + 33))
           .map((b) => b.toString(16).padStart(2, '0'))

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -139,11 +139,7 @@ type IndexerImportPreview = {
 
 type ContractDashboardSource = 'indexer' | 'local' | 'both';
 type ContractDashboardFilter =
-  | 'all'
-  | 'deadman'
-  | 'timelock'
-  | 'multisig'
-  | 'escrow';
+  'all' | 'deadman' | 'timelock' | 'multisig' | 'escrow';
 // Status dimension, composed on top of the template-type filter above.
 type ContractStatusFilter = 'all' | 'active' | 'history';
 type ContractParticipant = {

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -684,7 +684,11 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
             return;
           }
         }
-        this.queueInboundIndexerImport(contractId);
+        this.detailRouteId.set(contractId);
+        this.detailPanelTab.set('details');
+        this.actionPageView.set('list');
+        this.activeTab.set('detail');
+        void this.openDetailFromRoute(contractId);
       }
     });
     void this.applyInboundContractLink();

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
@@ -15,7 +15,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { KcInputComponent, KcButtonComponent, KcIconComponent } from '@kaspacom/ui-kit';
 import { OnboardingStep } from '../onboarding-page/onboarding-step.enum';
 import { ImportExistingFlowComponent } from '../onboarding-page/flows/import-existing-flow/import-existing-flow.component';
@@ -29,6 +29,7 @@ import {
 import { IframeAccountSelectionService } from '../../services/iframe-account-selection.service';
 import { MonitorService } from '../../../services/monitor.service';
 import { IFrameCommunicationApp } from '../../../services/communication-service/communication-app/iframe-communication.service';
+import { getSafeReturnUrl } from '../../shared/utils/return-url.util';
 
 type LoginPasswordType = 'password' | 'text';
 
@@ -62,6 +63,7 @@ export class OnboardingPageV2Component implements AfterViewInit, OnDestroy {
   private readonly passwordManagerService = inject(PasswordManagerService);
   private readonly walletService = inject(WalletService);
   private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
   private readonly fb = inject(FormBuilder);
   private readonly iframeAccountSelectionService = inject(
     IframeAccountSelectionService,
@@ -253,7 +255,7 @@ export class OnboardingPageV2Component implements AfterViewInit, OnDestroy {
         is_iframe: IFrameCommunicationApp.isIframe(),
       });
 
-      await this.router.navigate(['./app/home']);
+      await this.router.navigateByUrl(getSafeReturnUrl(this.activatedRoute));
     } catch (error) {
       console.error('Login failed', error);
       this.loginForm.get('password')?.setErrors({ invalidCredentials: true });

--- a/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
+++ b/src/app/v2/pages/onboarding-page-v2/onboarding-page-v2.component.ts
@@ -16,7 +16,11 @@ import {
   Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { KcInputComponent, KcButtonComponent, KcIconComponent } from '@kaspacom/ui-kit';
+import {
+  KcInputComponent,
+  KcButtonComponent,
+  KcIconComponent,
+} from '@kaspacom/ui-kit';
 import { OnboardingStep } from '../onboarding-page/onboarding-step.enum';
 import { ImportExistingFlowComponent } from '../onboarding-page/flows/import-existing-flow/import-existing-flow.component';
 import { NewWalletFlowComponent } from '../onboarding-page/flows/new-wallet-flow/new-wallet-flow.component';

--- a/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/success-import-existing-step/success-import-existing-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/import-existing-flow/steps/success-import-existing-step/success-import-existing-step.component.ts
@@ -1,9 +1,10 @@
 import { NgOptimizedImage } from '@angular/common';
 import { Component, inject, output } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { KcButtonComponent } from '@kaspacom/ui-kit';
 import { WalletService } from '../../../../../../../services/wallet.service';
 import { FlowPagesService } from '../../../../../../services/flow-pages.service';
+import { getSafeReturnUrl } from '../../../../../../shared/utils/return-url.util';
 
 @Component({
   selector: 'app-success-import-existing-step',
@@ -18,6 +19,7 @@ export class SuccessImportExistingStepComponent {
   private readonly walletService: WalletService = inject(WalletService);
 
   private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
   private readonly flowPagesService = inject(FlowPagesService);
 
   async finish() {
@@ -39,6 +41,6 @@ export class SuccessImportExistingStepComponent {
     }
     // Ensure any flow overlays are closed
     this.flowPagesService.closePage();
-    this.router.navigate(['/app/home']);
+    this.router.navigateByUrl(getSafeReturnUrl(this.activatedRoute));
   }
 }

--- a/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/address-new-wallet-step/address-new-wallet-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/address-new-wallet-step/address-new-wallet-step.component.ts
@@ -1,6 +1,10 @@
 import { NgOptimizedImage } from '@angular/common';
 import { Component, OnInit, computed, inject, output } from '@angular/core';
-import { KcButtonComponent, KcIconComponent, NotificationService } from '@kaspacom/ui-kit';
+import {
+  KcButtonComponent,
+  KcIconComponent,
+  NotificationService,
+} from '@kaspacom/ui-kit';
 import { NewWalletFlowService } from '../../service/new-wallet-flow.service';
 import { WalletService } from '../../../../../../../services/wallet.service';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -9,11 +13,7 @@ import { getSafeReturnUrl } from '../../../../../../shared/utils/return-url.util
 
 @Component({
   selector: 'app-address-new-wallet-step',
-  imports: [
-    KcButtonComponent,
-    NgOptimizedImage,
-    KcIconComponent,
-  ],
+  imports: [KcButtonComponent, NgOptimizedImage, KcIconComponent],
   templateUrl: './address-new-wallet-step.component.html',
   styleUrl: './address-new-wallet-step.component.scss',
 })
@@ -37,7 +37,7 @@ export class AddressNewWalletStepComponent {
 
   displayWalletAddress = computed(() => {
     const address = this.walletAddress();
-    
+
     const len = 15;
     if (address.length < len) {
       return address;

--- a/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/address-new-wallet-step/address-new-wallet-step.component.ts
+++ b/src/app/v2/pages/onboarding-page/flows/new-wallet-flow/steps/address-new-wallet-step/address-new-wallet-step.component.ts
@@ -3,8 +3,9 @@ import { Component, OnInit, computed, inject, output } from '@angular/core';
 import { KcButtonComponent, KcIconComponent, NotificationService } from '@kaspacom/ui-kit';
 import { NewWalletFlowService } from '../../service/new-wallet-flow.service';
 import { WalletService } from '../../../../../../../services/wallet.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FlowPagesService } from '../../../../../../services/flow-pages.service';
+import { getSafeReturnUrl } from '../../../../../../shared/utils/return-url.util';
 
 @Component({
   selector: 'app-address-new-wallet-step',
@@ -27,6 +28,7 @@ export class AddressNewWalletStepComponent {
   private readonly notificationService = inject(NotificationService);
 
   private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
   private readonly flowPagesService = inject(FlowPagesService);
 
   walletAddress = computed(
@@ -82,6 +84,6 @@ export class AddressNewWalletStepComponent {
     }
     // Ensure any flow overlays are closed
     this.flowPagesService.closePage();
-    this.router.navigate(['/app/home']);
+    this.router.navigateByUrl(getSafeReturnUrl(this.activatedRoute));
   }
 }

--- a/src/app/v2/services/approval-flow.service.ts
+++ b/src/app/v2/services/approval-flow.service.ts
@@ -122,6 +122,17 @@ export class ApprovalFlowService {
     await this.actionIndexingCompletionSignal();
   }
 
+  // The success page's "Skip waiting" link dismisses the poll's blocking
+  // effect without cancelling the poll itself (trackActionIndexingCore()
+  // keeps running in the background and still updates the registry/
+  // pendingConfirmation when it eventually settles). Clearing the signal
+  // here just means the *next* waitForActionIndexing() call — from the
+  // freshly re-created Contracts instance — resolves immediately instead of
+  // waiting on a promise the user explicitly opted out of.
+  skipActionIndexing() {
+    this.actionIndexingCompletionSignal.set(null);
+  }
+
   /**
    * Shows approval dialog using the appropriate display mode
    */

--- a/src/app/v2/services/approval-flow.service.ts
+++ b/src/app/v2/services/approval-flow.service.ts
@@ -117,6 +117,19 @@ export class ApprovalFlowService {
     this.actionIndexingCompletionSignal.set(promise);
   }
 
+  // A poll's own cleanup must not blindly null the signal: if the user
+  // skipped/moved on and started a second covenant action before this poll
+  // finished, the signal has since been overwritten with that newer poll's
+  // promise — clearing unconditionally here would wipe that reference out
+  // while the newer poll is still running, making the next
+  // waitForActionIndexing() resolve immediately instead of waiting on it.
+  // Only clear if the signal still holds the exact promise this poll set.
+  clearActionIndexingCompletion(promise: Promise<void>) {
+    if (this.actionIndexingCompletionSignal() === promise) {
+      this.actionIndexingCompletionSignal.set(null);
+    }
+  }
+
   /** Resolves immediately if no action-indexing poll is in flight. */
   async waitForActionIndexing(): Promise<void> {
     await this.actionIndexingCompletionSignal();

--- a/src/app/v2/services/approval-flow.service.ts
+++ b/src/app/v2/services/approval-flow.service.ts
@@ -102,6 +102,26 @@ export class ApprovalFlowService {
     this.pendingConfirmationSignal.set(state);
   }
 
+  // The flow-page outlet destroys ContractsPageComponent the instant the
+  // approval overlay covers it (see isContractsWide's comment in
+  // app-wrapper.component.ts), so the action-indexing poll that started on
+  // the old instance keeps running detached from any UI once the user
+  // returns to "My Contracts" — a freshly-created instance's own initial
+  // load has no idea that check is still in flight, and races ahead with
+  // its own fetch, which is exactly the staleness the poll exists to avoid.
+  // Tracking the poll's completion here, outside the component, lets that
+  // new instance await it before doing its own first load instead of racing it.
+  private actionIndexingCompletionSignal = signal<Promise<void> | null>(null);
+
+  setActionIndexingCompletion(promise: Promise<void> | null) {
+    this.actionIndexingCompletionSignal.set(promise);
+  }
+
+  /** Resolves immediately if no action-indexing poll is in flight. */
+  async waitForActionIndexing(): Promise<void> {
+    await this.actionIndexingCompletionSignal();
+  }
+
   /**
    * Shows approval dialog using the appropriate display mode
    */

--- a/src/app/v2/shared/utils/return-url.util.ts
+++ b/src/app/v2/shared/utils/return-url.util.ts
@@ -1,0 +1,20 @@
+import { ActivatedRoute } from '@angular/router';
+
+const DEFAULT_RETURN_URL = '/app/home';
+
+/**
+ * Reads the `returnUrl` query param AuthGuard attaches when it redirects an
+ * unauthenticated visit to `/onboarding` (e.g. a pasted covenant link).
+ * Restricted to same-app paths to avoid an open redirect via a crafted
+ * returnUrl.
+ */
+export function getSafeReturnUrl(
+  route: ActivatedRoute,
+  fallback: string = DEFAULT_RETURN_URL,
+): string {
+  const returnUrl = route.snapshot.queryParamMap.get('returnUrl');
+  if (returnUrl && returnUrl.startsWith('/') && !returnUrl.startsWith('//')) {
+    return returnUrl;
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary

**Indexer-tracking bail-out survives the approval overlay**
- `trackActionIndexing()`'s poll loop bailed via a component-local `destroyed` flag, but the contracts page component is genuinely destroyed (not just visually covered) when the approval success overlay opens — so every covenant action bailed the poll immediately, flushing `pendingConfirmation` to `unavailable` before the indexer had a chance to catch up.
- Replaced the flag with `bailIfLeftContractsFlow()`, which checks whether `'contracts'` is still in the flow-page stack (true while the overlay merely covers it) instead of instance destruction — so the poll now only bails once the user actually navigates away.
- Added a "Skip waiting" link on the approval success page, now meaningful since the tracking can genuinely still be in progress.
- Clears the transient state saved before opening the co-signer partial-spend dialog once it closes, so a contract opened via a direct link no longer gets stuck restoring the old detail/action-form view instead of the My Contracts list.

**Pasting a covenant link while logged out now returns you to that link**
- `AuthGuard` discarded the originally requested URL when redirecting an unauthenticated visit to `/onboarding`, so pasting a covenant link always landed on `/app/home` after connecting instead of the link that was pasted. It's now passed through as a `returnUrl` query param and consumed by the login, create-wallet, and import-wallet completion paths via a shared `getSafeReturnUrl()` helper (restricted to same-app paths to avoid an open redirect).
- Comparing the full URL (path + query string) against the onboarding path list also meant that once `returnUrl` was attached, the guard no longer recognized `/onboarding?returnUrl=...` as the onboarding route and kept redirecting to itself, nesting the previous URL as a new `returnUrl` each time — an infinite loop that froze the page. Fixed by comparing the path only.

**Contract links open the detail view, not Import/Share**
- Visiting `/app/contracts/:contractId` always routed into the `lookup-import` tab via `queueInboundIndexerImport()`, even though a `detailRouteId` / `openDetailFromRoute()` flow already existed for exactly this case, complete with its own not-found handling — it just was never wired up from the route param subscription. Wired it in, so a pasted covenant link opens the contract's detail view instead of the Import/Share tab.

## Test plan
- [x] Trigger a covenant action (e.g. keepAlive/withdraw) and confirm the success page's Done button stays disabled until the indexer catches up, with "Skip waiting" as an escape hatch
- [x] Navigate away from contracts mid-poll and confirm `pendingConfirmation` still correctly flushes to `unavailable`
- [ ] Open a contract via a direct share link, complete a co-signer partial spend, and confirm it lands back on the My Contracts list (not a stale detail view)
- [x] Paste a covenant link while logged out, connect/create/import a wallet, and confirm it lands back on that exact link instead of `/app/home`
- [x] Confirm a contract link opens under My Contracts (detail view) rather than the Import/Share tab, including a proper "Contract not found" state for an unsupported or invalid id



https://github.com/user-attachments/assets/ed19a7c2-b89e-4fda-9123-9b98727cbbbb

https://github.com/user-attachments/assets/7e518054-2462-4168-ae9d-436f59254ae1