### PR TITLE
UI: styled whitelist wallet selector for Self-Custody Vault sweep

### DIFF
--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.html
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.html
@@ -730,20 +730,39 @@
         @if (getSelfCustodyInteractWhitelistWallets().length > 0) {
           <div class="form-group flex column gap-8">
             <label class="form-label">Send funds to</label>
-            <select
-              class="contract-input"
-              [disabled]="isInteracting()"
-              [ngModel]="interactOutputAddress()"
-              (ngModelChange)="onSelfCustodySweepDestinationChange($event)"
+            <kc-dropdown-select
+              class="whitelist-dropdown"
+              [options]="getSelfCustodySweepDropdownOptions()"
+              [placeholder]="'Select a whitelisted wallet'"
+              [isFullWidth]="true"
+              [isDisabled]="isInteracting()"
+              [value]="interactOutputAddress()"
+              (valueChange)="onSelfCustodySweepDestinationChange($any($event))"
             >
-              @for (
-                address of getSelfCustodyInteractWhitelistWallets();
-                track address;
-                let i = $index
-              ) {
-                <option [value]="address">{{ i }} - {{ address }}</option>
-              }
-            </select>
+              <ng-template #optionTemplate let-option>
+                <div class="whitelist-option">
+                  <app-wallet-profile-orb
+                    class="whitelist-option-avatar"
+                    [address]="$any(option.value)"
+                    [sizePx]="22"
+                  ></app-wallet-profile-orb>
+                  <span class="whitelist-option-index">{{
+                    getSelfCustodyWhitelistIndex(option.value)
+                  }}</span>
+                  <span
+                    class="whitelist-option-address"
+                    [title]="$any(option.value)"
+                    >{{ $any(option.value) | shortenAddress: 8 : 6 }}</span
+                  >
+                  <app-copy-button
+                    class="whitelist-option-copy"
+                    [value]="$any(option.value)"
+                    [size]="'xs'"
+                    (click)="$event.stopPropagation()"
+                  ></app-copy-button>
+                </div>
+              </ng-template>
+            </kc-dropdown-select>
             <span class="text-gray-60 typo-text-2">
               The full vault balance will be sent to the selected whitelisted
               wallet.

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.scss
@@ -128,3 +128,48 @@
     color: #fff !important;
   }
 }
+
+// Row content for each whitelisted wallet inside the styled kc-dropdown-select
+// (both the closed-state selected value and the open option list share this
+// template — see optionTemplate in the .html). Mirrors the read-only
+// .participant/.p-avatar/.p-body pattern used in contract-detail.component.scss.
+.whitelist-dropdown {
+  min-width: 0;
+}
+
+.whitelist-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+}
+
+.whitelist-option-avatar {
+  flex-shrink: 0;
+}
+
+.whitelist-option-index {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gray-60);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+
+.whitelist-option-address {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--white);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.whitelist-option-copy {
+  flex-shrink: 0;
+}

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.spec.ts
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.spec.ts
@@ -45,8 +45,9 @@ describe('ContractActionPanelComponent', () => {
       ],
     });
 
-    component = TestBed.createComponent(ContractActionPanelComponent)
-      .componentInstance;
+    component = TestBed.createComponent(
+      ContractActionPanelComponent,
+    ).componentInstance;
   });
 
   describe('getSelfCustodySweepDropdownOptions', () => {

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.spec.ts
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { Dialog } from '@angular/cdk/dialog';
+import { NotificationService } from '@kaspacom/ui-kit';
+import { ContractActionPanelComponent } from './contract-action-panel.component';
+import { WalletService } from '../../../../../../../services/wallet.service';
+import { WalletActionService } from '../../../../../../../services/wallet-action.service';
+import { QrScannerService } from '../../../../../../../services/qr-scanner.service';
+import { CovenantService } from '../../../../../../../services/covenant/covenant.service';
+import { TemplatePatcherService } from '../../../../../../services/covenant/template-patcher.service';
+import { FlowPagesService } from '../../../../../../services/flow-pages.service';
+import { ApprovalFlowService } from '../../../../../../services/approval-flow.service';
+import { ContractDisplayService } from '../../services/contract-display.service';
+import { CovenantTemplateService } from '../../services/covenant-template.service';
+import { ContractsDataService } from '../../services/contracts-data.service';
+
+// Long, realistic testnet addresses — long enough that the raw address
+// (rather than a shortened label) would visibly overflow a 375px-wide
+// dropdown if kc-dropdown-select's overlay sizing used it directly.
+const WHITELIST_ADDRESS_1 =
+  'kaspatest:qpglk4khgvnwn7fdfpnfq7v5edjyy7glw8e2rgh7ur2q3uwdlg5dznh824dvr';
+const WHITELIST_ADDRESS_2 =
+  'kaspatest:qq2ez0mgpg0hp082hlpqvcnrx8m0quwnh8hf5nc7f2z2q9nxfj9vv0y8dzgn';
+
+describe('ContractActionPanelComponent', () => {
+  let component: ContractActionPanelComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ContractActionPanelComponent],
+      providers: [
+        { provide: CovenantService, useValue: {} },
+        { provide: WalletActionService, useValue: {} },
+        { provide: TemplatePatcherService, useValue: {} },
+        { provide: CovenantTemplateService, useValue: {} },
+        { provide: ContractsDataService, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: ApprovalFlowService, useValue: {} },
+        { provide: FlowPagesService, useValue: {} },
+        { provide: NotificationService, useValue: {} },
+        { provide: QrScannerService, useValue: {} },
+        { provide: Dialog, useValue: {} },
+        { provide: WalletService, useValue: {} },
+        { provide: ContractDisplayService, useValue: {} },
+      ],
+    });
+
+    component = TestBed.createComponent(ContractActionPanelComponent)
+      .componentInstance;
+  });
+
+  describe('getSelfCustodySweepDropdownOptions', () => {
+    // Regression test for a review finding on the whitelist wallet selector
+    // dropdown: kc-dropdown-select sizes its overlay off DropdownOption.label
+    // via calculateLongestOptionWidth() — it measures the raw label text, not
+    // what optionTemplate actually renders. Passing the full address as label
+    // (instead of the shortened text shown in the row) forces an oversized
+    // minWidth that overflows/clips the overlay on narrow screens even though
+    // the rendered row itself is short. `value` must stay the full address
+    // (used for selection/equality); only `label` must be shortened.
+    it('uses a shortened label for sizing while keeping the full address as value', () => {
+      spyOn(
+        component,
+        'getSelfCustodyInteractWhitelistWallets',
+      ).and.returnValue([WHITELIST_ADDRESS_1, WHITELIST_ADDRESS_2]);
+
+      const options = component.getSelfCustodySweepDropdownOptions();
+
+      expect(options.length).toBe(2);
+      expect(options[0].value).toBe(WHITELIST_ADDRESS_1);
+      expect(options[1].value).toBe(WHITELIST_ADDRESS_2);
+      for (const option of options) {
+        const fullAddress = option.value as string;
+        expect(option.label).not.toBe(fullAddress);
+        expect(option.label.length).toBeLessThan(fullAddress.length);
+        expect(option.label).toContain('...');
+      }
+    });
+
+    it('returns no options when there is no whitelist', () => {
+      spyOn(
+        component,
+        'getSelfCustodyInteractWhitelistWallets',
+      ).and.returnValue([]);
+
+      expect(component.getSelfCustodySweepDropdownOptions()).toEqual([]);
+    });
+  });
+
+  describe('getSelfCustodyWhitelistIndex', () => {
+    it('resolves the index of an address within the whitelist', () => {
+      spyOn(
+        component,
+        'getSelfCustodyInteractWhitelistWallets',
+      ).and.returnValue([WHITELIST_ADDRESS_1, WHITELIST_ADDRESS_2]);
+
+      expect(component.getSelfCustodyWhitelistIndex(WHITELIST_ADDRESS_2)).toBe(
+        1,
+      );
+    });
+
+    it('falls back to 0 for an address not in the whitelist', () => {
+      spyOn(
+        component,
+        'getSelfCustodyInteractWhitelistWallets',
+      ).and.returnValue([WHITELIST_ADDRESS_1]);
+
+      expect(component.getSelfCustodyWhitelistIndex('unknown')).toBe(0);
+    });
+  });
+});

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.ts
@@ -107,6 +107,7 @@ export class ContractActionPanelComponent {
   private dialog = inject(Dialog);
   private walletService = inject(WalletService);
   display = inject(ContractDisplayService);
+  private shortenAddressPipe = new ShortenAddressPipe();
 
   readonly selfCustodyWhitelistCapacity = SELF_CUSTODY_WHITELIST_CAPACITY;
 
@@ -2327,9 +2328,15 @@ export class ContractActionPanelComponent {
   }
 
   getSelfCustodySweepDropdownOptions(): DropdownOption[] {
+    // label must mirror what optionTemplate renders (the shortened address),
+    // not the full address — kc-dropdown-select sizes its overlay from
+    // DropdownOption.label via calculateLongestOptionWidth(), not from the
+    // projected template, so a full raw address here forces an oversized
+    // minWidth that overflows on narrow screens even though the rendered
+    // row itself is short.
     return this.getSelfCustodyInteractWhitelistWallets().map((address) => ({
       value: address,
-      label: address,
+      label: this.shortenAddressPipe.transform(address, 8, 6),
     }));
   }
 

--- a/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.ts
+++ b/src/app/v2/pages/app/flows/contracts/components/contract-action-panel/contract-action-panel.component.ts
@@ -35,6 +35,8 @@ import {
 } from '../../../../../../../services/covenant/covenant-sdk/types';
 import type { CovenantFunctionArg } from '../../../../../../../services/covenant/covenant-sdk/covenant';
 import { CopyButtonComponent } from '../../../../../../shared/ui/copy-button/copy-button.component';
+import { WalletProfileOrbComponent } from '../../../../../../shared/ui/wallet-profile-orb/wallet-profile-orb.component';
+import { ShortenAddressPipe } from '../../../../../../../pipes/shorten-address.pipe';
 import {
   PartialSpendJsonDialogData,
   PartialSpendJsonModalComponent,
@@ -82,6 +84,8 @@ import { ContractsDataService } from '../../services/contracts-data.service';
     KcNumberInputComponent,
     KcTooltipDirective,
     CopyButtonComponent,
+    WalletProfileOrbComponent,
+    ShortenAddressPipe,
     AddressSmartInputComponent,
     CovenantDateTimeInputComponent,
     ContractActionFieldsComponent,
@@ -2320,6 +2324,20 @@ export class ContractActionPanelComponent {
     if (!raw) return [];
 
     return this.templateService.getAddressListFromRaw(raw);
+  }
+
+  getSelfCustodySweepDropdownOptions(): DropdownOption[] {
+    return this.getSelfCustodyInteractWhitelistWallets().map((address) => ({
+      value: address,
+      label: address,
+    }));
+  }
+
+  getSelfCustodyWhitelistIndex(address: unknown): number {
+    return Math.max(
+      0,
+      this.getSelfCustodyInteractWhitelistWallets().indexOf(String(address)),
+    );
   }
 
   onSelfCustodySweepDestinationChange(address: string) {

--- a/src/app/v2/pages/app/flows/contracts/components/contracts-dashboard/contracts-dashboard.component.html
+++ b/src/app/v2/pages/app/flows/contracts/components/contracts-dashboard/contracts-dashboard.component.html
@@ -88,6 +88,8 @@
     [text]="
       loading() ? 'Refreshing...' : indexerLoading() ? 'Syncing...' : 'Refresh'
     "
+    [variant]="'secondary'"
+    [size]="'s'"
     [isDisabled]="loading() || indexerLoading()"
     (buttonClick)="refreshRequested.emit()"
   ></kc-button>

--- a/src/app/v2/pages/app/flows/contracts/components/contracts-dashboard/contracts-dashboard.component.scss
+++ b/src/app/v2/pages/app/flows/contracts/components/contracts-dashboard/contracts-dashboard.component.scss
@@ -31,6 +31,9 @@ $tpl-accents: (
   gap: 12px;
   flex-wrap: wrap;
 }
+.dashboard-toolbar {
+  margin-bottom: 20px;
+}
 .dashboard-toolbar .dashboard-search {
   flex: 1;
   min-width: 220px;
@@ -75,6 +78,19 @@ $tpl-accents: (
 }
 
 // ── contract card grid ──────────────────────────────────────────────────
+// Shares the same top margin with its mutually-exclusive loading/empty
+// siblings (.skeleton-grid/.state-block, both defined in shared-ui.scss) and
+// with .banner (the indexer-sync/error notices that can precede them) so the
+// gap under .filter-row stays constant no matter which state renders first.
+// Adjacent block margins collapse, so a banner immediately followed by the
+// grid/skeleton/empty-state doesn't double this gap.
+.card-grid,
+.skeleton-grid,
+.state-block,
+.banner {
+  margin-top: 20px;
+}
+
 .card-grid {
   display: grid;
   grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Replace the native `<select>` in the Emergency Sweep/finalize "Send funds to" picker with `kc-dropdown-select`, matching the rest of the wallet UI instead of a raw browser dropdown.
- Each option now shows the whitelist index, a wallet orb avatar, the truncated address, and a copy button — reusing `WalletProfileOrbComponent`, `CopyButtonComponent`, and the `shortenAddress` pipe already used elsewhere for the read-only whitelist display.
- Fix the Contracts dashboard "Refresh" button, which rendered at default `kc-button` primary/m sizing and looked oversized next to the compact Active/History segmented control beside it — now `variant="secondary" size="s"`, matching the convention used elsewhere in the app.

No vault/contract logic was touched — `onSelfCustodySweepDestinationChange`, `destinationIndex`, and `interactOutputAddress` wiring are unchanged; only the trigger markup changed from `(ngModelChange)` to the dropdown's `(valueChange)`.

## Test plan
- [x] `ng build` passes clean
- [x] Deployed a real testnet `SelfCustodyVault` contract with a whitelist entry and opened Emergency Sweep — dropdown renders correctly closed and open, no horizontal overflow
- [x] Verified on desktop and 375px mobile viewport
- [x] Single whitelist wallet auto-selects (pre-existing `selectFunction()` behavior, unaffected)
- [x] Selecting an option round-trips correctly back into the combobox display and `destinationIndex`/`interactOutputAddress`
- [ ] Manual test with multiple (2+) whitelist wallets on-chain (verified visually via repeated option template, not tested with a second real address)

🤖 Generated with [Claude Code](https://claude.com/claude-code)