### PR TITLE
Hide Kaspa Mainnet on dev/test domain, clean up Select Network UI

### DIFF
--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.html
@@ -33,7 +33,18 @@
     </div>
 
     <!-- L2 Networks -->
-    <h3 class="network-group-title">L2 Networks</h3>
+    <div class="network-group-header">
+      <h3 class="network-group-title">L2 Networks</h3>
+      <kc-icon-button
+        class="add-network-btn"
+        [icon]="'icon-add'"
+        [size]="'sm'"
+        [variant]="'secondary'"
+        [ariaLabel]="'Add custom network'"
+        [title]="'Add custom network'"
+        (buttonClick)="onAddNetwork()"
+      />
+    </div>
     <div class="networks-list">
       @for (network of networks(); track network) {
         <div
@@ -111,21 +122,6 @@
           </div>
         </div>
       }
-    </div>
-
-    <!-- Add Network -->
-    <div
-      class="add-network-row"
-      role="button"
-      tabindex="0"
-      (click)="onAddNetwork()"
-      (keydown.enter)="onAddNetwork()"
-      (keydown.space)="onAddNetworkSpaceKey($event)"
-    >
-      <div class="add-network-icon">
-        <kc-icon [iconClass]="'icon-plus'" [size]="'sm'" />
-      </div>
-      <span class="add-network-label">Add custom network</span>
     </div>
   </div>
 </div>

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.scss
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.scss
@@ -60,8 +60,16 @@
         }
 
         &.confirming-delete {
-          background: color-mix(in srgb, var(--red-10, #fee2e2) 60%, transparent);
-          border-color: color-mix(in srgb, var(--red-30, #fca5a5) 80%, transparent);
+          background: color-mix(
+            in srgb,
+            var(--red-10, #fee2e2) 60%,
+            transparent
+          );
+          border-color: color-mix(
+            in srgb,
+            var(--red-30, #fca5a5) 80%,
+            transparent
+          );
           cursor: default;
         }
 

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.scss
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.scss
@@ -11,9 +11,28 @@
     overflow-y: auto;
 
     .network-group-title {
-      color: var(--gray-75);
-      border-bottom: 1px solid var(--gray-25);
-      padding-bottom: 10px;
+      margin: 0 0 8px;
+      padding: 0 4px;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--gray-70, var(--gray-75));
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+    }
+
+    .network-group-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 20px 0 8px;
+
+      .network-group-title {
+        margin: 0;
+      }
+
+      .add-network-btn {
+        flex-shrink: 0;
+      }
     }
 
     .networks-list {
@@ -125,41 +144,6 @@
             opacity: 1;
           }
         }
-      }
-    }
-
-    .add-network-row {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      margin-top: 4px;
-      border-radius: 12px;
-      cursor: pointer;
-      border: 1px dashed var(--gray-30, #d1d5db);
-      transition: all 0.2s ease;
-      color: var(--color-primary);
-
-      &:hover {
-        background: var(--color-primary-light);
-        border-color: var(--color-primary);
-      }
-
-      .add-network-icon {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 36px;
-        height: 36px;
-        border-radius: 50%;
-        background: var(--color-primary-light);
-        color: var(--color-primary);
-        flex-shrink: 0;
-      }
-
-      .add-network-label {
-        font-size: 15px;
-        font-weight: 600;
       }
     }
   }

--- a/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
+++ b/src/app/v2/shared/network-selection-modal/network-selection-modal.component.ts
@@ -257,11 +257,6 @@ export class NetworkSelectionModalComponent implements OnInit {
     this.setL2Network(network);
   }
 
-  onAddNetworkSpaceKey(event: Event): void {
-    event.preventDefault();
-    this.onAddNetwork();
-  }
-
   onAddNetwork(): void {
     this.flowPagesService.navigateToPage({
       id: 'add-custom-network',

--- a/src/environments/l1-network-configurations.ts
+++ b/src/environments/l1-network-configurations.ts
@@ -5,9 +5,7 @@ export const KASPA_MAINNET_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
   network: KASPA_NETWORKS.MAINNET,
   shortName: 'Kaspa Mainnet',
   icon: 'images/tokens-logos/KAS.png',
-  kaspaWrpcUrls: [
-    'wss://mainnet-node.kaspa.com/kaspa/mainnet/wrpc/borsh',
-  ],
+  kaspaWrpcUrls: ['wss://mainnet-node.kaspa.com/kaspa/mainnet/wrpc/borsh'],
   kaspaComApiBaseurl: 'https://api.kaspa.com',
   kaspaComDefiApiBaseurl: 'https://api-defi.kaspa.com',
   kasplexApiBaseurl: 'https://api.kasplex.org/v1',
@@ -33,13 +31,14 @@ export const KASPA_TN10_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
   kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
   kasplexApiBaseurl: 'https://tn10api.kasplex.org/v1',
   kaspaApiBaseurl: 'https://api-tn10.kaspa.org',
-  krc721ApiBaseurl: 'https://dev-krc721-indexer.kaspa.com/api/v1/krc721/testnet-10',
+  krc721ApiBaseurl:
+    'https://dev-krc721-indexer.kaspa.com/api/v1/krc721/testnet-10',
   krc721CacheStreamUrl: 'https://krc721-cache-dev.kaspa.com/krc721/testnet-10',
   knsApiBaseurl: 'https://api.knsdomains.org/tn10',
   covenantIndexerApiBaseurl: 'https://tn10-indexer.kaspa.com',
   kaspaExplorerBaseurl: 'https://explorer-tn10.kaspa.org',
   covenantExplorerBaseurl: 'https://tn10-covenants.kaspa.com',
-  l1AvatarCollection: 'PEPINO'
+  l1AvatarCollection: 'PEPINO',
 };
 
 export const KASPA_TN12_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
@@ -49,10 +48,11 @@ export const KASPA_TN12_L1_NETWORK_CONFIG: L1NetworkConfigInterface = {
   kaspaComApiBaseurl: 'https://dev-api.kaspa.com',
   kaspaComDefiApiBaseurl: 'https://dev-api-defi.kaspa.com',
   kaspaApiBaseurl: 'https://api-tn12.kaspa.org',
-  krc721ApiBaseurl: 'https://dev-krc721-indexer.kaspa.com/api/v1/krc721/testnet-10',
+  krc721ApiBaseurl:
+    'https://dev-krc721-indexer.kaspa.com/api/v1/krc721/testnet-10',
   krc721CacheStreamUrl: 'https://krc721-cache-dev.kaspa.com/krc721/testnet-10',
   kaspaExplorerBaseurl: 'https://tn12.kaspa.stream',
-  l1AvatarCollection: 'PEPINO'
+  l1AvatarCollection: 'PEPINO',
 };
 
 export const PRODUCTION_L1_NETWORKS: L1NetworkConfigInterface[] = [

--- a/src/environments/l1-network-configurations.ts
+++ b/src/environments/l1-network-configurations.ts
@@ -59,8 +59,8 @@ export const PRODUCTION_L1_NETWORKS: L1NetworkConfigInterface[] = [
   KASPA_MAINNET_L1_NETWORK_CONFIG,
 ];
 
+// Mainnet is intentionally excluded here: the dev/test domain must never expose it as a selectable network.
 export const DEVELOPMENT_L1_NETWORKS: L1NetworkConfigInterface[] = [
   KASPA_TN10_L1_NETWORK_CONFIG,
   KASPA_TN12_L1_NETWORK_CONFIG,
-  KASPA_MAINNET_L1_NETWORK_CONFIG,
 ];


### PR DESCRIPTION
## Summary
- Excluded `KASPA_MAINNET_L1_NETWORK_CONFIG` from `DEVELOPMENT_L1_NETWORKS` so Kaspa Mainnet is never listed or selectable on the dev/test domain build (`environment.development.ts`); production (`PRODUCTION_L1_NETWORKS`) is unchanged.
- Replaced the large dashed-border "Add custom network" box with a lightweight plus icon action next to the "L2 Networks" heading, matching the icon-button style used elsewhere in the wallet (e.g. the network delete action). Also fixed the icon class (`icon-plus` doesn't exist in the icon font; the correct class is `icon-add`), which had made the previous plus icon invisible.
- Normalized the L1/L2 section title typography (was unstyled `<h3>`, now matches the app's existing compact uppercase section-title convention) and tightened spacing.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified locally on a dev-configuration build at a 390x844 mobile viewport: Select Network modal shows only Kaspa TN10/TN12 under L1 (no Mainnet), the plus action opens Add Custom Network and back navigation returns cleanly, selected-row styling stays proportionate to other rows
- [ ] Verify production build still shows Kaspa Mainnet (config path unchanged, but worth a sanity check before merge)
<img width="382" height="643" alt="Capture d’écran 2026-08-03 à 14 50 05" src="https://github.com/user-attachments/assets/a18179c1-8439-438a-8f67-3f7e3ed1b002" />