### PR TITLE
Allow partial Dead Man's Switch claims

### DIFF
--- a/e2e/dead-mans-switch.spec.ts
+++ b/e2e/dead-mans-switch.spec.ts
@@ -1,0 +1,326 @@
+import { test, expect, Page } from '@playwright/test';
+import { authenticateFundedWallet } from './helpers/auth';
+import { readWalletAddress } from './helpers/home';
+import { login } from './helpers/onboarding';
+import { TN10 } from './fixtures/network';
+
+const SOMPI_PER_KAS = 100_000_000;
+const TEST_PASSWORD = 'WalletE2E!Password1';
+
+async function fetchBalanceKas(address: string): Promise<number> {
+  const res = await fetch(
+    `${TN10.kaspaApiBaseurl}/addresses/${encodeURIComponent(address)}/balance`,
+  );
+  if (!res.ok) throw new Error(`explorer ${res.status}`);
+  const body = (await res.json()) as { balance?: number | string };
+  const sompi =
+    typeof body.balance === 'string' ? Number(body.balance) : (body.balance ?? 0);
+  return sompi / SOMPI_PER_KAS;
+}
+
+async function fetchUtxoAmountsKas(address: string): Promise<number[]> {
+  const res = await fetch(
+    `${TN10.kaspaApiBaseurl}/addresses/${encodeURIComponent(address)}/utxos`,
+  );
+  if (!res.ok) throw new Error(`explorer ${res.status}`);
+  const body = (await res.json()) as Array<{ utxoEntry: { amount: string } }>;
+  return body.map((u) => Number(u.utxoEntry.amount) / SOMPI_PER_KAS);
+}
+
+/** datetime-local value in the machine's local timezone, `msFromNow` in the future. */
+function localDateTimeValue(msFromNow: number): string {
+  const d = new Date(Date.now() + msFromNow);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * The cookie-consent banner is injected by a script that can finish loading
+ * several seconds into the test, well after any one-time dismissal click
+ * would run, and an injected stylesheet doesn't reliably hide it (likely
+ * CSP-blocked) — so instead, watch for it and remove it outright as soon as
+ * it appears, on every navigation.
+ */
+async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const removeBanner = () => {
+      document.getElementById('kaspa-consent-banner')?.remove();
+    };
+    // `documentElement` may not exist yet this early in the navigation, and
+    // a MutationObserver can't attach to a null target — poll as a fallback
+    // in addition to observing once the tree exists.
+    removeBanner();
+    const intervalId = setInterval(removeBanner, 250);
+    setTimeout(() => clearInterval(intervalId), 60_000);
+    document.addEventListener('DOMContentLoaded', () => {
+      removeBanner();
+      new MutationObserver(removeBanner).observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    });
+  });
+}
+
+async function openContractsTab(page: Page): Promise<void> {
+  await page.locator('div', { hasText: /^Contracts$/ }).first().click();
+}
+
+async function openContractDetails(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Details' }).first().click();
+}
+
+/**
+ * Submit whatever curated action form is currently open (Claim, in this
+ * spec) and dismiss the resulting approval/result screens, retrying once if
+ * the network rejects the transaction for a stale locktime.
+ *
+ * The DMS covenant enforces `tx.time >= deadline` using the transaction's own
+ * locktime field, which the SDK derives from an estimate that can lag behind
+ * wall-clock time by tens of seconds. If the review screen sits open too
+ * long before Approve, the built locktime can fall back under the deadline
+ * and the node rejects it — a pre-existing quirk of any DMS claim (not
+ * specific to partial claims). Retrying rebuilds the transaction with a
+ * fresher locktime.
+ */
+async function submitActionWithLocktimeRetry(
+  page: Page,
+  reopenAction: () => Promise<void>,
+): Promise<void> {
+  const maxAttempts = 6;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await page.getByRole('button', { name: 'Approve' }).click();
+
+    const failed = page.getByText('Transaction Failed');
+    const succeeded = page.getByText('Transaction Successful!');
+    await expect(failed.or(succeeded)).toBeVisible({ timeout: 20_000 });
+
+    if (await succeeded.isVisible().catch(() => false)) return;
+
+    const errorText = await page
+      .locator('body')
+      .innerText()
+      .catch(() => '');
+    const isLocktimeStale = errorText.includes('Unsatisfied lock time');
+    if (!isLocktimeStale || attempt === maxAttempts) {
+      throw new Error(
+        `Transaction failed (attempt ${attempt}, locktimeStale=${isLocktimeStale}): ${errorText.slice(-600)}`,
+      );
+    }
+
+    await page.getByRole('button', { name: 'Close' }).click();
+    await page.waitForTimeout(20_000);
+    await reopenAction();
+  }
+}
+
+/**
+ * Return to the "My Contracts" detail view after a submitted action. The
+ * success screen's "Done"/continue button stays disabled until the indexer
+ * catches up, which can take longer than is worth blocking the test on —
+ * reloading (and logging back in) gets back to a consistent state either way
+ * since the registry update itself is applied optimistically, not indexer-
+ * gated.
+ */
+async function returnToContractDetails(page: Page): Promise<void> {
+  const done = page.getByRole('button', { name: /^Done$/ });
+  const gotDone = await done
+    .waitFor({ state: 'visible', timeout: 20_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (gotDone) {
+    await done.click();
+    await openContractDetails(page);
+    return;
+  }
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await login(page, TEST_PASSWORD);
+  await openContractsTab(page);
+  await openContractDetails(page);
+}
+
+async function openClaimForm(page: Page): Promise<void> {
+  await page.getByRole('button', { name: ' Claim Claim the inheritance' }).click();
+}
+
+/**
+ * A failed/closed attempt drops back to the "My Contracts" list, not the
+ * claim form — reopening means going through Details -> Claim again.
+ */
+async function reopenClaimForm(page: Page): Promise<void> {
+  await openContractDetails(page);
+  await openClaimForm(page);
+}
+
+async function claimAmount(page: Page, amountKas: string): Promise<void> {
+  // Called right after returnToContractDetails(), so the Details view is
+  // already open — just open the Claim form directly.
+  await openClaimForm(page);
+  await page.getByRole('textbox', { name: '0' }).fill(amountKas);
+  await page.getByRole('button', { name: 'Claim', exact: true }).click();
+  await submitActionWithLocktimeRetry(page, async () => {
+    await reopenClaimForm(page);
+    await page.getByRole('textbox', { name: '0' }).fill(amountKas);
+    await page.getByRole('button', { name: 'Claim', exact: true }).click();
+  });
+  await returnToContractDetails(page);
+}
+
+test.describe("Dead Man's Switch — partial claim", () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('@funded deploy, sequential partial claims, invalid amounts, then full remainder', async ({
+    page,
+  }, testInfo) => {
+    // Deploy + deadline wait + multiple on-chain claims comfortably exceeds
+    // the default 60s Playwright timeout.
+    test.setTimeout(14 * 60_000);
+
+    await suppressCookieBanner(page);
+    await authenticateFundedWallet(page);
+    const address = await readWalletAddress(page);
+    testInfo.annotations.push({ type: 'owner-heir-address', description: address });
+
+    const balanceBeforeDeploy = await fetchBalanceKas(address);
+    testInfo.annotations.push({
+      type: 'balance-before-deploy-kas',
+      description: balanceBeforeDeploy.toString(),
+    });
+
+    // ── Deploy a Dead Man's Switch: owner = heir = this wallet (single-seed
+    // test), deadline ~70s out so the heir becomes eligible to claim shortly.
+    await openContractsTab(page);
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await page.getByRole('button', { name: /Dead Man's Switch/ }).click();
+
+    await page.getByRole('textbox', { name: 'Heir wallet' }).fill(address);
+    const deadlineValue = localDateTimeValue(70_000);
+    await page.locator('input[type="datetime-local"]').fill(deadlineValue);
+    const deployAmountKas = 6;
+    await page.getByRole('textbox', { name: '0.5' }).fill(String(deployAmountKas));
+
+    await page.getByRole('button', { name: 'Review and deploy covenant' }).click();
+    await page.getByRole('button', { name: 'Approve' }).click();
+    await expect(page.getByText('Transaction Successful!')).toBeVisible({
+      timeout: 30_000,
+    });
+    const deployTxid = await page
+      .locator('div', { hasText: /^Transaction ID$/ })
+      .last()
+      .locator('xpath=following-sibling::*[1]')
+      .textContent()
+      .catch(() => null);
+    testInfo.annotations.push({
+      type: 'deploy-txid',
+      description: deployTxid?.trim() || '(not captured)',
+    });
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    // Find the contract's covenant address from the detail panel so we can
+    // poll the explorer independently of the UI. Truncated address displays
+    // carry the full value in a `title` attribute; the contract address is
+    // whichever one isn't this wallet's own address (owner === heir here).
+    await openContractDetails(page);
+    const addressTitles = page.locator('[title^="kaspatest:"]');
+    let contractAddress: string | undefined;
+    const titleCount = await addressTitles.count();
+    for (let i = 0; i < titleCount; i++) {
+      const title = await addressTitles.nth(i).getAttribute('title');
+      if (title && title !== address) {
+        contractAddress = title;
+        break;
+      }
+    }
+
+    // Wait for the deadline to pass with margin — the DMS covenant's
+    // `tx.time >= deadline` check compares against the built transaction's
+    // locktime, which lags wall-clock time (see submitActionWithLocktimeRetry).
+    await page.waitForTimeout(70_000 + 30_000);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await login(page, TEST_PASSWORD);
+    await openContractsTab(page);
+    await openContractDetails(page);
+
+    // ── Invalid amounts, rejected inline with no on-chain effect.
+    await openClaimForm(page);
+    for (const [bad, expectedMessage] of [
+      ['0', 'Output amount must be greater than 0'],
+      ['-1', 'Output amount must be greater than 0'],
+      ['abc', 'Output amount must be greater than 0'],
+      ['999', 'Withdraw amount cannot exceed the contract balance'],
+    ] as const) {
+      await page.getByRole('textbox', { name: '0' }).fill(bad);
+      await page.getByRole('button', { name: 'Claim', exact: true }).click();
+      await expect(page.getByText(expectedMessage)).toBeVisible();
+    }
+    // No transaction was submitted by any of the rejected amounts above —
+    // balance only reflects the deploy spend (amount + its own small fee).
+    const balanceDuringValidation = await fetchBalanceKas(address);
+    expect(balanceDuringValidation).toBeGreaterThan(
+      balanceBeforeDeploy - deployAmountKas - 0.02,
+    );
+    expect(balanceDuringValidation).toBeLessThan(balanceBeforeDeploy - deployAmountKas + 0.001);
+
+    // ── Sequential partial claims: 2 KAS, then 1.5 KAS.
+    await page.getByRole('textbox', { name: '0' }).fill('2');
+    await page.getByRole('button', { name: 'Claim', exact: true }).click();
+    await submitActionWithLocktimeRetry(page, async () => {
+      await reopenClaimForm(page);
+      await page.getByRole('textbox', { name: '0' }).fill('2');
+      await page.getByRole('button', { name: 'Claim', exact: true }).click();
+    });
+    await returnToContractDetails(page);
+
+    if (contractAddress) {
+      await expect
+        .poll(() => fetchUtxoAmountsKas(contractAddress), { timeout: 30_000 })
+        .toEqual([4]);
+    }
+    testInfo.annotations.push({
+      type: 'balance-after-partial-1-kas',
+      description: (await fetchBalanceKas(address)).toString(),
+    });
+
+    await claimAmount(page, '1.5');
+
+    if (contractAddress) {
+      await expect
+        .poll(() => fetchUtxoAmountsKas(contractAddress), { timeout: 30_000 })
+        .toEqual([2.5]);
+    }
+    testInfo.annotations.push({
+      type: 'balance-after-partial-2-kas',
+      description: (await fetchBalanceKas(address)).toString(),
+    });
+
+    // ── Full remainder claim — single output, contract fully spent.
+    await openClaimForm(page);
+    await page.locator('.max-text.clickable').first().click();
+    await page.getByRole('button', { name: 'Claim', exact: true }).click();
+    await submitActionWithLocktimeRetry(page, async () => {
+      await reopenClaimForm(page);
+      await page.locator('.max-text.clickable').first().click();
+      await page.getByRole('button', { name: 'Claim', exact: true }).click();
+    });
+
+    if (contractAddress) {
+      await expect
+        .poll(() => fetchUtxoAmountsKas(contractAddress), { timeout: 30_000 })
+        .toEqual([]);
+    }
+    // Owner === heir here, so the deployed amount round-trips back to the
+    // same wallet across the 3 claims minus only the handful of tx fees
+    // (deploy + 3 claims, a few thousandths of a KAS each) — allow a
+    // generous 0.1 KAS margin. The balance endpoint can lag a UTXO-level
+    // view briefly right after broadcast, so poll rather than read once.
+    await expect
+      .poll(() => fetchBalanceKas(address), { timeout: 30_000 })
+      .toBeGreaterThan(balanceBeforeDeploy - 0.1);
+    const finalBalance = await fetchBalanceKas(address);
+    testInfo.annotations.push({
+      type: 'balance-after-full-remainder-kas',
+      description: finalBalance.toString(),
+    });
+  });
+});

--- a/e2e/dead-mans-switch.spec.ts
+++ b/e2e/dead-mans-switch.spec.ts
@@ -14,7 +14,9 @@ async function fetchBalanceKas(address: string): Promise<number> {
   if (!res.ok) throw new Error(`explorer ${res.status}`);
   const body = (await res.json()) as { balance?: number | string };
   const sompi =
-    typeof body.balance === 'string' ? Number(body.balance) : (body.balance ?? 0);
+    typeof body.balance === 'string'
+      ? Number(body.balance)
+      : (body.balance ?? 0);
   return sompi / SOMPI_PER_KAS;
 }
 
@@ -63,7 +65,10 @@ async function suppressCookieBanner(page: Page): Promise<void> {
 }
 
 async function openContractsTab(page: Page): Promise<void> {
-  await page.locator('div', { hasText: /^Contracts$/ }).first().click();
+  await page
+    .locator('div', { hasText: /^Contracts$/ })
+    .first()
+    .click();
 }
 
 async function openContractDetails(page: Page): Promise<void> {
@@ -141,7 +146,9 @@ async function returnToContractDetails(page: Page): Promise<void> {
 }
 
 async function openClaimForm(page: Page): Promise<void> {
-  await page.getByRole('button', { name: ' Claim Claim the inheritance' }).click();
+  await page
+    .getByRole('button', { name: ' Claim Claim the inheritance' })
+    .click();
 }
 
 /**
@@ -180,7 +187,10 @@ test.describe("Dead Man's Switch — partial claim", () => {
     await suppressCookieBanner(page);
     await authenticateFundedWallet(page);
     const address = await readWalletAddress(page);
-    testInfo.annotations.push({ type: 'owner-heir-address', description: address });
+    testInfo.annotations.push({
+      type: 'owner-heir-address',
+      description: address,
+    });
 
     const balanceBeforeDeploy = await fetchBalanceKas(address);
     testInfo.annotations.push({
@@ -198,9 +208,13 @@ test.describe("Dead Man's Switch — partial claim", () => {
     const deadlineValue = localDateTimeValue(70_000);
     await page.locator('input[type="datetime-local"]').fill(deadlineValue);
     const deployAmountKas = 6;
-    await page.getByRole('textbox', { name: '0.5' }).fill(String(deployAmountKas));
+    await page
+      .getByRole('textbox', { name: '0.5' })
+      .fill(String(deployAmountKas));
 
-    await page.getByRole('button', { name: 'Review and deploy covenant' }).click();
+    await page
+      .getByRole('button', { name: 'Review and deploy covenant' })
+      .click();
     await page.getByRole('button', { name: 'Approve' }).click();
     await expect(page.getByText('Transaction Successful!')).toBeVisible({
       timeout: 30_000,
@@ -260,7 +274,9 @@ test.describe("Dead Man's Switch — partial claim", () => {
     expect(balanceDuringValidation).toBeGreaterThan(
       balanceBeforeDeploy - deployAmountKas - 0.02,
     );
-    expect(balanceDuringValidation).toBeLessThan(balanceBeforeDeploy - deployAmountKas + 0.001);
+    expect(balanceDuringValidation).toBeLessThan(
+      balanceBeforeDeploy - deployAmountKas + 0.001,
+    );
 
     // ── Sequential partial claims: 2 KAS, then 1.5 KAS.
     await page.getByRole('textbox', { name: '0' }).fill('2');

--- a/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
+++ b/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
@@ -117,16 +117,19 @@ export const CONTRACT_ACTION_FIELDS: ContractActionFieldConfig = {
       suppressGenericExtraArgs: true,
     },
     claim: {
-      // No amount field: leaving a remainder locked in the same DMS script
-      // would let the (presumably unresponsive) owner call keepAlive on it —
-      // DMS keepAlive has no deadline check — permanently blocking the heir
-      // from ever claiming it. The heir always claims the full balance.
       fields: [
         { type: 'address', key: 'outputAddress', label: 'Send to' },
         {
+          type: 'amount',
+          key: 'outputAmount',
+          label: 'Claim amount (KAS)',
+          allowMax: true,
+          description: 'Claim part or all of the locked balance.',
+        },
+        {
           type: 'banner',
-          tone: 'info',
-          text: 'Claiming always transfers the full locked balance — partial claims are not allowed, so the owner cannot re-arm the deadline on a leftover balance.',
+          tone: 'warning',
+          text: "Leaving a balance behind keeps it secured under the same heir and deadline — but the owner can still call Keep Alive at any time (even after the deadline passes) to reset the countdown on it. Claim the full balance if you want to guarantee you receive it now.",
         },
       ],
     },

--- a/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
+++ b/src/app/v2/pages/app/flows/contracts/contract-action-fields.config.ts
@@ -1,10 +1,5 @@
 export type ActionFieldType =
-  | 'address'
-  | 'amount'
-  | 'timestamp'
-  | 'extra-int'
-  | 'extra-bool'
-  | 'banner';
+  'address' | 'amount' | 'timestamp' | 'extra-int' | 'extra-bool' | 'banner';
 
 interface ActionFieldBase {
   type: ActionFieldType;
@@ -129,7 +124,7 @@ export const CONTRACT_ACTION_FIELDS: ContractActionFieldConfig = {
         {
           type: 'banner',
           tone: 'warning',
-          text: "Leaving a balance behind keeps it secured under the same heir and deadline — but the owner can still call Keep Alive at any time (even after the deadline passes) to reset the countdown on it. Claim the full balance if you want to guarantee you receive it now.",
+          text: 'Leaving a balance behind keeps it secured under the same heir and deadline — but the owner can still call Keep Alive at any time (even after the deadline passes) to reset the countdown on it. Claim the full balance if you want to guarantee you receive it now.',
         },
       ],
     },

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2964,7 +2964,9 @@
             </div>
             <div class="form-group flex column gap-8">
               <kc-number-input
-                [label]="isDmsClaim() ? 'Claim amount (KAS)' : 'Withdraw amount (KAS)'"
+                [label]="
+                  isDmsClaim() ? 'Claim amount (KAS)' : 'Withdraw amount (KAS)'
+                "
                 [placeholder]="'0'"
                 [min]="'0'"
                 [isDisabled]="isInteracting()"
@@ -2974,9 +2976,7 @@
                 <div
                   (click)="!isInteracting() && fillMaxOutputAmount()"
                   [class]="
-                    isInteracting()
-                      ? 'max-text disabled'
-                      : 'max-text clickable'
+                    isInteracting() ? 'max-text disabled' : 'max-text clickable'
                   "
                   rightSideSlot
                 >
@@ -2993,11 +2993,11 @@
                 "
               >
                 <span class="text-yellow typo-text-2"
-                  >Leaving a balance behind keeps it secured under the same
-                  heir and deadline — but the owner can still call Keep Alive
-                  at any time (even after the deadline passes) to reset the
-                  countdown on it. Claim the full balance if you want to
-                  guarantee you receive it now.</span
+                  >Leaving a balance behind keeps it secured under the same heir
+                  and deadline — but the owner can still call Keep Alive at any
+                  time (even after the deadline passes) to reset the countdown
+                  on it. Claim the full balance if you want to guarantee you
+                  receive it now.</span
                 >
               </div>
             }

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.html
@@ -2962,41 +2962,43 @@
                 (qrClick)="onInteractOutputQrClick()"
               ></app-address-smart-input>
             </div>
+            <div class="form-group flex column gap-8">
+              <kc-number-input
+                [label]="isDmsClaim() ? 'Claim amount (KAS)' : 'Withdraw amount (KAS)'"
+                [placeholder]="'0'"
+                [min]="'0'"
+                [isDisabled]="isInteracting()"
+                [ngModel]="interactOutputAmount"
+                (valueChange)="onInteractOutputAmountChange($event)"
+              >
+                <div
+                  (click)="!isInteracting() && fillMaxOutputAmount()"
+                  [class]="
+                    isInteracting()
+                      ? 'max-text disabled'
+                      : 'max-text clickable'
+                  "
+                  rightSideSlot
+                >
+                  <span>Max</span>
+                </div>
+              </kc-number-input>
+            </div>
             @if (isDmsClaim()) {
               <div
                 class="p-12 rounded-lg"
                 style="
-                  background: rgba(111, 199, 186, 0.08);
-                  border: 1px solid rgba(111, 199, 186, 0.2);
+                  background: rgba(255, 193, 7, 0.08);
+                  border: 1px solid rgba(255, 193, 7, 0.2);
                 "
               >
-                <span class="text-gray-75 typo-text-2"
-                  >Claiming sends the entire contract balance to this address —
-                  Dead Man's Switch claims can't be partial.</span
+                <span class="text-yellow typo-text-2"
+                  >Leaving a balance behind keeps it secured under the same
+                  heir and deadline — but the owner can still call Keep Alive
+                  at any time (even after the deadline passes) to reset the
+                  countdown on it. Claim the full balance if you want to
+                  guarantee you receive it now.</span
                 >
-              </div>
-            } @else {
-              <div class="form-group flex column gap-8">
-                <kc-number-input
-                  [label]="'Withdraw amount (KAS)'"
-                  [placeholder]="'0'"
-                  [min]="'0'"
-                  [isDisabled]="isInteracting()"
-                  [ngModel]="interactOutputAmount"
-                  (valueChange)="onInteractOutputAmountChange($event)"
-                >
-                  <div
-                    (click)="!isInteracting() && fillMaxOutputAmount()"
-                    [class]="
-                      isInteracting()
-                        ? 'max-text disabled'
-                        : 'max-text clickable'
-                    "
-                    rightSideSlot
-                  >
-                    <span>Max</span>
-                  </div>
-                </kc-number-input>
               </div>
             }
           }

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.spec.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.spec.ts
@@ -1,0 +1,451 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import {
+  ActivatedRoute,
+  Router,
+  convertToParamMap,
+} from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
+import { NotificationService } from '@kaspacom/ui-kit';
+
+import { ContractsPageComponent } from './contracts-page.component';
+import { WalletService } from '../../../../../services/wallet.service';
+import { WalletActionService } from '../../../../../services/wallet-action.service';
+import { QrScannerService } from '../../../../../services/qr-scanner.service';
+import { UtilsHelper } from '../../../../../services/utils.service';
+import { CovenantService } from '../../../../../services/covenant/covenant.service';
+import { CovenantIndexerService } from '../../../../../services/covenant/covenant-indexer.service';
+import { RpcService } from '../../../../../services/kaspa-netwrok-services/rpc.service';
+import { ContractRegistryService } from '../../../../../services/covenant/contract-registry.service';
+import { TemplatePatcherService } from '../../../../services/covenant/template-patcher.service';
+import { KaspaL1NetworkService } from '../../../../../services/kaspa-netwrok-services/kaspa-l1-network.service';
+import { FlowPagesService } from '../../../../services/flow-pages.service';
+import { WideWorkspaceService } from '../../../../services/wide-workspace.service';
+import { ApprovalFlowService } from '../../../../services/approval-flow.service';
+import { CompiledContract } from '../../../../../services/covenant/covenant-sdk/types';
+
+const MIN_CONTINUATION_AMOUNT_SOMPI = 50_000_000n; // 0.5 KAS
+
+const DMS_COMPILED_CONTRACT: CompiledContract = {
+  contract_name: 'DeadManSwitch',
+  script: [],
+  without_selector: false,
+  ast: {
+    name: 'DeadManSwitch',
+    params: [],
+    constants: {},
+    functions: [
+      {
+        name: 'keepAlive',
+        params: [],
+        entrypoint: true,
+        return_types: [],
+        body: [],
+      },
+      {
+        name: 'changeHeir',
+        params: [],
+        entrypoint: true,
+        return_types: [],
+        body: [],
+      },
+      { name: 'topUp', params: [], entrypoint: true, return_types: [], body: [] },
+      { name: 'claim', params: [], entrypoint: true, return_types: [], body: [] },
+    ],
+  },
+  abi: [
+    {
+      name: 'keepAlive',
+      inputs: [
+        { name: 's', type_name: 'sig' },
+        { name: 'newDeadline', type_name: 'int' },
+      ],
+    },
+    {
+      name: 'changeHeir',
+      inputs: [
+        { name: 's', type_name: 'sig' },
+        { name: 'newHeir', type_name: 'pubkey' },
+      ],
+    },
+    { name: 'topUp', inputs: [] },
+    { name: 'claim', inputs: [{ name: 's', type_name: 'sig' }] },
+  ],
+};
+
+const COVENANT_ADDRESS = 'kaspatest:qzcovenantaddressmock';
+const HEIR_ADDRESS = 'kaspatest:qzheiraddressmock';
+
+describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
+  let component: ContractsPageComponent;
+  let walletActionServiceSpy: jasmine.SpyObj<WalletActionService>;
+  let covenantServiceSpy: jasmine.SpyObj<CovenantService>;
+  let registryServiceSpy: jasmine.SpyObj<ContractRegistryService>;
+
+  beforeEach(async () => {
+    const walletServiceSpy = jasmine.createSpyObj('WalletService', [
+      'getAllWalletsByIdAndAccount',
+      'getCurrentWallet',
+      'selectCurrentWallet',
+    ]);
+    walletServiceSpy.getCurrentWallet.and.returnValue({
+      getAddress: () => 'kaspatest:qzownerheiraddressmock',
+      getPrivateKey: () => ({
+        toString: () => 'fakeprivatekeyhex',
+        toPublicKey: () => ({
+          toXOnlyPublicKey: () => ({ toString: () => 'fakepubkeyhex' }),
+        }),
+      }),
+      getIdWithAccount: () => 'wallet-0',
+      getDisplayName: () => 'Test Wallet',
+    } as any);
+
+    walletActionServiceSpy = jasmine.createSpyObj('WalletActionService', [
+      'validateAndApproveAction',
+      'validateAndDoActionAfterApproval',
+    ]);
+    walletActionServiceSpy.validateAndDoActionAfterApproval.and.resolveTo({
+      success: true,
+      result: { txid: 'f'.repeat(64), functionName: 'claim' },
+    } as any);
+
+    const qrScannerServiceSpy = jasmine.createSpyObj('QrScannerService', [
+      'isCurrentlyScanning',
+      'startScanning',
+      'stopScanning',
+    ]);
+
+    const utilsHelperSpy = jasmine.createSpyObj('UtilsHelper', [
+      'isValidWalletAddress',
+    ]);
+    utilsHelperSpy.isValidWalletAddress.and.returnValue(true);
+
+    covenantServiceSpy = jasmine.createSpyObj('CovenantService', [
+      'buildPartial',
+      'getContractAddress',
+      'parseCompiledContract',
+    ]);
+    covenantServiceSpy.getContractAddress.and.returnValue(COVENANT_ADDRESS);
+    covenantServiceSpy.parseCompiledContract.and.callFake(
+      (json: string) => JSON.parse(json),
+    );
+
+    const covenantIndexerServiceSpy = jasmine.createSpyObj(
+      'CovenantIndexerService',
+      [
+        'getCovenant',
+        'getCovenantActions',
+        'getCovenantByCanonicalId',
+        'getCovenantUtxos',
+        'getTransactionActions',
+        'getTransactionSettlementStatus',
+        'listCovenants',
+        'search',
+      ],
+    );
+    covenantIndexerServiceSpy.listCovenants.and.resolveTo([]);
+    // Rejecting makes trackActionIndexing() bail out after a single attempt
+    // instead of looping/delaying in the background after each test.
+    covenantIndexerServiceSpy.getTransactionSettlementStatus.and.rejectWith(
+      new Error('not mocked'),
+    );
+
+    const rpcServiceSpy = jasmine.createSpyObj('RpcService', [
+      'getNetwork',
+      'getRpc',
+      'setNetwork',
+    ]);
+    rpcServiceSpy.getNetwork.and.returnValue('testnet-10');
+
+    registryServiceSpy = jasmine.createSpyObj('ContractRegistryService', [
+      'addContract',
+      'deleteContract',
+      'generateId',
+      'getAllContracts',
+      'migrateContractsRegistryFromLocalStorage',
+      'updateContract',
+    ]);
+    registryServiceSpy.getAllContracts.and.resolveTo([]);
+    registryServiceSpy.migrateContractsRegistryFromLocalStorage.and.resolveTo();
+    registryServiceSpy.updateContract.and.resolveTo();
+
+    const templatePatcherSpy = jasmine.createSpyObj('TemplatePatcherService', [
+      'applyPatch',
+      'extractPatchDescriptor',
+      'kaspaAddressToPubkeyBytes',
+    ]);
+
+    const kaspaL1NetworkServiceSpy = jasmine.createSpyObj(
+      'KaspaL1NetworkService',
+      ['getCovenantExplorerBaseurl', 'getKaspaExplorerBaseurl'],
+    );
+
+    const flowPagesServiceSpy = jasmine.createSpyObj('FlowPagesService', [
+      'getTransientState',
+      'saveTransientState',
+    ]);
+    flowPagesServiceSpy.getTransientState.and.returnValue(undefined);
+
+    const wideWorkspaceServiceSpy = jasmine.createSpyObj(
+      'WideWorkspaceService',
+      ['activate', 'deactivate'],
+    );
+
+    const approvalFlowServiceSpy = jasmine.createSpyObj('ApprovalFlowService', [
+      'closeApproval',
+      'setPendingConfirmation',
+    ]);
+
+    const notificationServiceSpy = jasmine.createSpyObj('NotificationService', [
+      'success',
+    ]);
+
+    const dialogSpy = jasmine.createSpyObj('Dialog', ['open']);
+    dialogSpy.open.and.returnValue({ closed: of(undefined) });
+
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    const activatedRouteStub = {
+      paramMap: of(convertToParamMap({})),
+      snapshot: { queryParamMap: convertToParamMap({}) },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ContractsPageComponent],
+      providers: [
+        { provide: WalletService, useValue: walletServiceSpy },
+        { provide: WalletActionService, useValue: walletActionServiceSpy },
+        { provide: QrScannerService, useValue: qrScannerServiceSpy },
+        { provide: UtilsHelper, useValue: utilsHelperSpy },
+        { provide: CovenantService, useValue: covenantServiceSpy },
+        { provide: CovenantIndexerService, useValue: covenantIndexerServiceSpy },
+        { provide: RpcService, useValue: rpcServiceSpy },
+        { provide: ContractRegistryService, useValue: registryServiceSpy },
+        { provide: TemplatePatcherService, useValue: templatePatcherSpy },
+        { provide: HttpClient, useValue: jasmine.createSpyObj('HttpClient', ['get']) },
+        { provide: KaspaL1NetworkService, useValue: kaspaL1NetworkServiceSpy },
+        { provide: FlowPagesService, useValue: flowPagesServiceSpy },
+        { provide: WideWorkspaceService, useValue: wideWorkspaceServiceSpy },
+        { provide: ApprovalFlowService, useValue: approvalFlowServiceSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+        { provide: Router, useValue: routerSpy },
+        { provide: Dialog, useValue: dialogSpy },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: NotificationService, useValue: notificationServiceSpy },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(ContractsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function setUpDmsClaim(options: {
+    inputSompi: bigint;
+    outputAmountKas: string;
+    outputAddress?: string;
+  }) {
+    component.interactContractJson.set(JSON.stringify(DMS_COMPILED_CONTRACT));
+    component.selectedContractId.set('registry-entry-1');
+    component.selectedFunction = 'claim';
+    component.interactOutpointTxid = 'a'.repeat(64);
+    component.interactOutpointVout = '0';
+    component.interactInputAmount = options.inputSompi.toString();
+    component.interactOutputAddress = options.outputAddress ?? HEIR_ADDRESS;
+    component.interactOutputAmount = options.outputAmountKas;
+  }
+
+  function lastSpendOutputs(): { address: string; amount: bigint; covenantId?: string }[] {
+    const call =
+      walletActionServiceSpy.validateAndDoActionAfterApproval.calls.mostRecent();
+    return (call.args[0] as any).data.outputs;
+  }
+
+  describe('buildWithdrawalOutputs() — shared partial-withdrawal engine', () => {
+    it('splits a partial withdrawal into a payout output plus a continuation output', () => {
+      const outputs = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        200_000_000n,
+        HEIR_ADDRESS,
+        100_000_000n,
+      );
+      expect(outputs).toEqual([
+        { address: HEIR_ADDRESS, amount: 100_000_000n },
+        { address: COVENANT_ADDRESS, amount: 100_000_000n, covenantId: undefined },
+      ]);
+    });
+
+    it('returns a single output for a full-balance withdrawal (no continuation)', () => {
+      const outputs = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        200_000_000n,
+        HEIR_ADDRESS,
+        200_000_000n,
+      );
+      expect(outputs).toEqual([{ address: HEIR_ADDRESS, amount: 200_000_000n }]);
+    });
+
+    it('supports multiple sequential partial withdrawals against the shrinking balance', () => {
+      const first = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        200_000_000n,
+        HEIR_ADDRESS,
+        50_000_000n,
+      );
+      expect(first[1].amount).toBe(150_000_000n);
+
+      const second = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        first[1].amount,
+        HEIR_ADDRESS,
+        100_000_000n,
+      );
+      // Remainder lands exactly on the 0.5 KAS minimum — boundary is inclusive.
+      expect(second).toEqual([
+        { address: HEIR_ADDRESS, amount: 100_000_000n },
+        {
+          address: COVENANT_ADDRESS,
+          amount: MIN_CONTINUATION_AMOUNT_SOMPI,
+          covenantId: undefined,
+        },
+      ]);
+    });
+
+    it('rejects a withdrawal amount above the available balance', () => {
+      const outputs = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        200_000_000n,
+        HEIR_ADDRESS,
+        300_000_000n,
+      );
+      expect(outputs).toBeUndefined();
+      expect(component.interactError()).toBe(
+        'Withdraw amount cannot exceed the contract balance',
+      );
+    });
+
+    it('rejects a partial withdrawal that would leave a remainder below 0.5 KAS', () => {
+      const outputs = (component as any).buildWithdrawalOutputs(
+        DMS_COMPILED_CONTRACT,
+        200_000_000n,
+        HEIR_ADDRESS,
+        180_000_000n,
+      );
+      expect(outputs).toBeUndefined();
+      expect(component.interactError()).toContain(
+        'must leave at least 0.5 KAS',
+      );
+    });
+  });
+
+  describe('interactContract() — DMS claim', () => {
+    it('submits a partial claim as [payout, continuation] and keeps the registry entry active', async () => {
+      setUpDmsClaim({ inputSompi: 200_000_000n, outputAmountKas: '1' });
+
+      await component.interactContract();
+
+      expect(lastSpendOutputs()).toEqual([
+        { address: HEIR_ADDRESS, amount: 100_000_000n },
+        { address: COVENANT_ADDRESS, amount: 100_000_000n, covenantId: undefined },
+      ]);
+      expect(registryServiceSpy.updateContract).toHaveBeenCalledWith(
+        'registry-entry-1',
+        jasmine.objectContaining({
+          outpoint: { txid: 'f'.repeat(64), vout: 1 },
+          amountSompi: '100000000',
+        }),
+      );
+      expect(registryServiceSpy.updateContract).not.toHaveBeenCalledWith(
+        'registry-entry-1',
+        jasmine.objectContaining({ status: 'spent' }),
+      );
+    });
+
+    it('submits a full claim as a single output and marks the registry entry spent', async () => {
+      setUpDmsClaim({ inputSompi: 200_000_000n, outputAmountKas: '2' });
+
+      await component.interactContract();
+
+      expect(lastSpendOutputs()).toEqual([
+        { address: HEIR_ADDRESS, amount: 200_000_000n },
+      ]);
+      expect(registryServiceSpy.updateContract).toHaveBeenCalledWith(
+        'registry-entry-1',
+        jasmine.objectContaining({ status: 'spent', spendTxid: 'f'.repeat(64) }),
+      );
+    });
+
+    for (const bad of ['0', '-1', 'abc']) {
+      it(`rejects a claim amount of "${bad}" without submitting a transaction`, async () => {
+        setUpDmsClaim({ inputSompi: 200_000_000n, outputAmountKas: bad });
+
+        await component.interactContract();
+
+        expect(component.interactError()).toBe(
+          'Output amount must be greater than 0',
+        );
+        expect(
+          walletActionServiceSpy.validateAndDoActionAfterApproval,
+        ).not.toHaveBeenCalled();
+        expect(registryServiceSpy.updateContract).not.toHaveBeenCalled();
+      });
+    }
+
+    it('rejects a claim amount above the available balance without submitting a transaction', async () => {
+      setUpDmsClaim({ inputSompi: 200_000_000n, outputAmountKas: '3' });
+
+      await component.interactContract();
+
+      expect(component.interactError()).toBe(
+        'Withdraw amount cannot exceed the contract balance',
+      );
+      expect(
+        walletActionServiceSpy.validateAndDoActionAfterApproval,
+      ).not.toHaveBeenCalled();
+      expect(registryServiceSpy.updateContract).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('regression — other DMS actions are unaffected', () => {
+    it('still dispatches keepAlive through executeDmsKeepAlive', async () => {
+      const keepAliveSpy = spyOn(
+        component as any,
+        'executeDmsKeepAlive',
+      ).and.resolveTo();
+      component.interactContractJson.set(JSON.stringify(DMS_COMPILED_CONTRACT));
+      component.selectedFunction = 'keepAlive';
+      component.interactOutpointTxid = 'a'.repeat(64);
+      component.interactOutpointVout = '0';
+      component.interactInputAmount = '200000000';
+
+      await component.interactContract();
+
+      expect(keepAliveSpy).toHaveBeenCalled();
+      expect(
+        walletActionServiceSpy.validateAndDoActionAfterApproval,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('still dispatches changeHeir through executeDmsChangeHeir', async () => {
+      const changeHeirSpy = spyOn(
+        component as any,
+        'executeDmsChangeHeir',
+      ).and.resolveTo();
+      component.interactContractJson.set(JSON.stringify(DMS_COMPILED_CONTRACT));
+      component.selectedFunction = 'changeHeir';
+      component.interactOutpointTxid = 'a'.repeat(64);
+      component.interactOutpointVout = '0';
+      component.interactInputAmount = '200000000';
+      component.interactOutputAddress = HEIR_ADDRESS;
+
+      await component.interactContract();
+
+      expect(changeHeirSpy).toHaveBeenCalled();
+      expect(
+        walletActionServiceSpy.validateAndDoActionAfterApproval,
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.spec.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.spec.ts
@@ -1,11 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import {
-  ActivatedRoute,
-  Router,
-  convertToParamMap,
-} from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { of } from 'rxjs';
 import { NotificationService } from '@kaspacom/ui-kit';
@@ -51,8 +47,20 @@ const DMS_COMPILED_CONTRACT: CompiledContract = {
         return_types: [],
         body: [],
       },
-      { name: 'topUp', params: [], entrypoint: true, return_types: [], body: [] },
-      { name: 'claim', params: [], entrypoint: true, return_types: [], body: [] },
+      {
+        name: 'topUp',
+        params: [],
+        entrypoint: true,
+        return_types: [],
+        body: [],
+      },
+      {
+        name: 'claim',
+        params: [],
+        entrypoint: true,
+        return_types: [],
+        body: [],
+      },
     ],
   },
   abi: [
@@ -78,7 +86,7 @@ const DMS_COMPILED_CONTRACT: CompiledContract = {
 const COVENANT_ADDRESS = 'kaspatest:qzcovenantaddressmock';
 const HEIR_ADDRESS = 'kaspatest:qzheiraddressmock';
 
-describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
+describe("ContractsPageComponent — Dead Man's Switch partial claim", () => {
   let component: ContractsPageComponent;
   let walletActionServiceSpy: jasmine.SpyObj<WalletActionService>;
   let covenantServiceSpy: jasmine.SpyObj<CovenantService>;
@@ -128,8 +136,8 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
       'parseCompiledContract',
     ]);
     covenantServiceSpy.getContractAddress.and.returnValue(COVENANT_ADDRESS);
-    covenantServiceSpy.parseCompiledContract.and.callFake(
-      (json: string) => JSON.parse(json),
+    covenantServiceSpy.parseCompiledContract.and.callFake((json: string) =>
+      JSON.parse(json),
     );
 
     const covenantIndexerServiceSpy = jasmine.createSpyObj(
@@ -220,11 +228,17 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
         { provide: QrScannerService, useValue: qrScannerServiceSpy },
         { provide: UtilsHelper, useValue: utilsHelperSpy },
         { provide: CovenantService, useValue: covenantServiceSpy },
-        { provide: CovenantIndexerService, useValue: covenantIndexerServiceSpy },
+        {
+          provide: CovenantIndexerService,
+          useValue: covenantIndexerServiceSpy,
+        },
         { provide: RpcService, useValue: rpcServiceSpy },
         { provide: ContractRegistryService, useValue: registryServiceSpy },
         { provide: TemplatePatcherService, useValue: templatePatcherSpy },
-        { provide: HttpClient, useValue: jasmine.createSpyObj('HttpClient', ['get']) },
+        {
+          provide: HttpClient,
+          useValue: jasmine.createSpyObj('HttpClient', ['get']),
+        },
         { provide: KaspaL1NetworkService, useValue: kaspaL1NetworkServiceSpy },
         { provide: FlowPagesService, useValue: flowPagesServiceSpy },
         { provide: WideWorkspaceService, useValue: wideWorkspaceServiceSpy },
@@ -257,7 +271,11 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
     component.interactOutputAmount = options.outputAmountKas;
   }
 
-  function lastSpendOutputs(): { address: string; amount: bigint; covenantId?: string }[] {
+  function lastSpendOutputs(): {
+    address: string;
+    amount: bigint;
+    covenantId?: string;
+  }[] {
     const call =
       walletActionServiceSpy.validateAndDoActionAfterApproval.calls.mostRecent();
     return (call.args[0] as any).data.outputs;
@@ -273,7 +291,11 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
       );
       expect(outputs).toEqual([
         { address: HEIR_ADDRESS, amount: 100_000_000n },
-        { address: COVENANT_ADDRESS, amount: 100_000_000n, covenantId: undefined },
+        {
+          address: COVENANT_ADDRESS,
+          amount: 100_000_000n,
+          covenantId: undefined,
+        },
       ]);
     });
 
@@ -284,7 +306,9 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
         HEIR_ADDRESS,
         200_000_000n,
       );
-      expect(outputs).toEqual([{ address: HEIR_ADDRESS, amount: 200_000_000n }]);
+      expect(outputs).toEqual([
+        { address: HEIR_ADDRESS, amount: 200_000_000n },
+      ]);
     });
 
     it('supports multiple sequential partial withdrawals against the shrinking balance', () => {
@@ -348,7 +372,11 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
 
       expect(lastSpendOutputs()).toEqual([
         { address: HEIR_ADDRESS, amount: 100_000_000n },
-        { address: COVENANT_ADDRESS, amount: 100_000_000n, covenantId: undefined },
+        {
+          address: COVENANT_ADDRESS,
+          amount: 100_000_000n,
+          covenantId: undefined,
+        },
       ]);
       expect(registryServiceSpy.updateContract).toHaveBeenCalledWith(
         'registry-entry-1',
@@ -373,7 +401,10 @@ describe('ContractsPageComponent — Dead Man\'s Switch partial claim', () => {
       ]);
       expect(registryServiceSpy.updateContract).toHaveBeenCalledWith(
         'registry-entry-1',
-        jasmine.objectContaining({ status: 'spent', spendTxid: 'f'.repeat(64) }),
+        jasmine.objectContaining({
+          status: 'spent',
+          spendTxid: 'f'.repeat(64),
+        }),
       );
     });
 

--- a/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/contracts-page.component.ts
@@ -5380,22 +5380,6 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
           outputAddress,
         );
         return;
-      } else if (this.isDmsClaim()) {
-        // DMS claim always transfers the entire balance to the heir — there's
-        // no continuation output for a remainder to go to, since the
-        // Dead Man's Switch relationship ends once claimed. Ignore whatever
-        // amount the user may have typed and use the full input amount
-        // instead of routing through buildWithdrawalOutputs's partial path.
-        if (!outputAddress) {
-          this.interactError.set('Output address is required');
-          return;
-        }
-        outputs = [
-          {
-            address: outputAddress,
-            amount: inputAmount,
-          },
-        ];
       } else if (this.functionRequiresOutput(functionName)) {
         if (
           compiled.contract_name === 'DeadManSwitch' &&
@@ -6456,9 +6440,12 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Returns true when the current function is DMS claim. Claim always
-   * transfers the full balance to the heir — there's no continuation output,
-   * so unlike a regular withdrawal it can't be partial.
+   * Returns true when the current function is a Dead Man's Switch claim.
+   * Claim can be partial — it routes through the generic
+   * buildWithdrawalOutputs() path like any other withdrawal — but this
+   * predicate still gates a claim-specific warning: any remainder left in
+   * the contract stays under the same heir/deadline, and the owner's
+   * keepAlive has no deadline check, so it could re-arm a leftover balance.
    */
   isDmsClaim(): boolean {
     const contract = this.parsedInteractContract();
@@ -6530,9 +6517,9 @@ export class ContractsPageComponent implements OnInit, OnDestroy {
       // Withdrawal function: default output to user's wallet, clear amount
       this.interactOutputAddress = this.currentWallet()?.getAddress() || '';
       this.interactOutputAmount = '';
-      // Curated actions whose field config omits an amount field (e.g. DMS
-      // claim) always withdraw the full balance — there's no input for the
-      // user to fill in, so fill it in for them instead of leaving it empty.
+      // Curated actions whose field config omits an amount field always
+      // withdraw the full balance — there's no input for the user to fill
+      // in, so fill it in for them instead of leaving it empty.
       // (getSelectedActionFieldConfig() already reflects `name` — it was
       // just assigned to selectedFunction above.)
       const config = this.getSelectedActionFieldConfig();


### PR DESCRIPTION
## Summary
- The heir can now claim part of a Dead Man's Switch's locked balance instead of being forced to withdraw everything at once. The remainder stays locked under the same heir and deadline as a continuation UTXO.
- No contract/script change needed: the deployed `claim` entrypoint has no `validateOutputState`/output constraints, so a continuation output back to the same covenant address was already permitted on-chain. This routes DMS claim through the existing generic partial-withdrawal path (`buildWithdrawalOutputs`) already used by Escrow, instead of hardcoding a full-balance-only output.
- Adds an amount field (with Max) and a warning banner to the claim form, replacing the old "claims can't be partial" notice, in both the curated action form and the advanced/manual interact form.
- Zero, negative, malformed, and above-available amounts are rejected inline with no contract-state side effects (reuses existing validation).
- Full claim and the `keepAlive`/`changeHeir` flows are unaffected.

Known tradeoff (intentional, discussed and accepted): `keepAlive` has no `tx.time >= deadline` check, so the owner can reset the deadline at any time, even after it passes. A remainder left behind by a partial claim is theoretically exposed to this — same risk that already existed for full claims (owner could race a `keepAlive` against a pending claim). The claim form now shows a warning banner about this instead of blocking partial claims outright.

## Test plan
- [x] `ng test` — 57/57 passing, including new `contracts-page.component.spec.ts` (partial/full/sequential withdrawals, over-balance + below-minimum-remainder rejection, zero/negative/NaN rejection, registry status updates, keepAlive/changeHeir regression)
- [x] New `e2e/dead-mans-switch.spec.ts` (`@funded`, requires `KASPA_E2E_SEED`) — deploy → invalid amounts → two sequential partial claims → full remainder claim, asserted against the TN10 explorer directly. Passing (~4 min).
- [x] Manually verified live on TN10: deploy 10 KAS → partial claim 4 KAS (txid `2d4bce43...`) → confirmed 6 KAS continuation UTXO at the same contract address/heir/deadline via explorer → full remainder claim (txid `3131156f...`) → confirmed contract UTXO set empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)